### PR TITLE
upgrade reqwest to 0.13, switch to rustls - avoid long build times on android and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets --all-features
 
       - name: Test
-        run: cargo test
+        run: cargo test --all-features
 
       - name: Build
-        run: cargo build
+        run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ async-trait = "0.1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
-reqwest = { version = "0.12", features = ["json", "stream"] }
-reqwest-eventsource = "0.6"
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
+reqwest-eventsource = { package = "kameleoon-reqwest-eventsource", version = "0.6" }
 futures = "0.3"
 rand = "0.10.0"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["agent", "llm", "ai", "tools", "streaming"]
 categories = ["api-bindings", "asynchronous"]
 authors = ["Yuanhao <yuanhao@yolog.dev>"]
-rust-version = "1.75"
+rust-version = "1.85"
 exclude = ["docs/images/*", "docs/theme/*", ".github/*", "scripts/*"]
 
 [dependencies]
@@ -24,7 +24,7 @@ async-trait = "0.1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
+reqwest = { version = "0.13", features = ["json", "stream", "socks"] }
 reqwest-eventsource = { package = "kameleoon-reqwest-eventsource", version = "0.6" }
 futures = "0.3"
 rand = "0.10.0"
@@ -33,7 +33,7 @@ openapiv3 = { version = "2", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [features]
-openapi = ["dep:openapiv3", "dep:serde_yaml"]
+openapi = ["dep:openapiv3", "dep:serde_yaml", "reqwest/query"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/openapi/types.rs
+++ b/src/openapi/types.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::fmt;
 
 /// Authentication method for OpenAPI requests.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum OpenApiAuth {
     /// No authentication.
+    #[default]
     None,
     /// Bearer token (Authorization: Bearer <token>).
     Bearer(String),
@@ -23,12 +24,6 @@ impl fmt::Debug for OpenApiAuth {
                 .field("value", &"****")
                 .finish(),
         }
-    }
-}
-
-impl Default for OpenApiAuth {
-    fn default() -> Self {
-        Self::None
     }
 }
 
@@ -108,9 +103,10 @@ impl OpenApiConfig {
 }
 
 /// Controls which operations from the spec become tools.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum OperationFilter {
     /// Include all operations.
+    #[default]
     All,
     /// Include only operations with these operation IDs.
     ByOperationId(Vec<String>),
@@ -118,12 +114,6 @@ pub enum OperationFilter {
     ByTag(Vec<String>),
     /// Include only operations whose path starts with this prefix.
     ByPathPrefix(String),
-}
-
-impl Default for OperationFilter {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 /// Parsed operation metadata (internal).


### PR DESCRIPTION
- reqwest: 0.12 → 0.13, default-features=false, use rustls instead of openssl
- reqwest-eventsource → kameleoon-reqwest-eventsource (compatible with reqwest 0.13)

Fixes #49