### PR TITLE
feat: new Claude/GPT generation support and OpenCode Zen/Go presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ use yoagent::types::*;
 async fn main() {
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a helpful assistant.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY").unwrap());
 
     let mut rx = agent.prompt("What is Rust's ownership model?").await;
@@ -158,7 +158,7 @@ A ~250-line interactive coding agent with all built-in tools, skills support, st
   yoagent cli — mini coding agent
   Type /quit to exit, /clear to reset
 
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-5
   skills: 3 loaded
   cwd:   /home/user/my-project
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
 - [Google Gemini](providers/google.md)
 - [Amazon Bedrock](providers/bedrock.md)
 - [Azure OpenAI](providers/azure-openai.md)
+- [OpenCode Zen & Go](providers/opencode.md)
 
 # Reference
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -97,7 +97,7 @@ pub struct AgentLoopConfig {
 | Field | Purpose |
 |-------|---------|
 | `provider` | The `StreamProvider` implementation to use |
-| `model` | Model identifier (e.g., `"claude-sonnet-4-20250514"`) |
+| `model` | Model identifier (e.g., `"claude-sonnet-5"`) |
 | `api_key` | API key for the provider |
 | `thinking_level` | `Off`, `Minimal`, `Low`, `Medium`, `High` |
 | `model_config` | Optional `ModelConfig` for multi-provider support (base URL, headers, compat flags) |

--- a/docs/concepts/context-management.md
+++ b/docs/concepts/context-management.md
@@ -110,7 +110,7 @@ let agent = Agent::new(OpenAiCompatProvider)
 
 // Anthropic with 200K context → compacts at 160K
 let agent = Agent::new(AnthropicProvider)
-    .with_model_config(ModelConfig::anthropic("claude-sonnet-4-20250514", "Claude Sonnet 4"))
+    .with_model_config(ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5"))
     .with_api_key(api_key);
 ```
 

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -15,7 +15,7 @@ std::fs::write("conversation.json", &json)?;
 let json = std::fs::read_to_string("conversation.json")?;
 let mut agent = Agent::new(provider)
     .with_system_prompt("You are helpful.")
-    .with_model("claude-sonnet-4-20250514")
+    .with_model("claude-sonnet-5")
     .with_api_key(api_key);
 
 agent.restore_messages(&json)?;
@@ -51,7 +51,7 @@ Messages serialize as a JSON array. Each message is tagged by role:
     "role": "assistant",
     "content": [{"type": "text", "text": "Hi there!"}],
     "stopReason": "stop",
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "provider": "anthropic",
     "usage": {"input": 100, "output": 50, "cache_read": 0, "cache_write": 0, "total_tokens": 150},
     "timestamp": 1700000001000

--- a/docs/concepts/prompt-caching.md
+++ b/docs/concepts/prompt-caching.md
@@ -92,9 +92,9 @@ For a typical 10-turn agent conversation with Anthropic Claude:
 | Without Caching | With Caching (auto) |
 |-----------------|-------------------|
 | ~500K input tokens billed at full price | ~50K at full price + ~450K at 10% price |
-| **$2.50** (Sonnet) | **$0.39** (Sonnet) |
+| **$1.50** (Claude Sonnet 5) | **$0.29** (Claude Sonnet 5) |
 
-That's an **84% cost reduction** with zero configuration.
+That's an **~80% cost reduction** with zero configuration.
 
 ## Best Practices
 

--- a/docs/concepts/sub-agents.md
+++ b/docs/concepts/sub-agents.md
@@ -27,7 +27,7 @@ use yoagent::tools;
 let researcher = SubAgentTool::new("researcher", Arc::new(AnthropicProvider))
     .with_description("Searches and reads files to gather information.")
     .with_system_prompt("You are a research assistant. Be thorough and concise.")
-    .with_model("claude-sonnet-4-20250514")
+    .with_model("claude-sonnet-5")
     .with_api_key(&api_key)
     .with_tools(vec![
         Arc::new(tools::ReadFileTool::new()),
@@ -43,7 +43,7 @@ use yoagent::agent::Agent;
 
 let mut agent = Agent::new(AnthropicProvider)
     .with_system_prompt("You coordinate between sub-agents.")
-    .with_model("claude-sonnet-4-20250514")
+    .with_model("claude-sonnet-5")
     .with_api_key(api_key)
     .with_sub_agent(researcher)
     .with_sub_agent(coder);
@@ -93,7 +93,7 @@ state.set("ci_log", large_log_text).await.unwrap();
 
 let analyzer = SubAgentTool::new("analyzer", provider.clone())
     .with_system_prompt("Analyze the CI log for failures.")
-    .with_model("claude-sonnet-4-20250514")
+    .with_model("claude-sonnet-5")
     .with_api_key(&api_key)
     .with_shared_state(state.clone());  // opt-in
 ```
@@ -179,7 +179,7 @@ Sub-agents can use any provider supported by yoagent — not just Anthropic. Pas
 use yoagent::provider::{OpenAiCompatProvider, model::ModelConfig};
 
 let provider = Arc::new(OpenAiCompatProvider);
-let model_config = ModelConfig::xai("grok-3-mini-fast", "Grok 3 Mini Fast");
+let model_config = ModelConfig::xai("grok-4-1-fast-reasoning", "Grok 3 Mini Fast");
 
 let analyst = SubAgentTool::new("analyst", provider)
     .with_model(&model_config.id)

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -355,7 +355,7 @@ impl AgentTool for DeployTool {
 async fn main() {
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a deployment assistant.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
         .with_tools(vec![Box::new(DeployTool)]);
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ use yoagent::tools::default_tools;
 async fn main() {
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a helpful coding assistant.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
         .with_tools(default_tools());
 
@@ -56,7 +56,7 @@ use yoagent::tools::default_tools;
 async fn main() {
     let mut agent = Agent::new(OpenAiCompatProvider)
         .with_system_prompt("You are a helpful assistant.")
-        .with_model("gpt-4o")
+        .with_model("gpt-5.5")
         .with_api_key(std::env::var("OPENAI_API_KEY").unwrap())
         .with_tools(default_tools());
 
@@ -89,7 +89,7 @@ use yoagent::tools::default_tools;
 async fn main() {
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a helpful assistant.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
         .with_tools(default_tools());
 
@@ -142,7 +142,7 @@ async fn main() {
 
     let config = AgentLoopConfig {
         provider: std::sync::Arc::new(AnthropicProvider),
-        model: "claude-sonnet-4-20250514".into(),
+        model: "claude-sonnet-5".into(),
         api_key: std::env::var("ANTHROPIC_API_KEY").unwrap(),
         thinking_level: ThinkingLevel::Off,
         max_tokens: None,

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -21,7 +21,7 @@ use yoagent::provider::AnthropicProvider;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a helpful assistant with file access.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY")?)
         .with_mcp_server_stdio(
             "npx",

--- a/docs/guides/openapi.md
+++ b/docs/guides/openapi.md
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are an API assistant.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(std::env::var("ANTHROPIC_API_KEY")?)
         .with_openapi_file("petstore.yaml", config, &OperationFilter::All)
         .await?;

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -8,7 +8,7 @@
 use yoagent::provider::AnthropicProvider;
 
 let agent = Agent::new(AnthropicProvider)
-    .with_model("claude-sonnet-4-20250514")
+    .with_model("claude-sonnet-5")
     .with_api_key(std::env::var("ANTHROPIC_API_KEY").unwrap());
 ```
 
@@ -25,18 +25,40 @@ Uses `reqwest-eventsource` to parse Anthropic's SSE stream. Events handled:
 - `message_delta` — Stop reason, output usage
 - `message_stop` — Stream complete
 
-### Extended Thinking
+### Thinking
 
-Set `thinking_level` to enable thinking with a token budget:
+Set `thinking_level` to enable thinking. By default the provider sends
+**adaptive thinking** (`thinking: {"type": "adaptive"}`), which the current
+model generation requires (Claude Fable 5, Opus 4.7/4.8, Sonnet 5 reject
+budget-based thinking with a 400). The level maps to an `output_config.effort`
+hint:
 
-| Level | Budget Tokens |
-|-------|--------------|
-| `Minimal` | 128 |
-| `Low` | 512 |
-| `Medium` | 2,048 |
-| `High` | 8,192 |
+| Level | Effort |
+|-------|--------|
+| `Minimal`, `Low` | `low` |
+| `Medium` | `medium` |
+| `High` | `high` |
+
+For pre-4.6 models, opt into legacy budget-based thinking via
+`AnthropicCompat::legacy()`:
+
+```rust
+let mut config = ModelConfig::anthropic("claude-sonnet-4-5", "Claude Sonnet 4.5");
+config.anthropic = Some(AnthropicCompat::legacy());
+```
+
+Legacy budgets: `Minimal`/`Low` 1,024 (the API minimum), `Medium` 2,048,
+`High` 8,192. `max_tokens` is automatically raised above the budget when
+needed.
 
 Thinking content is streamed as `Content::Thinking` with a cryptographic `signature` for verification.
+
+### Refusals
+
+Models with safety classifiers (e.g. Claude Fable 5) can decline a request
+with `stop_reason: "refusal"`. The provider maps this to `StopReason::Refusal`;
+the agent loop stops the turn like a normal `Stop`, and callers can match on
+the variant to retry on a fallback model.
 
 ### Cache Control
 
@@ -51,10 +73,14 @@ This means on repeated calls, only the latest message is processed at full price
 
 | Setting | Value |
 |---------|-------|
-| API URL | `https://api.anthropic.com/v1/messages` |
+| API URL | `{base_url}/messages` (default `https://api.anthropic.com/v1/messages`) |
 | API Version | `2023-06-01` |
-| Auth Header | `x-api-key` |
-| Default Max Tokens | 8,192 |
+| Auth Header | `x-api-key` (or `Authorization: Bearer` with `AnthropicCompat { bearer_auth: true }` / a custom `authorization` header in `ModelConfig.headers`) |
+| Default Max Tokens | request `max_tokens`, else `ModelConfig.max_tokens`, else 8,192 |
+
+Setting `ModelConfig.base_url` retargets the provider at any gateway that
+speaks the Anthropic Messages protocol (e.g. OpenCode Zen/Go — see
+[OpenCode Zen & Go](opencode.md)).
 
 ## Environment Variables
 

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -8,7 +8,7 @@
 use yoagent::provider::AzureOpenAiProvider;
 
 let agent = Agent::new(AzureOpenAiProvider)
-    .with_model("gpt-4o")
+    .with_model("gpt-5.5")
     .with_api_key(std::env::var("AZURE_OPENAI_API_KEY").unwrap());
 ```
 

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -8,7 +8,7 @@
 use yoagent::provider::BedrockProvider;
 
 let agent = Agent::new(BedrockProvider)
-    .with_model("anthropic.claude-3-sonnet-20240229-v1:0")
+    .with_model("anthropic.claude-opus-4-8")
     .with_api_key("ACCESS_KEY:SECRET_KEY");  // or ACCESS_KEY:SECRET_KEY:SESSION_TOKEN
 ```
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -11,7 +11,7 @@ Two providers for Google's Gemini models:
 use yoagent::provider::GoogleProvider;
 
 let agent = Agent::new(GoogleProvider)
-    .with_model("gemini-2.0-flash")
+    .with_model("gemini-2.5-flash")
     .with_api_key(std::env::var("GOOGLE_API_KEY").unwrap());
 ```
 

--- a/docs/providers/model-presets.md
+++ b/docs/providers/model-presets.md
@@ -8,8 +8,15 @@ Use a preset when the provider is listed here. Use a custom `ModelConfig` when y
 
 | Constructor | Provider | Protocol | Default Base URL | Context | Default Max Output |
 |-------------|----------|----------|------------------|---------|--------------------|
-| `ModelConfig::anthropic(id, name)` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com` | 200K | 8,192 |
+| `ModelConfig::anthropic(id, name)` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 200K | 16,000 |
+| `ModelConfig::claude_fable_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
+| `ModelConfig::claude_opus_4_8()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
+| `ModelConfig::claude_sonnet_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
+| `ModelConfig::claude_haiku_4_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 200K | 32,000 |
 | `ModelConfig::openai(id, name)` | OpenAI | `OpenAiCompletions` | `https://api.openai.com/v1` | 128K | 4,096 |
+| `ModelConfig::gpt_5_5()` | OpenAI | `OpenAiCompletions` | `https://api.openai.com/v1` | 1M | 64,000 |
+| `ModelConfig::opencode_zen(model_id)` | OpenCode Zen | by model family | `https://opencode.ai/zen/v1` | 128K | 16,000 |
+| `ModelConfig::opencode_go(model_id)` | OpenCode Go | by model family | `https://opencode.ai/zen/go/v1` | 128K | 16,000 |
 | `ModelConfig::google(id, name)` | Google Gemini | `GoogleGenerativeAi` | `https://generativelanguage.googleapis.com` | 1M | 8,192 |
 | `ModelConfig::xai(id, name)` | xAI | `OpenAiCompletions` | `https://api.x.ai/v1` | 131,072 | 4,096 |
 | `ModelConfig::groq(id, name)` | Groq | `OpenAiCompletions` | `https://api.groq.com/openai/v1` | 128K | 4,096 |
@@ -23,6 +30,8 @@ Use a preset when the provider is listed here. Use a custom `ModelConfig` when y
 | `ModelConfig::local(base_url, model_id)` | Local compatible server | `OpenAiCompletions` | caller provided | 128K | 4,096 |
 
 The constructors do not validate model IDs. They send the `id` you pass through to the provider, which lets you use newly released model IDs before yoagent updates its examples.
+
+The named presets (`claude_fable_5`, `claude_opus_4_8`, `claude_sonnet_5`, `claude_haiku_4_5`, `gpt_5_5`) also fill in real `CostConfig` pricing. The OpenCode presets select the API protocol from the model id — see [OpenCode Zen & Go](opencode.md).
 
 ## OpenAI-Compatible Presets
 

--- a/docs/providers/openai-compat.md
+++ b/docs/providers/openai-compat.md
@@ -12,7 +12,7 @@ Requires a `ModelConfig` with `compat` flags set in `StreamConfig.model_config`:
 use yoagent::provider::{OpenAiCompatProvider, ModelConfig};
 
 let agent = Agent::new(OpenAiCompatProvider)
-    .with_model("gpt-4o")
+    .with_model("gpt-5.5")
     .with_api_key(std::env::var("OPENAI_API_KEY").unwrap());
 ```
 
@@ -165,7 +165,7 @@ use yoagent::provider::{OpenAiCompatProvider, ModelConfig, OpenAiCompat};
 
 let mut config = ModelConfig::openai_compat(
     "https://api.githubcopilot.com",
-    "gpt-4o",
+    "gpt-5.5",
     "copilot",
     OpenAiCompat::openai(),
 );
@@ -175,7 +175,7 @@ config.headers.insert("Editor-Version".into(), "Neovim/0.10.0".into());
 
 let agent = Agent::new(OpenAiCompatProvider)
     .with_model_config(config)
-    .with_model("gpt-4o")
+    .with_model("gpt-5.5")
     .with_api_key(copilot_token); // see below
 ```
 

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -1,0 +1,64 @@
+# OpenCode Zen & Go
+
+[OpenCode Zen](https://opencode.ai/docs/zen) (pay-per-use) and [OpenCode Go](https://opencode.ai/docs/go) (subscription) are model gateways run by the OpenCode team. Both are supported through the `ModelConfig::opencode_zen()` and `ModelConfig::opencode_go()` presets.
+
+The gateways serve different model families over different protocols. The presets select the protocol automatically from the model id:
+
+| Gateway | Model family | Protocol | Pair with |
+|---------|-------------|----------|-----------|
+| Zen | `gpt-*` | OpenAI Responses | `OpenAiResponsesProvider` |
+| Zen | `claude-*`, `qwen*` | Anthropic Messages | `AnthropicProvider` |
+| Zen | DeepSeek, MiniMax, GLM, Kimi, ... | Chat Completions | `OpenAiCompatProvider` |
+| Go | `qwen*`, `minimax-*` | Anthropic Messages | `AnthropicProvider` |
+| Go | GLM, Kimi, DeepSeek, MiMo, ... | Chat Completions | `OpenAiCompatProvider` |
+
+Gemini models on Zen are **not supported** — Zen serves them over a Google-native endpoint shape yoagent does not target.
+
+## Usage
+
+Because `Agent::new()` takes a concrete provider, pair the preset with the provider matching its protocol (check `config.api`):
+
+```rust
+use yoagent::provider::{AnthropicProvider, ModelConfig, OpenAiCompatProvider};
+use yoagent::Agent;
+
+let key = std::env::var("OPENCODE_API_KEY").unwrap();
+
+// Chat-completions model (GLM, Kimi, DeepSeek, ...)
+let config = ModelConfig::opencode_zen("glm-5.2");
+let agent = Agent::new(OpenAiCompatProvider)
+    .with_model(&config.id)
+    .with_api_key(&key)
+    .with_model_config(config);
+
+// Claude/Qwen model — Anthropic Messages protocol
+let config = ModelConfig::opencode_zen("claude-sonnet-5");
+let agent = Agent::new(AnthropicProvider)
+    .with_model(&config.id)
+    .with_api_key(&key)
+    .with_model_config(config);
+```
+
+For OpenCode Go, use `ModelConfig::opencode_go("kimi-k2.7-code")` — the base URL and protocol map differ, the usage pattern is identical.
+
+## Authentication
+
+Both gateways use `Authorization: Bearer {api_key}`. For the Anthropic-protocol models the presets set `AnthropicCompat { bearer_auth: true, .. }` so the Anthropic provider sends Bearer auth instead of its native `x-api-key` header.
+
+Get an API key by signing in at [opencode.ai](https://opencode.ai) (Zen) or subscribing to Go.
+
+## Defaults
+
+The presets use conservative defaults (128K context window, 16K max output). Override the fields for models with larger limits:
+
+```rust
+let mut config = ModelConfig::opencode_zen("kimi-k2.7-code");
+config.context_window = 256_000;
+```
+
+## Endpoints
+
+- Zen: `https://opencode.ai/zen/v1/{chat/completions | messages | responses}`
+- Go: `https://opencode.ai/zen/go/v1/{chat/completions | messages}`
+
+Model list and metadata: `https://opencode.ai/zen/v1/models` and `https://opencode.ai/zen/go/v1/models`.

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -12,7 +12,9 @@ The gateways serve different model families over different protocols. The preset
 | Go | `qwen*`, `minimax-*` | Anthropic Messages | `AnthropicProvider` |
 | Go | GLM, Kimi, DeepSeek, MiMo, ... | Chat Completions | `OpenAiCompatProvider` |
 
-Gemini models on Zen are **not supported** — Zen serves them over a Google-native endpoint shape yoagent does not target.
+Gemini models on Zen are **not supported** — Zen serves them over a Google-native endpoint shape yoagent does not target. A `gemini-*` id falls through to Chat Completions (with a warning logged) and will fail at request time.
+
+The routing table mirrors the Zen/Go endpoint docs as of mid-2026. OpenCode can change gateway-side routing at any time — if a model errors, verify its protocol against `{base}/models`.
 
 ## Usage
 

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -34,7 +34,7 @@ Full configuration for a model, including provider routing:
 
 ```rust
 pub struct ModelConfig {
-    pub id: String,              // e.g. "gpt-4o"
+    pub id: String,              // e.g. "gpt-5.5"
     pub name: String,            // e.g. "GPT-4o"
     pub api: ApiProtocol,        // Which provider to use
     pub provider: String,        // e.g. "openai"
@@ -51,10 +51,10 @@ pub struct ModelConfig {
 First-class model presets are documented in [Model Presets](model-presets.md). Convenience constructors:
 
 ```rust
-let anthropic = ModelConfig::anthropic("claude-sonnet-4-20250514", "Claude Sonnet 4");
-let openai = ModelConfig::openai("gpt-4o", "GPT-4o");
-let google = ModelConfig::google("gemini-2.0-flash", "Gemini 2.0 Flash");
-let xai = ModelConfig::xai("grok-3-mini", "Grok 3 Mini");
+let anthropic = ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
+let openai = ModelConfig::openai("gpt-5.5", "GPT-4o");
+let google = ModelConfig::google("gemini-2.5-flash", "Gemini 2.0 Flash");
+let xai = ModelConfig::xai("grok-4-1-fast", "Grok 4.1 Fast");
 let groq = ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B");
 let deepseek = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
 let mistral = ModelConfig::mistral("mistral-large-latest", "Mistral Large");

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -35,7 +35,7 @@ Full configuration for a model, including provider routing:
 ```rust
 pub struct ModelConfig {
     pub id: String,              // e.g. "gpt-5.5"
-    pub name: String,            // e.g. "GPT-4o"
+    pub name: String,            // e.g. "GPT-5.5"
     pub api: ApiProtocol,        // Which provider to use
     pub provider: String,        // e.g. "openai"
     pub base_url: String,        // API endpoint
@@ -52,8 +52,8 @@ First-class model presets are documented in [Model Presets](model-presets.md). C
 
 ```rust
 let anthropic = ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
-let openai = ModelConfig::openai("gpt-5.5", "GPT-4o");
-let google = ModelConfig::google("gemini-2.5-flash", "Gemini 2.0 Flash");
+let openai = ModelConfig::openai("gpt-5.5", "GPT-5.5");
+let google = ModelConfig::google("gemini-2.5-flash", "Gemini 2.5 Flash");
 let xai = ModelConfig::xai("grok-4-1-fast", "Grok 4.1 Fast");
 let groq = ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B");
 let deepseek = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -89,12 +89,16 @@ pub struct ExecutionLimits {
 ```rust
 pub enum ThinkingLevel {
     Off,        // No thinking (default)
-    Minimal,    // effort "low" (adaptive) / 1,024-token budget (legacy)
-    Low,        // effort "low" / 1,024
-    Medium,     // effort "medium" / 2,048
-    High,       // effort "high" / 8,192
+    Minimal,    // Anthropic: effort "low" (adaptive) / 1,024-token budget (legacy)
+    Low,        // Anthropic: effort "low" / 1,024
+    Medium,     // Anthropic: effort "medium" / 2,048
+    High,       // Anthropic: effort "high" / 8,192
 }
 ```
+
+OpenAI-family providers map these levels to `reasoning_effort` where the
+compat flags enable it; the Google and Bedrock providers currently ignore
+`thinking_level`.
 
 ## CostConfig
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -89,10 +89,10 @@ pub struct ExecutionLimits {
 ```rust
 pub enum ThinkingLevel {
     Off,        // No thinking (default)
-    Minimal,    // 128 tokens (Anthropic budget)
-    Low,        // 512 tokens
-    Medium,     // 2,048 tokens
-    High,       // 8,192 tokens
+    Minimal,    // effort "low" (adaptive) / 1,024-token budget (legacy)
+    Low,        // effort "low" / 1,024
+    Medium,     // effort "medium" / 2,048
+    High,       // effort "high" / 8,192
 }
 ```
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     let mut agent = Agent::new(AnthropicProvider)
         .with_system_prompt("You are a helpful assistant. Be concise.")
-        .with_model("claude-sonnet-4-20250514")
+        .with_model("claude-sonnet-5")
         .with_api_key(api_key);
 
     println!("Sending prompt...");

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -294,6 +294,23 @@ async fn main() {
                     let msg = error_message.as_deref().unwrap_or("unknown error");
                     println!("{RED}  error: {msg}{RESET}");
                 }
+                AgentEvent::MessageEnd {
+                    message:
+                        AgentMessage::Llm(Message::Assistant {
+                            stop_reason: StopReason::Refusal,
+                            error_message,
+                            ..
+                        }),
+                } => {
+                    if in_text {
+                        println!();
+                        in_text = false;
+                    }
+                    let msg = error_message
+                        .as_deref()
+                        .unwrap_or("request declined by the model's safety system");
+                    println!("{RED}  refused: {msg}{RESET}");
+                }
                 AgentEvent::AgentEnd { messages } => {
                     // Extract usage from the last assistant message
                     for msg in messages.iter().rev() {

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -8,7 +8,7 @@
 //!
 //! Run:
 //!   ANTHROPIC_API_KEY=sk-... cargo run --example cli
-//!   ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --model claude-sonnet-4-20250514
+//!   ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --model claude-sonnet-5
 //!   ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --skills ./skills
 //!
 //! Run with a named provider (zai, qwen, openai, xai, groq, deepseek, mistral, minimax, ollama, google):
@@ -94,15 +94,15 @@ async fn main() {
     let default_model = match provider_name.as_deref() {
         Some("zai") => "glm-4.7",
         Some("qwen") => "qwen3.6-plus",
-        Some("openai") => "gpt-4o",
-        Some("xai") => "grok-3-mini",
+        Some("openai") => "gpt-5.5",
+        Some("xai") => "grok-4-1-fast",
         Some("groq") => "llama-3.3-70b-versatile",
         Some("deepseek") => "deepseek-v4-flash",
         Some("mistral") => "mistral-large-latest",
         Some("minimax") => "MiniMax-Text-01",
         Some("ollama") => "llama3.1:8b",
         Some("google") => "gemini-2.5-pro",
-        _ => "claude-sonnet-4-20250514",
+        _ => "claude-sonnet-5",
     };
 
     let model = args

--- a/examples/code_review.rs
+++ b/examples/code_review.rs
@@ -21,7 +21,7 @@ use yoagent::*;
 #[tokio::main]
 async fn main() {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("Set ANTHROPIC_API_KEY");
-    let model = "claude-sonnet-4-20250514";
+    let model = "claude-sonnet-5";
     let provider: Arc<dyn StreamProvider> = Arc::new(AnthropicProvider);
 
     // --- Read the target file from CLI args ---

--- a/examples/shared_state.rs
+++ b/examples/shared_state.rs
@@ -22,7 +22,7 @@ use yoagent::*;
 #[tokio::main]
 async fn main() {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("Set ANTHROPIC_API_KEY");
-    let model = "claude-sonnet-4-20250514";
+    let model = "claude-sonnet-5";
     let provider: Arc<dyn StreamProvider> = Arc::new(AnthropicProvider);
 
     // --- The artifact: a large CI log (simulated) ---

--- a/examples/sub_agent.rs
+++ b/examples/sub_agent.rs
@@ -18,7 +18,7 @@ use yoagent::*;
 #[tokio::main]
 async fn main() {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("Set ANTHROPIC_API_KEY");
-    let model = "claude-sonnet-4-20250514";
+    let model = "claude-sonnet-5";
     let provider: Arc<dyn StreamProvider> = Arc::new(AnthropicProvider);
 
     // Sub-agent 1: a researcher with file reading tools

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -12,6 +12,24 @@ use tracing::{debug, warn};
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
 const API_VERSION: &str = "2023-06-01";
 
+/// Resolve the request URL: `{base_url}/messages` when a `ModelConfig` is set
+/// (e.g. a gateway like OpenCode Zen), the official endpoint otherwise.
+fn request_url(config: &StreamConfig) -> String {
+    match &config.model_config {
+        Some(mc) => format!("{}/messages", mc.base_url.trim_end_matches('/')),
+        None => API_URL.to_string(),
+    }
+}
+
+/// Effective Anthropic quirk flags. `None` means current-generation defaults.
+fn anthropic_compat(config: &StreamConfig) -> crate::provider::AnthropicCompat {
+    config
+        .model_config
+        .as_ref()
+        .and_then(|mc| mc.anthropic.clone())
+        .unwrap_or_default()
+}
+
 pub struct AnthropicProvider;
 
 #[async_trait]
@@ -29,13 +47,29 @@ impl StreamProvider for AnthropicProvider {
             config.model, is_oauth
         );
 
+        let url = request_url(&config);
         let client = reqwest::Client::new();
         let mut builder = client
-            .post(API_URL)
+            .post(&url)
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json");
 
-        if is_oauth {
+        // Custom headers from ModelConfig. A user-supplied `authorization`
+        // header takes over auth entirely (bring-your-own-token gateways).
+        let mut user_auth = false;
+        if let Some(mc) = &config.model_config {
+            for (key, value) in &mc.headers {
+                if key.eq_ignore_ascii_case("authorization") {
+                    user_auth = true;
+                }
+                builder = builder.header(key, value);
+            }
+        }
+
+        let compat = anthropic_compat(&config);
+        if user_auth {
+            // Auth fully managed via ModelConfig.headers.
+        } else if is_oauth {
             // OAuth token — Bearer auth with Claude Code identity headers
             builder = builder
                 .header("authorization", format!("Bearer {}", config.api_key))
@@ -46,6 +80,9 @@ impl StreamProvider for AnthropicProvider {
                 .header("anthropic-dangerous-direct-browser-access", "true")
                 .header("user-agent", "claude-cli/2.1.2 (external, cli)")
                 .header("x-app", "cli");
+        } else if compat.bearer_auth {
+            // OpenAI-style gateway speaking the Anthropic protocol
+            builder = builder.header("authorization", format!("Bearer {}", config.api_key));
         } else {
             builder = builder.header("x-api-key", &config.api_key);
         }
@@ -185,7 +222,16 @@ impl StreamProvider for AnthropicProvider {
                                     if let Ok(data) = serde_json::from_str::<AnthropicMessageDelta>(&msg.data) {
                                         stop_reason = match data.delta.stop_reason.as_deref() {
                                             Some("tool_use") => StopReason::ToolUse,
-                                            Some("max_tokens") => StopReason::Length,
+                                            Some("max_tokens")
+                                            | Some("model_context_window_exceeded") => {
+                                                StopReason::Length
+                                            }
+                                            Some("refusal") => {
+                                                warn!(
+                                                    "Anthropic declined the request (stop_reason=refusal)"
+                                                );
+                                                StopReason::Refusal
+                                            }
                                             _ => StopReason::Stop,
                                         };
                                         usage.output = data.usage.output_tokens;
@@ -337,9 +383,22 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
         }
     }
 
+    // Default max_tokens: explicit request value, then the model's configured
+    // default, then a conservative fallback.
+    let mut max_tokens = config
+        .max_tokens
+        .or(config.model_config.as_ref().map(|mc| mc.max_tokens))
+        .unwrap_or(8192);
+    let compat = anthropic_compat(config);
+    // Legacy (budget-based) thinking requires max_tokens > budget_tokens.
+    if config.thinking_level != ThinkingLevel::Off && !compat.adaptive_thinking {
+        let budget = legacy_thinking_budget(config.thinking_level);
+        max_tokens = max_tokens.max(budget + 1024);
+    }
+
     let mut body = serde_json::json!({
         "model": config.model,
-        "max_tokens": config.max_tokens.unwrap_or(8192),
+        "max_tokens": max_tokens,
         "stream": true,
         "messages": messages,
     });
@@ -396,17 +455,23 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
     }
 
     if config.thinking_level != ThinkingLevel::Off {
-        let budget = match config.thinking_level {
-            ThinkingLevel::Minimal => 128,
-            ThinkingLevel::Low => 512,
-            ThinkingLevel::Medium => 2048,
-            ThinkingLevel::High => 8192,
-            ThinkingLevel::Off => 0,
-        };
-        body["thinking"] = serde_json::json!({
-            "type": "enabled",
-            "budget_tokens": budget,
-        });
+        if compat.adaptive_thinking {
+            // Current generation (Claude 4.6+ / Fable 5): adaptive thinking with
+            // an effort hint. Budget-based thinking is rejected with a 400.
+            let effort = match config.thinking_level {
+                ThinkingLevel::Minimal | ThinkingLevel::Low => "low",
+                ThinkingLevel::Medium => "medium",
+                ThinkingLevel::High => "high",
+                ThinkingLevel::Off => unreachable!(),
+            };
+            body["thinking"] = serde_json::json!({ "type": "adaptive" });
+            body["output_config"] = serde_json::json!({ "effort": effort });
+        } else {
+            body["thinking"] = serde_json::json!({
+                "type": "enabled",
+                "budget_tokens": legacy_thinking_budget(config.thinking_level),
+            });
+        }
     }
 
     if let Some(temp) = config.temperature {
@@ -414,6 +479,17 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
     }
 
     body
+}
+
+/// Budget tokens for legacy (pre-4.6) extended thinking. The API requires a
+/// minimum of 1024.
+fn legacy_thinking_budget(level: ThinkingLevel) -> u32 {
+    match level {
+        ThinkingLevel::Off => 0,
+        ThinkingLevel::Minimal | ThinkingLevel::Low => 1024,
+        ThinkingLevel::Medium => 2048,
+        ThinkingLevel::High => 8192,
+    }
 }
 
 fn content_to_anthropic(content: &[Content]) -> Vec<serde_json::Value> {
@@ -869,6 +945,101 @@ mod tests {
         assert_eq!(
             first_content.last().unwrap()["cache_control"]["type"],
             "ephemeral"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_thinking_by_default() {
+        let mut config = make_config(CacheConfig::default());
+        config.thinking_level = ThinkingLevel::High;
+
+        let body = build_request_body(&config, false);
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert!(body["thinking"].get("budget_tokens").is_none());
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn test_adaptive_thinking_effort_mapping() {
+        for (level, effort) in [
+            (ThinkingLevel::Minimal, "low"),
+            (ThinkingLevel::Low, "low"),
+            (ThinkingLevel::Medium, "medium"),
+            (ThinkingLevel::High, "high"),
+        ] {
+            let mut config = make_config(CacheConfig::default());
+            config.thinking_level = level;
+            let body = build_request_body(&config, false);
+            assert_eq!(body["output_config"]["effort"], effort);
+        }
+    }
+
+    #[test]
+    fn test_legacy_thinking_budget_clamped_to_api_minimum() {
+        let mut config = make_config(CacheConfig::default());
+        config.thinking_level = ThinkingLevel::Minimal;
+        let mut mc = crate::provider::ModelConfig::anthropic("claude-sonnet-4-5", "Sonnet 4.5");
+        mc.anthropic = Some(crate::provider::AnthropicCompat::legacy());
+        config.model_config = Some(mc);
+
+        let body = build_request_body(&config, false);
+        assert_eq!(body["thinking"]["type"], "enabled");
+        // API minimum is 1024
+        assert_eq!(body["thinking"]["budget_tokens"], 1024);
+        // max_tokens must exceed budget_tokens even though the request asked for 1024
+        assert!(body["max_tokens"].as_u64().unwrap() > 1024);
+    }
+
+    #[test]
+    fn test_thinking_off_sends_no_thinking_field() {
+        let config = make_config(CacheConfig::default());
+        let body = build_request_body(&config, false);
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn test_max_tokens_falls_back_to_model_config() {
+        let mut config = make_config(CacheConfig::default());
+        config.max_tokens = None;
+        config.model_config = Some(crate::provider::ModelConfig::anthropic(
+            "claude-sonnet-5",
+            "Claude Sonnet 5",
+        ));
+
+        let body = build_request_body(&config, false);
+        assert_eq!(body["max_tokens"], 16_000);
+    }
+
+    #[test]
+    fn test_request_url_from_model_config_base_url() {
+        let mut config = make_config(CacheConfig::default());
+        assert_eq!(
+            request_url(&config),
+            "https://api.anthropic.com/v1/messages"
+        );
+
+        let mut mc = crate::provider::ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
+        mc.base_url = "https://opencode.ai/zen/v1".into();
+        config.model_config = Some(mc.clone());
+        assert_eq!(request_url(&config), "https://opencode.ai/zen/v1/messages");
+
+        // trailing slash is tolerated
+        mc.base_url = "https://opencode.ai/zen/v1/".into();
+        config.model_config = Some(mc);
+        assert_eq!(request_url(&config), "https://opencode.ai/zen/v1/messages");
+    }
+
+    #[test]
+    fn test_default_base_url_yields_official_endpoint() {
+        let mut config = make_config(CacheConfig::default());
+        config.model_config = Some(crate::provider::ModelConfig::anthropic(
+            "claude-opus-4-8",
+            "Claude Opus 4.8",
+        ));
+        assert_eq!(
+            request_url(&config),
+            "https://api.anthropic.com/v1/messages"
         );
     }
 }

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -16,7 +16,16 @@ const API_VERSION: &str = "2023-06-01";
 /// (e.g. a gateway like OpenCode Zen), the official endpoint otherwise.
 fn request_url(config: &StreamConfig) -> String {
     match &config.model_config {
-        Some(mc) => format!("{}/messages", mc.base_url.trim_end_matches('/')),
+        Some(mc) => {
+            let base = mc.base_url.trim_end_matches('/');
+            // Configs created before 0.9.0 carry the un-versioned official
+            // host (base_url used to be ignored); keep them working.
+            if base == "https://api.anthropic.com" {
+                API_URL.to_string()
+            } else {
+                format!("{}/messages", base)
+            }
+        }
         None => API_URL.to_string(),
     }
 }
@@ -42,12 +51,11 @@ impl StreamProvider for AnthropicProvider {
     ) -> Result<Message, ProviderError> {
         let is_oauth = config.api_key.contains("sk-ant-oat");
         let body = build_request_body(&config, is_oauth);
-        debug!(
-            "Anthropic request: model={}, oauth={}",
-            config.model, is_oauth
-        );
-
         let url = request_url(&config);
+        debug!(
+            "Anthropic request: model={}, url={}, oauth={}",
+            config.model, url, is_oauth
+        );
         let client = reqwest::Client::new();
         let mut builder = client
             .post(&url)
@@ -95,6 +103,7 @@ impl StreamProvider for AnthropicProvider {
         let mut content: Vec<Content> = Vec::new();
         let mut usage = Usage::default();
         let mut stop_reason = StopReason::Stop;
+        let mut error_message: Option<String> = None;
 
         let _ = tx.send(StreamEvent::Start);
 
@@ -222,13 +231,25 @@ impl StreamProvider for AnthropicProvider {
                                     if let Ok(data) = serde_json::from_str::<AnthropicMessageDelta>(&msg.data) {
                                         stop_reason = match data.delta.stop_reason.as_deref() {
                                             Some("tool_use") => StopReason::ToolUse,
-                                            Some("max_tokens")
-                                            | Some("model_context_window_exceeded") => {
-                                                StopReason::Length
+                                            Some("max_tokens") => StopReason::Length,
+                                            Some("model_context_window_exceeded") => {
+                                                // In-stream overflow (HTTP 200). Map to the same
+                                                // Error + overflow-phrase shape as an HTTP 400
+                                                // overflow so Message::is_context_overflow() and
+                                                // compaction-retry hooks keep working.
+                                                warn!("Anthropic context window exceeded mid-stream");
+                                                error_message =
+                                                    Some("model_context_window_exceeded".into());
+                                                StopReason::Error
                                             }
                                             Some("refusal") => {
                                                 warn!(
                                                     "Anthropic declined the request (stop_reason=refusal)"
+                                                );
+                                                error_message = Some(
+                                                    "Request declined by the model's safety system \
+                                                     (stop_reason: refusal)"
+                                                        .into(),
                                                 );
                                                 StopReason::Refusal
                                             }
@@ -262,7 +283,8 @@ impl StreamProvider for AnthropicProvider {
         let has_tool_calls = content
             .iter()
             .any(|c| matches!(c, Content::ToolCall { .. }));
-        if has_tool_calls {
+        // Never let the tool-call fallback mask a refusal or an error signal.
+        if has_tool_calls && !matches!(stop_reason, StopReason::Refusal | StopReason::Error) {
             stop_reason = StopReason::ToolUse;
         }
 
@@ -273,7 +295,7 @@ impl StreamProvider for AnthropicProvider {
             provider: "anthropic".into(),
             usage,
             timestamp: now_ms(),
-            error_message: None,
+            error_message,
         };
 
         let _ = tx.send(StreamEvent::Done {
@@ -299,10 +321,16 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
                 }));
             }
             Message::Assistant { content, .. } => {
-                messages.push(serde_json::json!({
-                    "role": "assistant",
-                    "content": content_to_anthropic(content),
-                }));
+                // A refused or errored turn can leave an assistant message with
+                // no serializable content; the API rejects empty assistant
+                // content blocks mid-conversation, so skip such messages.
+                let blocks = content_to_anthropic(content);
+                if !blocks.is_empty() {
+                    messages.push(serde_json::json!({
+                        "role": "assistant",
+                        "content": blocks,
+                    }));
+                }
             }
             Message::ToolResult {
                 tool_call_id,
@@ -393,7 +421,14 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
     // Legacy (budget-based) thinking requires max_tokens > budget_tokens.
     if config.thinking_level != ThinkingLevel::Off && !compat.adaptive_thinking {
         let budget = legacy_thinking_budget(config.thinking_level);
-        max_tokens = max_tokens.max(budget + 1024);
+        if max_tokens <= budget {
+            debug!(
+                "Raising max_tokens from {} to {} to exceed the thinking budget",
+                max_tokens,
+                budget + 1024
+            );
+            max_tokens = budget + 1024;
+        }
     }
 
     let mut body = serde_json::json!({
@@ -482,7 +517,8 @@ fn build_request_body(config: &StreamConfig, is_oauth: bool) -> serde_json::Valu
 }
 
 /// Budget tokens for legacy (pre-4.6) extended thinking. The API requires a
-/// minimum of 1024.
+/// minimum of 1024. (`Off` returns 0 but never reaches a thinking-enabled
+/// request — both call sites guard on `!= ThinkingLevel::Off`.)
 fn legacy_thinking_budget(level: ThinkingLevel) -> u32 {
     match level {
         ThinkingLevel::Off => 0,
@@ -1009,6 +1045,64 @@ mod tests {
 
         let body = build_request_body(&config, false);
         assert_eq!(body["max_tokens"], 16_000);
+    }
+
+    #[test]
+    fn test_explicit_max_tokens_beats_model_config() {
+        let mut config = make_config(CacheConfig::default());
+        config.max_tokens = Some(1024);
+        config.model_config = Some(crate::provider::ModelConfig::claude_sonnet_5());
+
+        let body = build_request_body(&config, false);
+        assert_eq!(body["max_tokens"], 1024);
+    }
+
+    #[test]
+    fn test_adaptive_thinking_does_not_clamp_max_tokens() {
+        let mut config = make_config(CacheConfig::default());
+        config.thinking_level = ThinkingLevel::High;
+        config.max_tokens = Some(1024);
+
+        let body = build_request_body(&config, false);
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["max_tokens"], 1024);
+    }
+
+    #[test]
+    fn test_empty_assistant_message_is_skipped() {
+        let mut config = make_config(CacheConfig::default());
+        // A refused turn leaves an assistant message with no serializable content.
+        config.messages = vec![
+            Message::user("Hello"),
+            Message::Assistant {
+                content: vec![],
+                stop_reason: StopReason::Refusal,
+                model: "claude-sonnet-5".into(),
+                provider: "anthropic".into(),
+                usage: Usage::default(),
+                timestamp: 0,
+                error_message: Some("refused".into()),
+            },
+            Message::user("Try again"),
+        ];
+
+        let body = build_request_body(&config, false);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 2, "empty assistant message must be dropped");
+        assert!(msgs.iter().all(|m| m["role"] == "user"));
+    }
+
+    #[test]
+    fn test_legacy_official_base_url_without_version_still_works() {
+        // Configs persisted before 0.9.0 carry the un-versioned host.
+        let mut config = make_config(CacheConfig::default());
+        let mut mc = crate::provider::ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
+        mc.base_url = "https://api.anthropic.com".into();
+        config.model_config = Some(mc);
+        assert_eq!(
+            request_url(&config),
+            "https://api.anthropic.com/v1/messages"
+        );
     }
 
     #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -17,7 +17,7 @@ pub use bedrock::BedrockProvider;
 pub use google::GoogleProvider;
 pub use google_vertex::GoogleVertexProvider;
 pub use mock::MockProvider;
-pub use model::{ApiProtocol, CostConfig, ModelConfig, OpenAiCompat};
+pub use model::{AnthropicCompat, ApiProtocol, CostConfig, ModelConfig, OpenAiCompat};
 pub use openai_compat::OpenAiCompatProvider;
 pub use openai_responses::OpenAiResponsesProvider;
 pub use registry::ProviderRegistry;

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -212,6 +212,42 @@ impl OpenAiCompat {
     }
 }
 
+/// Quirk flags for the Anthropic Messages protocol (only for AnthropicMessages).
+///
+/// When `ModelConfig.anthropic` is `None`, providers use `AnthropicCompat::default()`,
+/// which targets the current model generation (Claude 4.6+ / Fable 5).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicCompat {
+    /// Use adaptive thinking (`thinking: {"type": "adaptive"}` plus
+    /// `output_config.effort`). Required by Claude Fable 5, Opus 4.7/4.8, and
+    /// Sonnet 5; recommended on Opus 4.6 / Sonnet 4.6. Set to `false` for
+    /// pre-4.6 models, which only accept `{"type": "enabled", "budget_tokens": N}`.
+    pub adaptive_thinking: bool,
+    /// Send the API key as `Authorization: Bearer {key}` instead of the
+    /// Anthropic-native `x-api-key` header. Needed for OpenAI-style gateways
+    /// that speak the Anthropic Messages protocol (e.g. OpenCode Zen/Go).
+    pub bearer_auth: bool,
+}
+
+impl Default for AnthropicCompat {
+    fn default() -> Self {
+        Self {
+            adaptive_thinking: true,
+            bearer_auth: false,
+        }
+    }
+}
+
+impl AnthropicCompat {
+    /// Compat flags for pre-4.6 Claude models (budget-based extended thinking).
+    pub fn legacy() -> Self {
+        Self {
+            adaptive_thinking: false,
+            bearer_auth: false,
+        }
+    }
+}
+
 /// Full model configuration. Knows everything needed to make API calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
@@ -240,6 +276,10 @@ pub struct ModelConfig {
     /// OpenAI-compat quirk flags (only for OpenAiCompletions protocol).
     #[serde(default)]
     pub compat: Option<OpenAiCompat>,
+    /// Anthropic Messages quirk flags (only for AnthropicMessages protocol).
+    /// `None` behaves like `AnthropicCompat::default()` (current generation).
+    #[serde(default)]
+    pub anthropic: Option<AnthropicCompat>,
 }
 
 impl ModelConfig {
@@ -250,13 +290,89 @@ impl ModelConfig {
             name: name.into(),
             api: ApiProtocol::AnthropicMessages,
             provider: "anthropic".into(),
-            base_url: "https://api.anthropic.com".into(),
-            reasoning: false,
+            base_url: "https://api.anthropic.com/v1".into(),
+            reasoning: true,
             context_window: 200_000,
-            max_tokens: 8192,
+            max_tokens: 16_000,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: None,
+        }
+    }
+
+    /// Claude Fable 5 — Anthropic's most capable model (1M context, 128K max output).
+    pub fn claude_fable_5() -> Self {
+        Self {
+            context_window: 1_000_000,
+            max_tokens: 64_000,
+            cost: CostConfig {
+                input_per_million: 10.0,
+                output_per_million: 50.0,
+                cache_read_per_million: 1.0,
+                cache_write_per_million: 12.5,
+            },
+            ..Self::anthropic("claude-fable-5", "Claude Fable 5")
+        }
+    }
+
+    /// Claude Opus 4.8 (1M context, 128K max output).
+    pub fn claude_opus_4_8() -> Self {
+        Self {
+            context_window: 1_000_000,
+            max_tokens: 64_000,
+            cost: CostConfig {
+                input_per_million: 5.0,
+                output_per_million: 25.0,
+                cache_read_per_million: 0.5,
+                cache_write_per_million: 6.25,
+            },
+            ..Self::anthropic("claude-opus-4-8", "Claude Opus 4.8")
+        }
+    }
+
+    /// Claude Sonnet 5 (1M context, 128K max output).
+    pub fn claude_sonnet_5() -> Self {
+        Self {
+            context_window: 1_000_000,
+            max_tokens: 64_000,
+            cost: CostConfig {
+                input_per_million: 3.0,
+                output_per_million: 15.0,
+                cache_read_per_million: 0.3,
+                cache_write_per_million: 3.75,
+            },
+            ..Self::anthropic("claude-sonnet-5", "Claude Sonnet 5")
+        }
+    }
+
+    /// Claude Haiku 4.5 (200K context, 64K max output).
+    pub fn claude_haiku_4_5() -> Self {
+        Self {
+            context_window: 200_000,
+            max_tokens: 32_000,
+            cost: CostConfig {
+                input_per_million: 1.0,
+                output_per_million: 5.0,
+                cache_read_per_million: 0.1,
+                cache_write_per_million: 1.25,
+            },
+            ..Self::anthropic("claude-haiku-4-5", "Claude Haiku 4.5")
+        }
+    }
+
+    /// GPT-5.5 (~1M context, 128K max output). Uses the Chat Completions API.
+    pub fn gpt_5_5() -> Self {
+        Self {
+            reasoning: true,
+            context_window: 1_000_000,
+            max_tokens: 64_000,
+            cost: CostConfig {
+                input_per_million: 5.0,
+                output_per_million: 30.0,
+                ..CostConfig::default()
+            },
+            ..Self::openai("gpt-5.5", "GPT-5.5")
         }
     }
 
@@ -273,6 +389,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::openai()),
         }
     }
@@ -291,7 +408,83 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::default()),
+        }
+    }
+
+    /// Create a config for a model served by OpenCode Zen
+    /// (<https://opencode.ai/docs/zen>), OpenCode's pay-per-use gateway.
+    ///
+    /// Zen serves each model family over a different protocol; the protocol is
+    /// selected from the model id:
+    /// - `gpt-*` → OpenAI Responses API (pair with `OpenAiResponsesProvider`)
+    /// - `claude-*`, `qwen*` → Anthropic Messages API (pair with `AnthropicProvider`)
+    /// - everything else (DeepSeek, MiniMax, GLM, Kimi, ...) → Chat Completions
+    ///   (pair with `OpenAiCompatProvider`)
+    ///
+    /// Gemini models are not supported — Zen serves them over a Google-native
+    /// endpoint shape yoagent does not target.
+    ///
+    /// Context window and max output default conservatively (128K / 16K);
+    /// override the fields for models with larger limits.
+    pub fn opencode_zen(model_id: impl Into<String>) -> Self {
+        let id = model_id.into();
+        Self::opencode(id, "opencode-zen", "https://opencode.ai/zen/v1", false)
+    }
+
+    /// Create a config for a model served by OpenCode Go
+    /// (<https://opencode.ai/docs/go>), OpenCode's subscription gateway for
+    /// open models.
+    ///
+    /// Protocol is selected from the model id:
+    /// - `qwen*`, `minimax-*` → Anthropic Messages API (pair with `AnthropicProvider`)
+    /// - everything else (GLM, Kimi, DeepSeek, MiMo, ...) → Chat Completions
+    ///   (pair with `OpenAiCompatProvider`)
+    pub fn opencode_go(model_id: impl Into<String>) -> Self {
+        let id = model_id.into();
+        Self::opencode(id, "opencode-go", "https://opencode.ai/zen/go/v1", true)
+    }
+
+    fn opencode(id: String, provider: &str, base_url: &str, is_go: bool) -> Self {
+        let lower = id.to_ascii_lowercase();
+        let anthropic_protocol = if is_go {
+            lower.starts_with("qwen") || lower.starts_with("minimax-")
+        } else {
+            lower.starts_with("claude-") || lower.starts_with("qwen")
+        };
+        let (api, compat, anthropic) = if anthropic_protocol {
+            (
+                ApiProtocol::AnthropicMessages,
+                None,
+                // Gateways use OpenAI-style Bearer auth, not x-api-key.
+                Some(AnthropicCompat {
+                    adaptive_thinking: true,
+                    bearer_auth: true,
+                }),
+            )
+        } else if !is_go && lower.starts_with("gpt-") {
+            (ApiProtocol::OpenAiResponses, None, None)
+        } else {
+            (
+                ApiProtocol::OpenAiCompletions,
+                Some(OpenAiCompat::default()),
+                None,
+            )
+        };
+        Self {
+            id: id.clone(),
+            name: id,
+            api,
+            provider: provider.into(),
+            base_url: base_url.into(),
+            reasoning: false,
+            context_window: 128_000,
+            max_tokens: 16_000,
+            cost: CostConfig::default(),
+            headers: HashMap::new(),
+            compat,
+            anthropic,
         }
     }
 
@@ -314,6 +507,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(compat),
         }
     }
@@ -334,6 +528,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::ollama()),
         }
     }
@@ -353,6 +548,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::zai()),
         }
     }
@@ -372,6 +568,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::minimax()),
         }
     }
@@ -391,13 +588,14 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::qwen()),
         }
     }
 
     /// Create a new xAI (Grok) model config.
     ///
-    /// Models: `grok-3-mini`, `grok-3`, etc.
+    /// Models: `grok-4-1-fast`, `grok-4-1`, etc.
     pub fn xai(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -410,6 +608,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::xai()),
         }
     }
@@ -429,6 +628,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::groq()),
         }
     }
@@ -451,6 +651,7 @@ impl ModelConfig {
             max_tokens: 384_000,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::deepseek()),
         }
     }
@@ -470,6 +671,7 @@ impl ModelConfig {
             max_tokens: 4096,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: Some(OpenAiCompat::mistral()),
         }
     }
@@ -487,6 +689,7 @@ impl ModelConfig {
             max_tokens: 8192,
             cost: CostConfig::default(),
             headers: HashMap::new(),
+            anthropic: None,
             compat: None,
         }
     }
@@ -498,10 +701,89 @@ mod tests {
 
     #[test]
     fn test_model_config_anthropic() {
-        let config = ModelConfig::anthropic("claude-sonnet-4-20250514", "Claude Sonnet 4");
+        let config = ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
         assert_eq!(config.api, ApiProtocol::AnthropicMessages);
         assert_eq!(config.provider, "anthropic");
+        assert_eq!(config.base_url, "https://api.anthropic.com/v1");
         assert!(config.compat.is_none());
+        assert!(config.anthropic.is_none());
+    }
+
+    #[test]
+    fn test_new_generation_presets() {
+        let fable = ModelConfig::claude_fable_5();
+        assert_eq!(fable.id, "claude-fable-5");
+        assert_eq!(fable.api, ApiProtocol::AnthropicMessages);
+        assert_eq!(fable.context_window, 1_000_000);
+        assert_eq!(fable.cost.input_per_million, 10.0);
+        assert_eq!(fable.cost.output_per_million, 50.0);
+
+        let opus = ModelConfig::claude_opus_4_8();
+        assert_eq!(opus.id, "claude-opus-4-8");
+        assert_eq!(opus.context_window, 1_000_000);
+        assert_eq!(opus.cost.input_per_million, 5.0);
+
+        let sonnet = ModelConfig::claude_sonnet_5();
+        assert_eq!(sonnet.id, "claude-sonnet-5");
+        assert_eq!(sonnet.cost.output_per_million, 15.0);
+
+        let haiku = ModelConfig::claude_haiku_4_5();
+        assert_eq!(haiku.id, "claude-haiku-4-5");
+        assert_eq!(haiku.context_window, 200_000);
+
+        let gpt = ModelConfig::gpt_5_5();
+        assert_eq!(gpt.id, "gpt-5.5");
+        assert_eq!(gpt.api, ApiProtocol::OpenAiCompletions);
+        assert_eq!(gpt.context_window, 1_000_000);
+        assert_eq!(gpt.cost.output_per_million, 30.0);
+        assert!(gpt.compat.is_some());
+    }
+
+    #[test]
+    fn test_opencode_zen_protocol_selection() {
+        // GPT models → Responses API
+        let gpt = ModelConfig::opencode_zen("gpt-5.5");
+        assert_eq!(gpt.api, ApiProtocol::OpenAiResponses);
+        assert_eq!(gpt.provider, "opencode-zen");
+        assert_eq!(gpt.base_url, "https://opencode.ai/zen/v1");
+
+        // Claude and Qwen models → Anthropic Messages with Bearer auth
+        for id in ["claude-sonnet-5", "qwen3.7-max"] {
+            let config = ModelConfig::opencode_zen(id);
+            assert_eq!(config.api, ApiProtocol::AnthropicMessages, "{id}");
+            let compat = config.anthropic.expect("anthropic compat set");
+            assert!(compat.bearer_auth);
+        }
+
+        // Everything else → Chat Completions
+        for id in ["deepseek-v4-pro", "minimax-m3", "glm-5.2", "kimi-k2.7-code"] {
+            let config = ModelConfig::opencode_zen(id);
+            assert_eq!(config.api, ApiProtocol::OpenAiCompletions, "{id}");
+            assert!(config.compat.is_some());
+        }
+    }
+
+    #[test]
+    fn test_opencode_go_protocol_selection() {
+        // Qwen and MiniMax models → Anthropic Messages with Bearer auth
+        for id in ["qwen3.7-max", "minimax-m3"] {
+            let config = ModelConfig::opencode_go(id);
+            assert_eq!(config.api, ApiProtocol::AnthropicMessages, "{id}");
+            assert_eq!(config.base_url, "https://opencode.ai/zen/go/v1");
+            assert!(config.anthropic.expect("anthropic compat set").bearer_auth);
+        }
+
+        // Everything else → Chat Completions (Go has no GPT models)
+        for id in [
+            "glm-5.2",
+            "kimi-k2.7-code",
+            "deepseek-v4-flash",
+            "mimo-v2.5",
+        ] {
+            let config = ModelConfig::opencode_go(id);
+            assert_eq!(config.api, ApiProtocol::OpenAiCompletions, "{id}");
+            assert_eq!(config.provider, "opencode-go", "{id}");
+        }
     }
 
     #[test]

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -217,6 +217,7 @@ impl OpenAiCompat {
 /// When `ModelConfig.anthropic` is `None`, providers use `AnthropicCompat::default()`,
 /// which targets the current model generation (Claude 4.6+ / Fable 5).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct AnthropicCompat {
     /// Use adaptive thinking (`thinking: {"type": "adaptive"}` plus
     /// `output_config.effort`). Required by Claude Fable 5, Opus 4.7/4.8, and
@@ -244,6 +245,31 @@ impl AnthropicCompat {
         Self {
             adaptive_thinking: false,
             bearer_auth: false,
+        }
+    }
+}
+
+/// The two OpenCode gateways (<https://opencode.ai>).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenCodeGateway {
+    /// Pay-per-use gateway (`opencode.ai/zen/v1`).
+    Zen,
+    /// Subscription gateway for open models (`opencode.ai/zen/go/v1`).
+    Go,
+}
+
+impl OpenCodeGateway {
+    fn provider_name(self) -> &'static str {
+        match self {
+            Self::Zen => "opencode-zen",
+            Self::Go => "opencode-go",
+        }
+    }
+
+    fn base_url(self) -> &'static str {
+        match self {
+            Self::Zen => "https://opencode.ai/zen/v1",
+            Self::Go => "https://opencode.ai/zen/go/v1",
         }
     }
 }
@@ -301,7 +327,8 @@ impl ModelConfig {
         }
     }
 
-    /// Claude Fable 5 — Anthropic's most capable model (1M context, 128K max output).
+    /// Claude Fable 5 — Anthropic's most capable model.
+    /// 1M context; defaults to 64K of the model's 128K max output.
     pub fn claude_fable_5() -> Self {
         Self {
             context_window: 1_000_000,
@@ -316,7 +343,7 @@ impl ModelConfig {
         }
     }
 
-    /// Claude Opus 4.8 (1M context, 128K max output).
+    /// Claude Opus 4.8. 1M context; defaults to 64K of the model's 128K max output.
     pub fn claude_opus_4_8() -> Self {
         Self {
             context_window: 1_000_000,
@@ -331,7 +358,7 @@ impl ModelConfig {
         }
     }
 
-    /// Claude Sonnet 5 (1M context, 128K max output).
+    /// Claude Sonnet 5. 1M context; defaults to 64K of the model's 128K max output.
     pub fn claude_sonnet_5() -> Self {
         Self {
             context_window: 1_000_000,
@@ -346,7 +373,7 @@ impl ModelConfig {
         }
     }
 
-    /// Claude Haiku 4.5 (200K context, 64K max output).
+    /// Claude Haiku 4.5. 200K context; defaults to 32K of the model's 64K max output.
     pub fn claude_haiku_4_5() -> Self {
         Self {
             context_window: 200_000,
@@ -361,7 +388,8 @@ impl ModelConfig {
         }
     }
 
-    /// GPT-5.5 (~1M context, 128K max output). Uses the Chat Completions API.
+    /// GPT-5.5. ~1M context; defaults to 64K of the model's 128K max output.
+    /// Uses the Chat Completions API.
     pub fn gpt_5_5() -> Self {
         Self {
             reasoning: true,
@@ -370,7 +398,8 @@ impl ModelConfig {
             cost: CostConfig {
                 input_per_million: 5.0,
                 output_per_million: 30.0,
-                ..CostConfig::default()
+                cache_read_per_million: 0.5,
+                cache_write_per_million: 0.0,
             },
             ..Self::openai("gpt-5.5", "GPT-5.5")
         }
@@ -424,13 +453,16 @@ impl ModelConfig {
     ///   (pair with `OpenAiCompatProvider`)
     ///
     /// Gemini models are not supported — Zen serves them over a Google-native
-    /// endpoint shape yoagent does not target.
+    /// endpoint shape yoagent does not target. A `gemini-*` id falls through to
+    /// Chat Completions (with a warning) and will likely fail at request time.
+    ///
+    /// The routing mirrors the Zen endpoint tables as of mid-2026; if a model
+    /// errors, verify its protocol against `https://opencode.ai/zen/v1/models`.
     ///
     /// Context window and max output default conservatively (128K / 16K);
     /// override the fields for models with larger limits.
     pub fn opencode_zen(model_id: impl Into<String>) -> Self {
-        let id = model_id.into();
-        Self::opencode(id, "opencode-zen", "https://opencode.ai/zen/v1", false)
+        Self::opencode(model_id.into(), OpenCodeGateway::Zen)
     }
 
     /// Create a config for a model served by OpenCode Go
@@ -442,20 +474,27 @@ impl ModelConfig {
     /// - everything else (GLM, Kimi, DeepSeek, MiMo, ...) → Chat Completions
     ///   (pair with `OpenAiCompatProvider`)
     pub fn opencode_go(model_id: impl Into<String>) -> Self {
-        let id = model_id.into();
-        Self::opencode(id, "opencode-go", "https://opencode.ai/zen/go/v1", true)
+        Self::opencode(model_id.into(), OpenCodeGateway::Go)
     }
 
-    fn opencode(id: String, provider: &str, base_url: &str, is_go: bool) -> Self {
+    fn opencode(id: String, gateway: OpenCodeGateway) -> Self {
         let lower = id.to_ascii_lowercase();
-        let anthropic_protocol = if is_go {
-            lower.starts_with("qwen") || lower.starts_with("minimax-")
-        } else {
-            lower.starts_with("claude-") || lower.starts_with("qwen")
+        if lower.starts_with("gemini-") {
+            tracing::warn!(
+                "OpenCode serves Gemini models over a Google-native endpoint yoagent \
+                 does not target; '{}' is routed to /chat/completions and will likely \
+                 fail at request time",
+                id
+            );
+        }
+        let anthropic_protocol = match gateway {
+            OpenCodeGateway::Zen => lower.starts_with("claude-") || lower.starts_with("qwen"),
+            OpenCodeGateway::Go => lower.starts_with("qwen") || lower.starts_with("minimax-"),
         };
-        let (api, compat, anthropic) = if anthropic_protocol {
+        let (api, reasoning, compat, anthropic) = if anthropic_protocol {
             (
                 ApiProtocol::AnthropicMessages,
+                true,
                 None,
                 // Gateways use OpenAI-style Bearer auth, not x-api-key.
                 Some(AnthropicCompat {
@@ -463,11 +502,12 @@ impl ModelConfig {
                     bearer_auth: true,
                 }),
             )
-        } else if !is_go && lower.starts_with("gpt-") {
-            (ApiProtocol::OpenAiResponses, None, None)
+        } else if gateway == OpenCodeGateway::Zen && lower.starts_with("gpt-") {
+            (ApiProtocol::OpenAiResponses, true, None, None)
         } else {
             (
                 ApiProtocol::OpenAiCompletions,
+                false,
                 Some(OpenAiCompat::default()),
                 None,
             )
@@ -476,9 +516,9 @@ impl ModelConfig {
             id: id.clone(),
             name: id,
             api,
-            provider: provider.into(),
-            base_url: base_url.into(),
-            reasoning: false,
+            provider: gateway.provider_name().into(),
+            base_url: gateway.base_url().into(),
+            reasoning,
             context_window: 128_000,
             max_tokens: 16_000,
             cost: CostConfig::default(),
@@ -829,6 +869,28 @@ mod tests {
         assert!(qwen.supports_usage_in_streaming);
         assert!(!qwen.supports_reasoning_effort);
         assert!(!qwen.supports_thinking_control);
+    }
+
+    #[test]
+    fn test_model_config_deserializes_without_anthropic_field() {
+        // Configs persisted before 0.9.0 have no `anthropic` field.
+        let mut value = serde_json::to_value(ModelConfig::anthropic("m", "M")).unwrap();
+        value.as_object_mut().unwrap().remove("anthropic");
+        let config: ModelConfig = serde_json::from_value(value).unwrap();
+        assert!(config.anthropic.is_none());
+    }
+
+    #[test]
+    fn test_anthropic_compat_deserializes_from_partial_json() {
+        // Container-level serde(default): missing fields use Default (adaptive on).
+        let compat: AnthropicCompat = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(compat.adaptive_thinking);
+        assert!(!compat.bearer_auth);
+
+        let compat: AnthropicCompat =
+            serde_json::from_value(serde_json::json!({"bearer_auth": true})).unwrap();
+        assert!(compat.adaptive_thinking);
+        assert!(compat.bearer_auth);
     }
 
     #[test]

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -180,6 +180,7 @@ const OVERFLOW_PHRASES: &[&str] = &[
     "exceeded model token limit",         // Kimi
     "context length exceeded",            // Generic
     "context_length_exceeded",            // Generic (underscore variant)
+    "model_context_window_exceeded",      // Anthropic in-stream stop_reason
     "too many tokens",                    // Generic
     "token limit exceeded",               // Generic
 ];

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,6 +170,12 @@ pub enum StopReason {
     ToolUse,
     Error,
     Aborted,
+    /// The provider's safety system declined the request (HTTP 200 with an
+    /// empty or partial response). Currently emitted by Anthropic models that
+    /// support the `refusal` stop reason (e.g. Claude Fable 5). The loop
+    /// treats it like `Stop`; callers can match on it to retry on a fallback
+    /// model.
+    Refusal,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -501,6 +507,7 @@ impl fmt::Display for StopReason {
             Self::ToolUse => write!(f, "toolUse"),
             Self::Error => write!(f, "error"),
             Self::Aborted => write!(f, "aborted"),
+            Self::Refusal => write!(f, "refusal"),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,11 +170,12 @@ pub enum StopReason {
     ToolUse,
     Error,
     Aborted,
-    /// The provider's safety system declined the request (HTTP 200 with an
-    /// empty or partial response). Currently emitted by Anthropic models that
-    /// support the `refusal` stop reason (e.g. Claude Fable 5). The loop
-    /// treats it like `Stop`; callers can match on it to retry on a fallback
-    /// model.
+    /// The provider's safety system declined the request. The stream completes
+    /// normally (HTTP 200) but with `stop_reason: refusal` and empty or partial
+    /// content; `error_message` carries an explanation. Currently emitted by
+    /// Anthropic models that support the `refusal` stop reason (e.g. Claude
+    /// Fable 5). The agent loop does not special-case it (the turn ends like a
+    /// normal `Stop`); callers can match on it to retry on a fallback model.
     Refusal,
 }
 

--- a/tests/anthropic_stream_test.rs
+++ b/tests/anthropic_stream_test.rs
@@ -1,0 +1,182 @@
+//! Streaming tests for `AnthropicProvider` against a local mock server.
+//!
+//! These cover the response-parsing and auth behavior that unit tests on
+//! `build_request_body` can't reach: stop-reason mapping from SSE events and
+//! the request headers actually sent on the wire.
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+use yoagent::provider::{
+    AnthropicCompat, AnthropicProvider, ModelConfig, StreamConfig, StreamProvider,
+};
+use yoagent::types::*;
+
+/// Matcher: the request must NOT carry the given header.
+struct HeaderAbsent(&'static str);
+
+impl wiremock::Match for HeaderAbsent {
+    fn matches(&self, request: &Request) -> bool {
+        !request.headers.contains_key(self.0)
+    }
+}
+
+/// Canned SSE body for a stream that ends with the given stop_reason and no
+/// content blocks (the shape of a pre-output refusal).
+fn sse_empty_with_stop(stop_reason: &str) -> String {
+    format!(
+        "event: message_start\n\
+         data: {{\"type\":\"message_start\",\"message\":{{\"usage\":{{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}}}}\n\n\
+         event: message_delta\n\
+         data: {{\"type\":\"message_delta\",\"delta\":{{\"stop_reason\":\"{stop_reason}\"}},\"usage\":{{\"output_tokens\":0}}}}\n\n\
+         event: message_stop\n\
+         data: {{\"type\":\"message_stop\"}}\n\n"
+    )
+}
+
+fn stream_config(base_url: &str, anthropic: Option<AnthropicCompat>) -> StreamConfig {
+    let mut mc = ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5");
+    mc.base_url = base_url.to_string();
+    mc.anthropic = anthropic;
+    StreamConfig {
+        model: "claude-sonnet-5".into(),
+        system_prompt: "test".into(),
+        messages: vec![Message::user("hi")],
+        tools: vec![],
+        thinking_level: ThinkingLevel::Off,
+        api_key: "test-key".into(),
+        max_tokens: Some(256),
+        temperature: None,
+        model_config: Some(mc),
+        cache_config: CacheConfig::default(),
+    }
+}
+
+async fn run_stream(config: StreamConfig) -> Result<Message, yoagent::provider::ProviderError> {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    AnthropicProvider
+        .stream(config, tx, CancellationToken::new())
+        .await
+}
+
+#[tokio::test]
+async fn refusal_stop_reason_maps_to_refusal_with_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop("refusal"), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+
+    let Message::Assistant {
+        stop_reason,
+        error_message,
+        ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(*stop_reason, StopReason::Refusal);
+    assert!(
+        error_message.as_deref().unwrap_or("").contains("refusal"),
+        "error_message should explain the refusal, got {error_message:?}"
+    );
+}
+
+#[tokio::test]
+async fn context_window_exceeded_maps_to_overflow_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse_empty_with_stop("model_context_window_exceeded"),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+
+    assert!(
+        message.is_context_overflow(),
+        "in-stream overflow must trigger the documented recovery hook"
+    );
+}
+
+#[tokio::test]
+async fn bearer_auth_sends_authorization_and_no_x_api_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .and(header("authorization", "Bearer test-key"))
+        .and(HeaderAbsent("x-api-key"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop("end_turn"), "text/event-stream"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = stream_config(
+        &server.uri(),
+        Some(AnthropicCompat {
+            adaptive_thinking: true,
+            bearer_auth: true,
+        }),
+    );
+    run_stream(config).await.expect("stream should succeed");
+    // Mock expectation (`expect(1)`) verifies the headers on drop.
+}
+
+#[tokio::test]
+async fn default_auth_sends_x_api_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .and(header("x-api-key", "test-key"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop("end_turn"), "text/event-stream"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+}
+
+#[tokio::test]
+async fn user_authorization_header_suppresses_x_api_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .and(header("authorization", "Bearer custom-token"))
+        .and(HeaderAbsent("x-api-key"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop("end_turn"), "text/event-stream"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut config = stream_config(&server.uri(), None);
+    if let Some(mc) = &mut config.model_config {
+        mc.headers
+            .insert("Authorization".into(), "Bearer custom-token".into());
+    }
+    run_stream(config).await.expect("stream should succeed");
+}

--- a/tests/integration_anthropic.rs
+++ b/tests/integration_anthropic.rs
@@ -17,11 +17,11 @@ fn api_key() -> String {
 fn make_config(provider: AnthropicProvider) -> AgentLoopConfig {
     AgentLoopConfig {
         provider: std::sync::Arc::new(provider),
-        model: "claude-sonnet-4-20250514".into(),
+        model: "claude-sonnet-5".into(),
         api_key: api_key(),
         thinking_level: ThinkingLevel::Off,
         max_tokens: Some(1024),
-        temperature: Some(0.0),
+        temperature: None,
         model_config: None,
         convert_to_llm: None,
         transform_context: None,

--- a/tests/integration_opencode.rs
+++ b/tests/integration_opencode.rs
@@ -1,0 +1,112 @@
+//! Integration tests against the OpenCode Zen gateway (https://opencode.ai/docs/zen).
+//! Run with: OPENCODE_API_KEY=... cargo test --test integration_opencode -- --ignored
+//!
+//! These tests are #[ignore] by default so they don't run in CI without a key.
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use yoagent::agent_loop::{agent_loop, AgentLoopConfig};
+use yoagent::provider::{AnthropicProvider, ModelConfig, OpenAiCompatProvider, StreamProvider};
+use yoagent::types::*;
+
+fn api_key() -> String {
+    std::env::var("OPENCODE_API_KEY").expect("OPENCODE_API_KEY must be set")
+}
+
+fn make_config(
+    provider: std::sync::Arc<dyn StreamProvider>,
+    model_config: ModelConfig,
+) -> AgentLoopConfig {
+    AgentLoopConfig {
+        provider,
+        model: model_config.id.clone(),
+        api_key: api_key(),
+        thinking_level: ThinkingLevel::Off,
+        max_tokens: Some(1024),
+        temperature: None,
+        model_config: Some(model_config),
+        convert_to_llm: None,
+        transform_context: None,
+        get_steering_messages: None,
+        get_follow_up_messages: None,
+        context_config: None,
+        compaction_strategy: None,
+        execution_limits: None,
+        cache_config: CacheConfig::default(),
+        tool_execution: ToolExecutionStrategy::default(),
+        retry_config: yoagent::RetryConfig::default(),
+        before_turn: None,
+        after_turn: None,
+        on_error: None,
+        input_filters: vec![],
+        turn_delay: None,
+    }
+}
+
+fn extract_assistant_text(messages: &[AgentMessage]) -> String {
+    messages
+        .iter()
+        .filter_map(|m| {
+            if let AgentMessage::Llm(Message::Assistant { content, .. }) = m {
+                Some(
+                    content
+                        .iter()
+                        .filter_map(|c| {
+                            if let Content::Text { text } = c {
+                                Some(text.as_str())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(""),
+                )
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+async fn run_simple_prompt(config: AgentLoopConfig) -> String {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+
+    let mut context = AgentContext {
+        system_prompt: "Reply with exactly one word.".into(),
+        messages: Vec::new(),
+        tools: Vec::new(),
+    };
+
+    let prompt = AgentMessage::Llm(Message::user("What color is the sky?"));
+    let new_messages = agent_loop(vec![prompt], &mut context, &config, tx, cancel).await;
+
+    assert!(
+        !new_messages.is_empty(),
+        "Expected at least one new message"
+    );
+    let text = extract_assistant_text(&new_messages);
+    assert!(!text.is_empty(), "Expected non-empty text response");
+    text
+}
+
+/// Chat-completions model through the Zen gateway.
+#[tokio::test]
+#[ignore]
+async fn test_opencode_zen_chat_completions() {
+    let model = ModelConfig::opencode_zen("glm-5.2");
+    let config = make_config(std::sync::Arc::new(OpenAiCompatProvider), model);
+    let text = run_simple_prompt(config).await;
+    println!("Zen chat-completions response: {}", text);
+}
+
+/// Anthropic-protocol model through the Zen gateway (Bearer auth + /messages).
+#[tokio::test]
+#[ignore]
+async fn test_opencode_zen_anthropic_messages() {
+    let model = ModelConfig::opencode_zen("claude-haiku-4-5");
+    let config = make_config(std::sync::Arc::new(AnthropicProvider), model);
+    let text = run_simple_prompt(config).await;
+    println!("Zen /messages response: {}", text);
+}

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -191,3 +191,23 @@ fn test_tool_execution_strategy_roundtrip() {
     roundtrip(&ToolExecutionStrategy::Parallel);
     roundtrip(&ToolExecutionStrategy::Batched { size: 4 });
 }
+
+#[test]
+fn test_refusal_stop_reason_round_trip() {
+    use yoagent::types::*;
+
+    let message = Message::Assistant {
+        content: vec![],
+        stop_reason: StopReason::Refusal,
+        model: "claude-fable-5".into(),
+        provider: "anthropic".into(),
+        usage: Usage::default(),
+        timestamp: 1,
+        error_message: Some("declined".into()),
+    };
+
+    let json = serde_json::to_string(&message).unwrap();
+    let back: Message = serde_json::from_str(&json).unwrap();
+    assert_eq!(message, back);
+    assert_eq!(StopReason::Refusal.to_string(), "refusal");
+}


### PR DESCRIPTION
Closes #48

## What this does

**Modernizes the Anthropic provider** (`src/provider/anthropic.rs`) — previously the only provider that ignored `ModelConfig`:
- Honors `base_url` (`{base}/messages`) and custom headers; Bearer auth for gateways via `AnthropicCompat.bearer_auth` or a user-supplied `authorization` header. Pre-0.9 configs with the un-versioned official host keep working.
- **Adaptive thinking by default** (`thinking: {type: "adaptive"}` + `output_config.effort`). Claude Fable 5 / Opus 4.8 / Sonnet 5 reject budget-based thinking with a 400. `AnthropicCompat::legacy()` keeps `budget_tokens` for pre-4.6 models, clamped to the API's 1024 minimum (fixes a latent 400 on `Minimal`/`Low`).
- Maps `refusal` → new `StopReason::Refusal` (with `error_message` set, and empty refused turns no longer poison the conversation history) and in-stream `model_context_window_exceeded` → the standard overflow-error shape so compaction-retry hooks keep working.
- `max_tokens` falls back to `ModelConfig.max_tokens` before the hardcoded 8192.

**New model presets** with verified context windows, output caps, and real pricing: `claude_fable_5()`, `claude_opus_4_8()`, `claude_sonnet_5()`, `claude_haiku_4_5()`, `gpt_5_5()`.

**OpenCode Zen & Go presets (#48)**: `opencode_zen(id)` / `opencode_go(id)` select the API protocol from the model family (GPT → Responses, Claude/Qwen → Anthropic Messages + Bearer, rest → Chat Completions). New docs page at `docs/providers/opencode.md`; Gemini-via-Zen documented as unsupported (warns at construction). Key-gated integration test in `tests/integration_opencode.rs`.

**Docs refresh**: stale model IDs replaced across ~25 files (`claude-sonnet-4-20250514` → `claude-sonnet-5`, `gpt-4o` → `gpt-5.5`, etc.); thinking and pricing tables updated.

## Breaking changes (batch with reqwest 0.13 → release as 0.9.0)

- New `StopReason::Refusal` variant (breaks exhaustive matches downstream)
- New `ModelConfig.anthropic: Option<AnthropicCompat>` field (breaks struct-literal construction; serde-compatible with old JSON)
- `ModelConfig::anthropic()` base_url now includes `/v1` and defaults changed (max_tokens 8192 → 16000, reasoning true)
- Adaptive thinking is the new default for the Anthropic provider — pre-4.6 models with thinking enabled need `AnthropicCompat::legacy()`

## Testing

- Full CI parity locally: fmt, clippy `-Dwarnings --all-features`, 270+ tests across 13 suites
- New wiremock-based stream tests cover refusal/overflow stop-reason mapping from real SSE bytes and all three auth branches (asserting wire headers, including `x-api-key` absence)
- Reviewed by a 5-agent review pass (code, tests, comments, types, silent failures); all findings addressed in the third commit
- **Not yet run**: live smoke tests (`integration_anthropic.rs` against `claude-sonnet-5` with thinking on; `integration_opencode.rs` against a Zen key) — no API keys in the dev environment. Recommend running both before tagging 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)