### PR TITLE
release: v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Version bump for the 0.9.0 breaking release. See the release notes in the upcoming GitHub Release for the full changelog (reqwest 0.13/rustls, new model generation + OpenCode gateways, queue inspection API, non_exhaustive policy, Google provider hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)