### PR TITLE
feat: tool middleware — approve/deny/modify hooks for every tool call (C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+- **Tool middleware (permissions)** — `ToolMiddleware`, an async
+  approve/deny/modify hook gating every tool call, installed via
+  `Agent::with_tool_middleware` / `SubAgentTool::with_tool_middleware` /
+  `AgentLoopConfig::tool_middleware`. `Deny(reason)` becomes an error tool
+  result the LLM can adapt to (the loop continues); `Modify(args)` rewrites
+  the call. Empty chain = allow all (no behavior change).
+
 ## 0.10.0
 
 The headline change is a **config-first construction API**. You now build an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ The loop: stream assistant response → extract tool calls → execute tools (pa
 - `Sequential` — one at a time, checks steering queue between each
 - `Batched { size }` — concurrent within batch, steering check between batches
 
+**Tool middleware** (`ToolMiddleware` in `types.rs`): async approve/deny/modify hooks gating every tool call, run in a chain at the single choke point (`execute_single_tool`) shared by all three strategies. `Deny(reason)` becomes an error tool result the LLM sees (loop continues); `Modify(args)` rewrites the call. Installed via `Agent::with_tool_middleware` / `SubAgentTool::with_tool_middleware` / `AgentLoopConfig::tool_middleware`. Empty chain = allow all.
+
 ### OpenAPI Integration (`openapi/`, feature-gated)
 
 Behind the `openapi` Cargo feature. `OpenApiToolAdapter` parses an OpenAPI 3.0 spec and creates one `AgentTool` per operation. Factory methods: `from_str`, `from_file`, `from_url`, `from_spec`. `OperationFilter` controls which operations become tools. Added to `Agent` via `with_openapi_file()` / `with_openapi_url()` / `with_openapi_spec()`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Everything is observable via events. Supports 7 API protocols covering 20+ LLM p
 - Full event stream: `AgentStart` → `TurnStart` → `MessageUpdate` (deltas) → `ToolExecution` → `TurnEnd` → `AgentEnd`
 - Parallel tool execution by default — sequential and batched strategies also available
 - Sub-agents via `SubAgentTool` — delegate tasks to child agent loops with their own tools and system prompts
+- Tool middleware — async approve/deny/modify hooks gating every tool call (`with_tool_middleware`), the mechanism for permission prompts and policy engines
 - Real-time event streaming — `prompt()` spawns the loop concurrently and returns events immediately; `prompt_with_sender()` accepts a caller-provided channel for custom consumption
 - Streaming tool output — tools emit real-time progress via `on_update` callback
 - Multimodal support — `Content::Image` flows through tool results across all providers

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -452,3 +452,57 @@ let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Claude
 - **Batched**: When you want parallelism but also want steering checkpoints. For example, `Batched { size: 3 }` runs 3 tools concurrently, checks for user interrupts, then runs the next 3.
 
 Steering messages are always checked between execution units (between each tool in Sequential, after all tools in Parallel, between batches in Batched). If a user interrupts, remaining tools are skipped.
+
+## Permissions: Tool Middleware
+
+Every tool call can be gated by an async **middleware chain** — the mechanism
+behind permission prompts, policy engines, and argument rewriting. yoagent
+ships the hook, not a policy: with no middleware installed, every call runs.
+
+```rust
+use yoagent::{ToolDecision, ToolMiddleware};
+
+struct ReadOnlyPolicy;
+
+#[async_trait::async_trait]
+impl ToolMiddleware for ReadOnlyPolicy {
+    async fn before_tool(
+        &self,
+        _tool_call_id: &str,
+        tool_name: &str,
+        _args: &serde_json::Value,
+    ) -> ToolDecision {
+        match tool_name {
+            "write_file" | "edit_file" | "bash" => {
+                ToolDecision::Deny("read-only session".into())
+            }
+            _ => ToolDecision::Allow,
+        }
+    }
+}
+
+let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
+    .with_tools(default_tools())
+    .with_tool_middleware(ReadOnlyPolicy);
+```
+
+Semantics:
+
+- **`Allow`** — the call proceeds (with the current arguments).
+- **`Modify(args)`** — the call proceeds with replacement arguments (e.g.
+  rewrite a path into a sandbox). Later middleware in the chain see the
+  rewritten arguments; the `ToolExecutionStart` event carries what actually
+  runs.
+- **`Deny(reason)`** — the call never executes. The reason is returned to the
+  LLM as an **error tool result** (`"Tool call denied: ..."`), so the model can
+  adapt — pick another tool, ask the user — and the loop continues. A denial
+  never aborts the run.
+
+The hook is `async`, so an interactive app can prompt a human before deciding.
+Note that under the default `Parallel` execution strategy, middleware for
+parallel tool calls run concurrently — if you need one-at-a-time approval UX,
+serialize inside your middleware (e.g. a `tokio::sync::Mutex`) or switch to
+`ToolExecutionStrategy::Sequential`.
+
+Sub-agents gate their own tool calls the same way via
+`SubAgentTool::with_tool_middleware`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -63,6 +63,9 @@ pub struct Agent {
     // Input filters
     input_filters: Vec<Arc<dyn InputFilter>>,
 
+    // Tool middleware (permissions/policy hooks)
+    tool_middleware: Vec<Arc<dyn ToolMiddleware>>,
+
     // Custom compaction strategy
     compaction_strategy: Option<Arc<dyn CompactionStrategy>>,
 
@@ -240,6 +243,7 @@ impl Agent {
             after_turn: None,
             on_error: None,
             input_filters: Vec::new(),
+            tool_middleware: Vec::new(),
             compaction_strategy: None,
             cancel: None,
             is_streaming: false,
@@ -373,6 +377,16 @@ impl Agent {
     /// Add an input filter. Filters run in order on user messages before the LLM call.
     pub fn with_input_filter(mut self, filter: impl InputFilter + 'static) -> Self {
         self.input_filters.push(Arc::new(filter));
+        self
+    }
+
+    /// Add a tool middleware — an async approve/deny/modify hook that gates
+    /// every tool call (see [`ToolMiddleware`]). Middleware run in
+    /// installation order; each may rewrite the arguments seen by later ones,
+    /// and the first `Deny` turns the call into an error tool result carrying
+    /// the reason (the LLM sees it and adapts — the loop continues).
+    pub fn with_tool_middleware(mut self, middleware: impl ToolMiddleware + 'static) -> Self {
+        self.tool_middleware.push(Arc::new(middleware));
         self
     }
 
@@ -996,6 +1010,7 @@ impl Agent {
             after_turn: self.after_turn.clone(),
             on_error: self.on_error.clone(),
             input_filters: self.input_filters.clone(),
+            tool_middleware: self.tool_middleware.clone(),
             turn_delay: None,
         }
     }

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -73,6 +73,10 @@ pub struct AgentLoopConfig {
     /// Tool execution strategy (sequential, parallel, or batched).
     pub tool_execution: ToolExecutionStrategy,
 
+    /// Tool middleware chain — approve/deny/modify every tool call before it
+    /// executes (see [`ToolMiddleware`]). Empty = allow all.
+    pub tool_middleware: Vec<Arc<dyn ToolMiddleware>>,
+
     /// Retry configuration for transient provider errors.
     pub retry_config: crate::retry::RetryConfig,
 
@@ -462,6 +466,7 @@ async fn run_loop(
                     cancel,
                     config.get_steering_messages.as_ref(),
                     &config.tool_execution,
+                    &config.tool_middleware,
                 )
                 .await;
 
@@ -736,20 +741,21 @@ async fn execute_tool_calls(
     cancel: &tokio_util::sync::CancellationToken,
     get_steering: Option<&GetMessagesFn>,
     strategy: &ToolExecutionStrategy,
+    middleware: &[Arc<dyn ToolMiddleware>],
 ) -> ToolExecutionResult {
     match strategy {
         ToolExecutionStrategy::Sequential => {
-            execute_sequential(tools, tool_calls, tx, cancel, get_steering).await
+            execute_sequential(tools, tool_calls, tx, cancel, get_steering, middleware).await
         }
         ToolExecutionStrategy::Parallel => {
-            execute_batch(tools, tool_calls, tx, cancel, get_steering).await
+            execute_batch(tools, tool_calls, tx, cancel, get_steering, middleware).await
         }
         ToolExecutionStrategy::Batched { size } => {
             let mut results: Vec<Message> = Vec::new();
             let mut steering_messages: Option<Vec<AgentMessage>> = None;
 
             for (batch_idx, batch) in tool_calls.chunks(*size).enumerate() {
-                let batch_result = execute_batch(tools, batch, tx, cancel, None).await;
+                let batch_result = execute_batch(tools, batch, tx, cancel, None, middleware).await;
                 results.extend(batch_result.tool_results);
 
                 // Check steering between batches
@@ -784,12 +790,14 @@ async fn execute_sequential(
     tx: &mpsc::UnboundedSender<AgentEvent>,
     cancel: &tokio_util::sync::CancellationToken,
     get_steering: Option<&GetMessagesFn>,
+    middleware: &[Arc<dyn ToolMiddleware>],
 ) -> ToolExecutionResult {
     let mut results: Vec<Message> = Vec::new();
     let mut steering_messages: Option<Vec<AgentMessage>> = None;
 
     for (index, (id, name, args)) in tool_calls.iter().enumerate() {
-        let (result_msg, _is_error) = execute_single_tool(tools, id, name, args, tx, cancel).await;
+        let (result_msg, _is_error) =
+            execute_single_tool(tools, id, name, args, tx, cancel, middleware).await;
         results.push(result_msg);
 
         // Check for steering — skip remaining tools if user interrupted
@@ -818,12 +826,13 @@ async fn execute_batch(
     tx: &mpsc::UnboundedSender<AgentEvent>,
     cancel: &tokio_util::sync::CancellationToken,
     get_steering: Option<&GetMessagesFn>,
+    middleware: &[Arc<dyn ToolMiddleware>],
 ) -> ToolExecutionResult {
     use futures::future::join_all;
 
     let futures: Vec<_> = tool_calls
         .iter()
-        .map(|(id, name, args)| execute_single_tool(tools, id, name, args, tx, cancel))
+        .map(|(id, name, args)| execute_single_tool(tools, id, name, args, tx, cancel, middleware))
         .collect();
 
     let batch_results = join_all(futures).await;
@@ -856,9 +865,27 @@ async fn execute_single_tool(
     args: &serde_json::Value,
     tx: &mpsc::UnboundedSender<AgentEvent>,
     cancel: &tokio_util::sync::CancellationToken,
+    middleware: &[Arc<dyn ToolMiddleware>],
 ) -> (Message, bool) {
+    // Middleware chain runs first: each hook may rewrite the args seen by
+    // later hooks; the first Deny short-circuits into an error tool result
+    // (the LLM sees the reason and can adapt — the loop continues).
+    let mut effective_args = args.clone();
+    for mw in middleware {
+        match mw.before_tool(id, name, &effective_args).await {
+            ToolDecision::Allow => {}
+            ToolDecision::Modify(new_args) => effective_args = new_args,
+            ToolDecision::Deny(reason) => {
+                return denied_tool_call(id, name, &effective_args, &reason, tx);
+            }
+        }
+    }
+    let args = &effective_args;
+
     let tool = tools.iter().find(|t| t.name() == name);
 
+    // The Start event carries the effective (post-middleware) args — what
+    // actually runs.
     tx.send(AgentEvent::ToolExecutionStart {
         tool_call_id: id.to_string(),
         tool_name: name.to_string(),
@@ -952,6 +979,57 @@ async fn execute_single_tool(
     .ok();
 
     (tool_result_msg, is_error)
+}
+
+/// Emit events and build the error tool result for a middleware-denied call.
+/// Start/End are both emitted so UI event pairing stays intact.
+fn denied_tool_call(
+    id: &str,
+    name: &str,
+    args: &serde_json::Value,
+    reason: &str,
+    tx: &mpsc::UnboundedSender<AgentEvent>,
+) -> (Message, bool) {
+    tx.send(AgentEvent::ToolExecutionStart {
+        tool_call_id: id.to_string(),
+        tool_name: name.to_string(),
+        args: args.clone(),
+    })
+    .ok();
+
+    let result = ToolResult {
+        content: vec![Content::Text {
+            text: format!("Tool call denied: {}", reason),
+        }],
+        details: serde_json::Value::Null,
+    };
+
+    tx.send(AgentEvent::ToolExecutionEnd {
+        tool_call_id: id.to_string(),
+        tool_name: name.to_string(),
+        result: result.clone(),
+        is_error: true,
+    })
+    .ok();
+
+    let msg = Message::ToolResult {
+        tool_call_id: id.to_string(),
+        tool_name: name.to_string(),
+        content: result.content,
+        is_error: true,
+        timestamp: now_ms(),
+    };
+
+    tx.send(AgentEvent::MessageStart {
+        message: msg.clone().into(),
+    })
+    .ok();
+    tx.send(AgentEvent::MessageEnd {
+        message: msg.clone().into(),
+    })
+    .ok();
+
+    (msg, true)
 }
 
 fn skip_tool_call(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@
 //! - **Steering** — inject guidance into a running agent ([`Agent::steer`]);
 //!   picked up between tool executions (per batch under the default parallel
 //!   strategy). Queue follow-ups, inspect/edit the queues.
+//! - **Permissions** ([`ToolMiddleware`]) — async approve/deny/modify hooks
+//!   gating every tool call; the mechanism behind approval prompts and
+//!   policy engines (yoagent ships no policy — you install it).
 //! - **Sub-agents** ([`SubAgentTool`]) — delegation with per-sub-agent models
 //!   and [`SharedState`] for passing artifacts by reference.
 //! - **Context management** ([`context`]) — token tracking and tiered

--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -63,6 +63,7 @@ pub struct SubAgentTool {
     shared_state: Option<SharedState>,
     turn_delay: Option<std::time::Duration>,
     model_config: Option<ModelConfig>,
+    tool_middleware: Vec<Arc<dyn ToolMiddleware>>,
 }
 
 impl SubAgentTool {
@@ -100,6 +101,7 @@ impl SubAgentTool {
             shared_state: None,
             turn_delay: None,
             model_config: None,
+            tool_middleware: Vec::new(),
         }
     }
 
@@ -198,6 +200,13 @@ impl SubAgentTool {
 
     pub fn with_tools(mut self, tools: Vec<Arc<dyn AgentTool>>) -> Self {
         self.tools = tools;
+        self
+    }
+
+    /// Add a tool middleware for the sub-agent's own tool calls. Mirrors
+    /// [`Agent::with_tool_middleware`](crate::Agent::with_tool_middleware).
+    pub fn with_tool_middleware(mut self, middleware: impl ToolMiddleware + 'static) -> Self {
+        self.tool_middleware.push(Arc::new(middleware));
         self
     }
 
@@ -409,6 +418,7 @@ impl AgentTool for SubAgentTool {
             after_turn: None,
             on_error: None,
             input_filters: vec![],
+            tool_middleware: self.tool_middleware.clone(),
             turn_delay: self.turn_delay,
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -607,6 +607,47 @@ pub trait InputFilter: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Tool middleware (permissions)
+// ---------------------------------------------------------------------------
+
+/// Decision returned by a [`ToolMiddleware`] before a tool executes.
+#[derive(Debug, Clone)]
+pub enum ToolDecision {
+    /// Execute the tool with the current arguments.
+    Allow,
+    /// Execute the tool with replacement arguments (e.g. a sandboxed path).
+    Modify(serde_json::Value),
+    /// Block the call. The reason is returned to the LLM as an error tool
+    /// result so it can adapt (pick another tool, ask the user, ...); the
+    /// loop itself continues.
+    Deny(String),
+}
+
+/// Async hook that gates every tool call — the mechanism behind permission
+/// prompts, policy engines, and argument rewriting.
+///
+/// yoagent ships the mechanism, not a policy: install middleware via
+/// [`Agent::with_tool_middleware`](crate::Agent::with_tool_middleware) (or
+/// [`AgentLoopConfig::tool_middleware`](crate::agent_loop::AgentLoopConfig))
+/// and decide per call. Middleware run in a chain: each may rewrite the
+/// arguments seen by later ones; the first `Deny` wins. With no middleware
+/// installed, every call is allowed — behavior is unchanged.
+///
+/// The hook is `async` so an interactive app can prompt a human. Under the
+/// default [`ToolExecutionStrategy::Parallel`], middleware for parallel tool
+/// calls runs concurrently — serialize approval prompts inside your
+/// implementation (or use `Sequential`) if you need one-at-a-time UX.
+#[async_trait::async_trait]
+pub trait ToolMiddleware: Send + Sync {
+    async fn before_tool(
+        &self,
+        tool_call_id: &str,
+        tool_name: &str,
+        args: &serde_json::Value,
+    ) -> ToolDecision;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -31,6 +31,7 @@ fn make_config(provider: MockProvider) -> AgentLoopConfig {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }
@@ -774,6 +775,7 @@ async fn test_execution_limit_counts_cached_tokens() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -875,6 +877,7 @@ async fn test_retry_on_rate_limit_succeeds() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -943,6 +946,7 @@ async fn test_retry_exhausted_returns_error() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -1013,6 +1017,7 @@ async fn test_no_retry_on_auth_error() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -1071,6 +1076,7 @@ async fn test_retry_none_disables_retries() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -1307,6 +1313,7 @@ async fn test_on_error_fires_on_provider_error() {
             error_msgs_clone.lock().unwrap().push(err.to_string());
         })),
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -2011,6 +2018,7 @@ async fn test_custom_compaction_strategy_is_called() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -2087,6 +2095,7 @@ async fn test_none_compaction_strategy_uses_default() {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     };
 
@@ -2267,6 +2276,7 @@ fn calibration_config(
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -696,3 +696,203 @@ async fn test_set_model_preserves_explicit_provider_and_key() {
         "set_model must keep the explicit provider and key"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Tool middleware: approve / deny / modify hooks gating tool execution
+// ---------------------------------------------------------------------------
+
+/// Tool that records whether it ran and with what args.
+struct RecordingTool {
+    ran: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+}
+
+#[async_trait::async_trait]
+impl AgentTool for RecordingTool {
+    fn name(&self) -> &str {
+        "recording_tool"
+    }
+    fn label(&self) -> &str {
+        "Recording Tool"
+    }
+    fn description(&self) -> &str {
+        "Records its invocation"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        *self.ran.lock().unwrap() = Some(params);
+        Ok(ToolResult {
+            content: vec![Content::Text { text: "ok".into() }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+/// Middleware driven by a closure, for tests.
+struct FnMiddleware<F>(F);
+
+#[async_trait::async_trait]
+impl<F> ToolMiddleware for FnMiddleware<F>
+where
+    F: Fn(&str, &serde_json::Value) -> ToolDecision + Send + Sync,
+{
+    async fn before_tool(
+        &self,
+        _tool_call_id: &str,
+        tool_name: &str,
+        args: &serde_json::Value,
+    ) -> ToolDecision {
+        (self.0)(tool_name, args)
+    }
+}
+
+/// Provider that calls recording_tool once, then finishes with text.
+fn tool_call_provider() -> MockProvider {
+    MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "recording_tool".into(),
+            arguments: serde_json::json!({"path": "/etc/passwd"}),
+        }]),
+        MockResponse::Text("done".into()),
+    ])
+}
+
+async fn run_middleware_agent(mut agent: Agent) -> (Agent, Vec<AgentEvent>) {
+    let mut rx = agent.prompt("go").await;
+    let mut events = Vec::new();
+    while let Some(e) = rx.recv().await {
+        events.push(e);
+    }
+    agent.finish().await;
+    (agent, events)
+}
+
+#[tokio::test]
+async fn test_tool_middleware_deny_blocks_tool_and_loop_continues() {
+    let ran = Arc::new(std::sync::Mutex::new(None));
+    let agent = Agent::from_provider(tool_call_provider(), yoagent::provider::ModelConfig::mock())
+        .with_tools(vec![Box::new(RecordingTool { ran: ran.clone() })])
+        .with_tool_middleware(FnMiddleware(|name: &str, _args: &serde_json::Value| {
+            if name == "recording_tool" {
+                ToolDecision::Deny("blocked by policy".into())
+            } else {
+                ToolDecision::Allow
+            }
+        }));
+
+    let (agent, events) = run_middleware_agent(agent).await;
+
+    // Tool must never have executed.
+    assert!(ran.lock().unwrap().is_none(), "denied tool must not run");
+
+    // The denial reaches the LLM as an error tool result with the reason.
+    let denial = agent
+        .messages()
+        .iter()
+        .find_map(|m| match m {
+            AgentMessage::Llm(Message::ToolResult {
+                content, is_error, ..
+            }) => Some((content.clone(), *is_error)),
+            _ => None,
+        })
+        .expect("a tool result must be recorded");
+    assert!(denial.1, "denial must be an error result");
+    match &denial.0[0] {
+        Content::Text { text } => {
+            assert!(text.contains("Tool call denied"), "got: {text}");
+            assert!(text.contains("blocked by policy"), "got: {text}");
+        }
+        other => panic!("expected text content, got {other:?}"),
+    }
+
+    // The loop continued to the final assistant text (not aborted).
+    assert!(matches!(
+        agent.messages().last(),
+        Some(AgentMessage::Llm(Message::Assistant { .. }))
+    ));
+
+    // Event pairing stays intact: Start and End both emitted, End is error.
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::ToolExecutionStart { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::ToolExecutionEnd { is_error: true, .. })));
+}
+
+#[tokio::test]
+async fn test_tool_middleware_modify_rewrites_args() {
+    let ran = Arc::new(std::sync::Mutex::new(None));
+    let agent = Agent::from_provider(tool_call_provider(), yoagent::provider::ModelConfig::mock())
+        .with_tools(vec![Box::new(RecordingTool { ran: ran.clone() })])
+        .with_tool_middleware(FnMiddleware(|_: &str, _: &serde_json::Value| {
+            ToolDecision::Modify(serde_json::json!({"path": "/tmp/sandboxed"}))
+        }));
+
+    let (_, events) = run_middleware_agent(agent).await;
+
+    // Tool ran with the REWRITTEN args, not the LLM's originals.
+    let seen = ran.lock().unwrap().clone().expect("tool must run");
+    assert_eq!(seen["path"], "/tmp/sandboxed");
+
+    // The Start event carries the effective (post-middleware) args.
+    let start_args = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::ToolExecutionStart { args, .. } => Some(args.clone()),
+            _ => None,
+        })
+        .expect("start event");
+    assert_eq!(start_args["path"], "/tmp/sandboxed");
+}
+
+#[tokio::test]
+async fn test_tool_middleware_chain_first_deny_wins() {
+    // First middleware rewrites; second sees the rewritten args and denies.
+    let ran = Arc::new(std::sync::Mutex::new(None));
+    let saw = Arc::new(std::sync::Mutex::new(None));
+    let saw2 = saw.clone();
+    let agent = Agent::from_provider(tool_call_provider(), yoagent::provider::ModelConfig::mock())
+        .with_tools(vec![Box::new(RecordingTool { ran: ran.clone() })])
+        .with_tool_middleware(FnMiddleware(|_: &str, _: &serde_json::Value| {
+            ToolDecision::Modify(serde_json::json!({"path": "/rewritten"}))
+        }))
+        .with_tool_middleware(FnMiddleware(move |_: &str, args: &serde_json::Value| {
+            *saw2.lock().unwrap() = Some(args.clone());
+            ToolDecision::Deny("second says no".into())
+        }));
+
+    let (agent, _) = run_middleware_agent(agent).await;
+
+    assert!(ran.lock().unwrap().is_none(), "denied tool must not run");
+    // Second middleware observed the first one's rewrite (chain order).
+    let observed = saw.lock().unwrap().clone().expect("second middleware ran");
+    assert_eq!(observed["path"], "/rewritten");
+    // Reason from the denying middleware reaches the LLM.
+    let has_reason = agent.messages().iter().any(|m| {
+        matches!(m, AgentMessage::Llm(Message::ToolResult { content, .. })
+            if matches!(&content[0], Content::Text { text } if text.contains("second says no")))
+    });
+    assert!(has_reason);
+}
+
+#[tokio::test]
+async fn test_tool_middleware_deny_under_sequential_strategy() {
+    // The choke point is shared, but pin the Sequential path explicitly too.
+    let ran = Arc::new(std::sync::Mutex::new(None));
+    let agent = Agent::from_provider(tool_call_provider(), yoagent::provider::ModelConfig::mock())
+        .with_tools(vec![Box::new(RecordingTool { ran: ran.clone() })])
+        .with_tool_execution(ToolExecutionStrategy::Sequential)
+        .with_tool_middleware(FnMiddleware(|_: &str, _: &serde_json::Value| {
+            ToolDecision::Deny("no".into())
+        }));
+
+    let _ = run_middleware_agent(agent).await;
+    assert!(ran.lock().unwrap().is_none());
+}

--- a/tests/integration_anthropic.rs
+++ b/tests/integration_anthropic.rs
@@ -37,6 +37,7 @@ fn make_config(provider: AnthropicProvider) -> AgentLoopConfig {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }

--- a/tests/integration_gemini.rs
+++ b/tests/integration_gemini.rs
@@ -39,6 +39,7 @@ fn make_config(model: &str) -> AgentLoopConfig {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }

--- a/tests/integration_opencode.rs
+++ b/tests/integration_opencode.rs
@@ -39,6 +39,7 @@ fn make_config(
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }

--- a/tests/sub_agent_test.rs
+++ b/tests/sub_agent_test.rs
@@ -33,6 +33,7 @@ fn make_config(provider: MockProvider) -> AgentLoopConfig {
         after_turn: None,
         on_error: None,
         input_filters: vec![],
+        tool_middleware: vec![],
         turn_delay: None,
     }
 }
@@ -868,4 +869,97 @@ fn test_sub_agent_from_config_with_errors_on_empty_registry() {
             yoagent::provider::ApiProtocol::AnthropicMessages
         )
     );
+}
+
+// ---------------------------------------------------------------------------
+// Tool middleware wiring: sub-agent's own tool calls are gated
+// ---------------------------------------------------------------------------
+
+struct DenyAll;
+
+#[async_trait::async_trait]
+impl yoagent::ToolMiddleware for DenyAll {
+    async fn before_tool(
+        &self,
+        _id: &str,
+        _name: &str,
+        _args: &serde_json::Value,
+    ) -> yoagent::ToolDecision {
+        yoagent::ToolDecision::Deny("sub-agent policy".into())
+    }
+}
+
+/// A tool that must never run under DenyAll.
+struct MustNotRun {
+    ran: Arc<std::sync::Mutex<bool>>,
+}
+
+#[async_trait::async_trait]
+impl AgentTool for MustNotRun {
+    fn name(&self) -> &str {
+        "must_not_run"
+    }
+    fn label(&self) -> &str {
+        "Must Not Run"
+    }
+    fn description(&self) -> &str {
+        "test"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        *self.ran.lock().unwrap() = true;
+        Ok(ToolResult {
+            content: vec![Content::Text { text: "ran".into() }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_sub_agent_tool_middleware_denies() {
+    let ran = Arc::new(std::sync::Mutex::new(false));
+    let provider = Arc::new(MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "must_not_run".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("finished".into()),
+    ]));
+
+    let tool =
+        SubAgentTool::from_provider("gated", provider, yoagent::provider::ModelConfig::mock())
+            .with_tools(vec![Arc::new(MustNotRun { ran: ran.clone() })])
+            .with_tool_middleware(DenyAll);
+
+    let result = tool
+        .execute(
+            serde_json::json!({"task": "go"}),
+            ToolContext {
+                tool_call_id: "tc-mw".into(),
+                tool_name: "gated".into(),
+                cancel: CancellationToken::new(),
+                on_update: None,
+                on_progress: None,
+            },
+        )
+        .await
+        .expect("sub-agent completes despite denial");
+
+    assert!(
+        !*ran.lock().unwrap(),
+        "denied tool must not run in sub-agent"
+    );
+    // Sub-agent still produced its final text.
+    let text = match &result.content[0] {
+        Content::Text { text } => text,
+        other => panic!("expected text, got {other:?}"),
+    };
+    assert!(text.contains("finished"));
 }


### PR DESCRIPTION
## What

Phase **C3** of the roadmap: loop-level permissions mechanism. Today only bash has a `confirm_fn` — an app embedding yoagent cannot gate file writes or MCP tools without forking the loop. This adds the missing hook. **yoagent ships the mechanism, not a policy**: with no middleware installed, behavior is byte-for-byte unchanged.

```rust
struct ReadOnlyPolicy;

#[async_trait::async_trait]
impl ToolMiddleware for ReadOnlyPolicy {
    async fn before_tool(&self, _id: &str, name: &str, _args: &serde_json::Value) -> ToolDecision {
        match name {
            "write_file" | "edit_file" | "bash" => ToolDecision::Deny("read-only session".into()),
            _ => ToolDecision::Allow,
        }
    }
}

let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
    .with_tools(default_tools())
    .with_tool_middleware(ReadOnlyPolicy);
```

## Design

- **`ToolDecision::{Allow, Modify(args), Deny(reason)}`** — `Deny` becomes an *error tool result* the LLM sees and adapts to (loop continues; a denial never aborts the run — matches the "tools return output even on failure" convention). `Modify` rewrites args; later middleware see the rewrite; `ToolExecutionStart` carries what actually runs.
- **Single choke point** — the chain runs at the top of `execute_single_tool`, shared by all three `ToolExecutionStrategy` variants. Start/End event pairing stays intact on denial.
- **Async hook** — an interactive app can prompt a human. Documented caveat: under default `Parallel`, hooks for parallel calls run concurrently — serialize in your middleware or use `Sequential` for one-at-a-time approval UX.
- Mirrors the existing `InputFilter` pattern; installed via `Agent::with_tool_middleware` / `SubAgentTool::with_tool_middleware` / `AgentLoopConfig::tool_middleware`.

## Breaking?

Additive for builder users. `AgentLoopConfig` gains a field, so literal constructors add one line (`tool_middleware: vec![]`) — routine 0.x minor, same as `turn_delay` before it.

## Tests (5 new, 334 total green)

deny blocks + reason reaches LLM + loop continues + event pairing · modify rewrites args (tool and Start event) · chain order (first-Deny-wins, second sees first's rewrite) · Sequential-strategy deny · sub-agent wiring.

## Verification

`cargo clippy --all-targets --all-features` (`-Dwarnings`) clean · `cargo test --all-features` 334 passed / 0 failed · `RUSTDOCFLAGS=-Dwarnings cargo doc` clean.

Docs: new "Permissions: Tool Middleware" section in `docs/concepts/tools.md`, plus lib.rs / README / CLAUDE.md / CHANGELOG (Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)