### PR TITLE
feat: session trees — branching history with fork + checkpoints (C2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Session trees** — `Session`: branching conversation history with
+  `append`/`seek`/`checkpoint`, fork-preserving edits, `path_messages()` for
+  branch resume, and JSONL persistence. The pi-style id/parentId tree; maps
+  to GASP's `transcripts/` tier.
+
 - **Structured outputs** — `Agent::prompt_structured::<T>(text, schema)`
   returns a typed, schema-validated reply. Enforcement is native per
   provider: Anthropic (forced tool call, unwrapped by the loop),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ Behind the `openapi` Cargo feature. `OpenApiToolAdapter` parses an OpenAPI 3.0 s
 
 `McpClient` communicates via `McpTransport` trait (stdio or HTTP). `McpToolAdapter` wraps MCP tools to implement `AgentTool`, making them transparent to the agent loop. Added via `Agent::with_mcp_server_stdio()` / `with_mcp_server_http()`.
 
+### Session Trees (`session.rs`)
+
+`Session` stores history as an id/parent_id tree: `append` advances the head, `seek`/`seek_checkpoint` move it, appending after a seek forks a new branch (never overwrites). `path_messages()` feeds a branch into `Agent::with_messages`; `append_new(agent.messages())` is the post-run sync. JSONL persistence (`to_jsonl`/`from_jsonl`, head = last line). Freestanding — no loop changes; maps to GASP's `transcripts/` tier.
+
 ### Shared State (`shared_state.rs`)
 
 `SharedState` is a pluggable key-value store (`Arc<dyn SharedStateBackend>`) for sub-agent communication. It lets a parent store large artifacts once and have multiple sub-agents read/write by reference — no re-pasting into prompts.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Everything is observable via events. Supports 7 API protocols covering 20+ LLM p
 - Automatic retry with exponential backoff and jitter for rate limits and network errors
 - Custom message types via `AgentMessage::Extension` — app-specific messages that don't pollute LLM context
 - State persistence — `save_messages()` / `restore_messages()` for pause/resume workflows
+- Session trees — branching history with fork, checkpoints, and JSONL persistence (`Session`); edit an earlier turn and re-run without losing the original branch
 - Lifecycle callbacks — `before_turn`, `after_turn`, `on_error` for observability and control
 - Full serde support — all core types implement `Serialize`/`Deserialize`/`PartialEq`
 - [AgentSkills](https://agentskills.io)-compatible skills — load skill directories, inject into system prompt, agent activates on demand

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Skills](concepts/skills.md)
 - [Sub-Agents](concepts/sub-agents.md)
 - [State Persistence](concepts/persistence.md)
+- [Session Trees](concepts/session-trees.md)
 - [Lifecycle Callbacks](concepts/callbacks.md)
 
 # Guides

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -85,3 +85,5 @@ Extension messages use a nested structure:
 | `ToolExecutionStrategy` | Yes | Yes | Yes |
 | `ContextConfig` | Yes | Yes | No |
 | `ExecutionLimits` | Yes | Yes | No |
+
+For **branching** history — fork, checkpoints, edit-and-rerun — see [Session Trees](session-trees.md).

--- a/docs/concepts/session-trees.md
+++ b/docs/concepts/session-trees.md
@@ -1,0 +1,69 @@
+# Session Trees
+
+A `Session` stores conversation history as a **tree**, not a flat list. Every
+entry has an `id` and `parent_id`; the *head* points at the current branch
+tip. Appending after a `seek` creates a **new branch** — history is never
+overwritten. This is the primitive behind:
+
+- **Fork** — try a different direction from any point
+- **Checkpoints** — label a state, come back to it later
+- **Edit & re-run** — change an earlier turn on a new branch; the original
+  branch stays intact
+
+```rust
+use yoagent::{Agent, Session, provider::ModelConfig};
+
+let mut session = Session::new();
+
+// Run a turn, record it.
+let mut agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"));
+let mut rx = agent.prompt("draft a plan").await;
+while rx.recv().await.is_some() {}
+agent.finish().await;
+session.append_new(agent.messages());
+session.checkpoint("first-draft")?;
+
+// ... more turns ...
+
+// Rewind to the checkpoint and branch.
+session.seek_checkpoint("first-draft")?;
+let mut agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
+    .with_messages(session.path_messages());   // only this branch's history
+let mut rx = agent.prompt("actually, make it a library instead").await;
+while rx.recv().await.is_some() {}
+agent.finish().await;
+session.append_new(agent.messages());          // new branch recorded
+
+// Both branches exist:
+assert_eq!(session.branch_tips().len(), 2);
+```
+
+## Persistence: JSONL
+
+```rust
+std::fs::write("session.jsonl", session.to_jsonl())?;
+let restored = Session::from_jsonl(&std::fs::read_to_string("session.jsonl")?)?;
+```
+
+One entry per line, append-friendly, diff-friendly. On load the head is the
+last line's entry. The flat `save_messages()` / `restore_messages()` API
+remains for single-branch persistence.
+
+## API sketch
+
+| Method | Purpose |
+|---|---|
+| `append(msg) -> id` | Add as child of head, advance head |
+| `append_new(&agent_messages)` | Record everything beyond the current path — the post-run sync |
+| `seek(id)` / `seek_checkpoint(label)` | Move the head (fork point) |
+| `checkpoint(label)` | Label the head |
+| `path_messages()` | Root→head messages — feed to `Agent::with_messages` |
+| `branch_tips()` / `children(id)` / `entries()` | Inspect the tree |
+| `to_jsonl()` / `from_jsonl()` | Persist / restore |
+
+## GASP
+
+This tree is the shape of the [GASP](https://github.com/yologdev/gasp)
+`transcripts/` tier — the raw-conversation cold tier. The semantic event log
+(goals/runs/evals living in a git repo) is a separate adapter layered on the
+`AgentEvent` stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@
 //!   policy engines (yoagent ships no policy — you install it).
 //! - **Sub-agents** ([`SubAgentTool`]) — delegation with per-sub-agent models
 //!   and [`SharedState`] for passing artifacts by reference.
+//! - **Session trees** ([`Session`]) — branching conversation history with
+//!   fork, checkpoints, and JSONL persistence; edit an earlier turn and
+//!   re-run without losing the original branch.
 //! - **Context management** ([`context`]) — token tracking and tiered
 //!   compaction so long sessions keep running.
 //! - **Skills** ([`skills`]) — load `SKILL.md` files per the
@@ -62,6 +65,7 @@ pub mod context;
 pub mod mcp;
 pub mod provider;
 pub mod retry;
+pub mod session;
 pub mod shared_state;
 pub mod skills;
 pub mod sub_agent;
@@ -75,6 +79,7 @@ pub use agent::{Agent, AgentBuildError, StructuredPromptError};
 pub use agent_loop::{agent_loop, agent_loop_continue};
 pub use context::{CompactionStrategy, DefaultCompaction};
 pub use retry::RetryConfig;
+pub use session::{Session, SessionEntry, SessionError};
 pub use shared_state::SharedState;
 pub use skills::SkillSet;
 pub use sub_agent::SubAgentTool;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,265 @@
+//! Conversation session trees — branching history with checkpoints.
+//!
+//! A [`Session`] stores messages as a **tree**, not a list: every entry has an
+//! `id` and a `parent_id`, the *head* points at the current branch tip, and
+//! appending after a [`seek`](Session::seek) creates a new branch instead of
+//! overwriting history. This is the primitive behind "edit that earlier
+//! message and re-run", checkpoints, and conversation forking.
+//!
+//! Persistence is JSONL — one entry per line, append-friendly, diff-friendly.
+//! (In GASP terms this is the shape of the `transcripts/` tier; the semantic
+//! event log is a separate adapter.)
+//!
+//! # Typical flow
+//!
+//! ```no_run
+//! use yoagent::{Agent, Session, provider::ModelConfig};
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! let mut session = Session::new();
+//!
+//! // Run the agent, then record the new messages into the session.
+//! let mut agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"));
+//! let mut rx = agent.prompt("hello").await;
+//! while rx.recv().await.is_some() {}
+//! agent.finish().await;
+//! session.append_new(agent.messages());
+//!
+//! // Checkpoint, keep working...
+//! session.checkpoint("after-hello").unwrap();
+//!
+//! // Later: fork from the checkpoint and try a different direction.
+//! session.seek_checkpoint("after-hello").unwrap();
+//! let mut agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
+//!     .with_messages(session.path_messages());
+//! // ...prompt again; append_new() records the new branch
+//! # }
+//! ```
+
+use crate::types::{now_ms, AgentMessage};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// One node in a session tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionEntry {
+    /// Unique id within the session (`"e1"`, `"e2"`, ...).
+    pub id: String,
+    /// Parent entry id; `None` for a root.
+    pub parent_id: Option<String>,
+    /// The message this entry carries.
+    pub message: AgentMessage,
+    /// Creation time (ms since epoch).
+    pub timestamp: u64,
+    /// Checkpoint label, if this entry was labeled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Error from session operations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionError {
+    /// No entry with the given id exists in this session.
+    #[error("unknown session entry: {0}")]
+    UnknownEntry(String),
+    /// No checkpoint with the given label exists in this session.
+    #[error("unknown checkpoint label: {0}")]
+    UnknownCheckpoint(String),
+    /// A JSONL line failed to parse.
+    #[error("failed to parse session line {line}: {error}")]
+    Parse { line: usize, error: String },
+    /// The session is empty where an entry was required.
+    #[error("session is empty")]
+    Empty,
+}
+
+/// A conversation history tree: append advances the head; seek + append forks.
+#[derive(Debug, Clone, Default)]
+pub struct Session {
+    entries: Vec<SessionEntry>,
+    head: Option<String>,
+    next_seq: u64,
+}
+
+impl Session {
+    /// Create an empty session.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a linear session from an existing flat history (e.g. an agent's
+    /// messages). Head ends at the last message.
+    pub fn from_messages(messages: &[AgentMessage]) -> Self {
+        let mut s = Self::new();
+        for m in messages {
+            s.append(m.clone());
+        }
+        s
+    }
+
+    /// Append a message as a child of the current head and advance the head.
+    /// After a [`seek`](Self::seek), this creates a new branch. Returns the
+    /// new entry's id.
+    pub fn append(&mut self, message: AgentMessage) -> String {
+        self.next_seq += 1;
+        let id = format!("e{}", self.next_seq);
+        self.entries.push(SessionEntry {
+            id: id.clone(),
+            parent_id: self.head.clone(),
+            message,
+            timestamp: now_ms(),
+            label: None,
+        });
+        self.head = Some(id.clone());
+        id
+    }
+
+    /// Append every message of `full_history` beyond the current path length
+    /// — the typical post-run sync from [`Agent::messages`](crate::Agent::messages).
+    pub fn append_new(&mut self, full_history: &[AgentMessage]) {
+        let known = self.path_ids().len();
+        for m in full_history.iter().skip(known) {
+            self.append(m.clone());
+        }
+    }
+
+    /// Current head entry id, if any.
+    pub fn head(&self) -> Option<&str> {
+        self.head.as_deref()
+    }
+
+    /// Move the head to an existing entry (a fork point). The next
+    /// [`append`](Self::append) starts a new branch from there; existing
+    /// branches are never deleted.
+    pub fn seek(&mut self, entry_id: &str) -> Result<(), SessionError> {
+        if self.entry(entry_id).is_none() {
+            return Err(SessionError::UnknownEntry(entry_id.to_string()));
+        }
+        self.head = Some(entry_id.to_string());
+        Ok(())
+    }
+
+    /// Label the current head as a checkpoint.
+    pub fn checkpoint(&mut self, label: impl Into<String>) -> Result<(), SessionError> {
+        let head = self.head.clone().ok_or(SessionError::Empty)?;
+        let label = label.into();
+        let entry = self
+            .entries
+            .iter_mut()
+            .find(|e| e.id == head)
+            .expect("head always exists");
+        entry.label = Some(label);
+        Ok(())
+    }
+
+    /// Move the head to the entry labeled `label`.
+    pub fn seek_checkpoint(&mut self, label: &str) -> Result<(), SessionError> {
+        let id = self
+            .entries
+            .iter()
+            .find(|e| e.label.as_deref() == Some(label))
+            .map(|e| e.id.clone())
+            .ok_or_else(|| SessionError::UnknownCheckpoint(label.to_string()))?;
+        self.head = Some(id);
+        Ok(())
+    }
+
+    /// The messages on the root→head path — what an agent should see when
+    /// resuming this branch. Pair with
+    /// [`Agent::with_messages`](crate::Agent::with_messages).
+    pub fn path_messages(&self) -> Vec<AgentMessage> {
+        self.path_ids()
+            .iter()
+            .map(|id| self.entry(id).expect("path ids exist").message.clone())
+            .collect()
+    }
+
+    /// Entry ids on the root→head path.
+    pub fn path_ids(&self) -> Vec<String> {
+        let mut ids = Vec::new();
+        let mut cursor = self.head.clone();
+        while let Some(id) = cursor {
+            cursor = self.entry(&id).and_then(|e| e.parent_id.clone());
+            ids.push(id);
+        }
+        ids.reverse();
+        ids
+    }
+
+    /// All entries, in insertion order (all branches).
+    pub fn entries(&self) -> &[SessionEntry] {
+        &self.entries
+    }
+
+    /// Look up an entry by id.
+    pub fn entry(&self, id: &str) -> Option<&SessionEntry> {
+        self.entries.iter().find(|e| e.id == id)
+    }
+
+    /// Ids of all leaf entries — one per branch.
+    pub fn branch_tips(&self) -> Vec<&str> {
+        let mut has_child: HashMap<&str, bool> = HashMap::new();
+        for e in &self.entries {
+            has_child.entry(e.id.as_str()).or_insert(false);
+            if let Some(p) = &e.parent_id {
+                has_child.insert(p.as_str(), true);
+            }
+        }
+        self.entries
+            .iter()
+            .filter(|e| !has_child.get(e.id.as_str()).copied().unwrap_or(false))
+            .map(|e| e.id.as_str())
+            .collect()
+    }
+
+    /// Direct children of an entry.
+    pub fn children(&self, id: &str) -> Vec<&SessionEntry> {
+        self.entries
+            .iter()
+            .filter(|e| e.parent_id.as_deref() == Some(id))
+            .collect()
+    }
+
+    /// Serialize to JSONL — one entry per line, insertion order. The head is
+    /// restored as the **last line's entry** on load; seek before saving is
+    /// not preserved (append after seeking and the new entry becomes both
+    /// last line and head).
+    pub fn to_jsonl(&self) -> String {
+        self.entries
+            .iter()
+            .map(|e| serde_json::to_string(e).expect("session entries serialize"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Load from JSONL produced by [`to_jsonl`](Self::to_jsonl). Head is set
+    /// to the last line's entry.
+    pub fn from_jsonl(s: &str) -> Result<Self, SessionError> {
+        let mut session = Self::new();
+        for (i, line) in s.lines().enumerate() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let entry: SessionEntry =
+                serde_json::from_str(line).map_err(|e| SessionError::Parse {
+                    line: i + 1,
+                    error: e.to_string(),
+                })?;
+            // Track the numeric suffix so future appends can't collide.
+            if let Some(n) = entry
+                .id
+                .strip_prefix('e')
+                .and_then(|n| n.parse::<u64>().ok())
+            {
+                session.next_seq = session.next_seq.max(n);
+            }
+            session.head = Some(entry.id.clone());
+            session.entries.push(entry);
+        }
+        Ok(session)
+    }
+}

--- a/tests/session_test.rs
+++ b/tests/session_test.rs
@@ -1,0 +1,191 @@
+//! Tests for session trees: branching, checkpoints, JSONL persistence,
+//! and the fork-edit-rerun flow with an Agent.
+
+use yoagent::provider::mock::*;
+use yoagent::provider::MockProvider;
+use yoagent::*;
+
+fn user(text: &str) -> AgentMessage {
+    AgentMessage::Llm(Message::user(text))
+}
+
+fn text_of(m: &AgentMessage) -> &str {
+    match m {
+        AgentMessage::Llm(Message::User { content, .. }) => match &content[0] {
+            Content::Text { text } => text,
+            _ => panic!("expected text"),
+        },
+        _ => panic!("expected user message"),
+    }
+}
+
+#[test]
+fn linear_append_builds_a_chain() {
+    let mut s = Session::new();
+    let a = s.append(user("one"));
+    let b = s.append(user("two"));
+
+    assert_eq!(s.head(), Some(b.as_str()));
+    assert_eq!(s.entry(&b).unwrap().parent_id.as_deref(), Some(a.as_str()));
+    let path = s.path_messages();
+    assert_eq!(path.len(), 2);
+    assert_eq!(text_of(&path[0]), "one");
+    assert_eq!(text_of(&path[1]), "two");
+}
+
+#[test]
+fn seek_and_append_forks_without_losing_the_old_branch() {
+    let mut s = Session::new();
+    let root = s.append(user("root"));
+    let old_tip = s.append(user("original direction"));
+
+    s.seek(&root).unwrap();
+    let new_tip = s.append(user("new direction"));
+
+    // Path follows the new branch.
+    let path = s.path_messages();
+    assert_eq!(path.len(), 2);
+    assert_eq!(text_of(&path[1]), "new direction");
+
+    // The original branch still exists: two tips, both reachable.
+    let mut tips = s.branch_tips();
+    tips.sort();
+    let mut expected = vec![old_tip.as_str(), new_tip.as_str()];
+    expected.sort();
+    assert_eq!(tips, expected);
+
+    // Both children hang off the root.
+    assert_eq!(s.children(&root).len(), 2);
+}
+
+#[test]
+fn seek_unknown_entry_errors() {
+    let mut s = Session::new();
+    s.append(user("x"));
+    assert!(matches!(s.seek("nope"), Err(SessionError::UnknownEntry(_))));
+}
+
+#[test]
+fn checkpoints_label_and_seek() {
+    let mut s = Session::new();
+    s.append(user("a"));
+    let b = s.append(user("b"));
+    s.checkpoint("stable").unwrap();
+    s.append(user("c"));
+
+    s.seek_checkpoint("stable").unwrap();
+    assert_eq!(s.head(), Some(b.as_str()));
+    assert!(matches!(
+        s.seek_checkpoint("missing"),
+        Err(SessionError::UnknownCheckpoint(_))
+    ));
+    // Checkpoint on empty session errors.
+    assert!(matches!(
+        Session::new().checkpoint("x"),
+        Err(SessionError::Empty)
+    ));
+}
+
+#[test]
+fn jsonl_roundtrip_preserves_tree_and_ids() {
+    let mut s = Session::new();
+    let root = s.append(user("root"));
+    s.append(user("branch-1"));
+    s.seek(&root).unwrap();
+    s.append(user("branch-2"));
+    s.checkpoint("tip2").unwrap();
+
+    let jsonl = s.to_jsonl();
+    let restored = Session::from_jsonl(&jsonl).unwrap();
+
+    assert_eq!(restored.entries().len(), 3);
+    // Head = last line's entry (the branch-2 tip).
+    assert_eq!(restored.head(), s.head());
+    // Tree shape intact: two children of root.
+    assert_eq!(restored.children(&root).len(), 2);
+    // Checkpoint label survives.
+    let mut r = restored.clone();
+    r.seek_checkpoint("tip2").unwrap();
+
+    // Appending after load can't collide with existing ids.
+    let mut r2 = restored;
+    let new_id = r2.append(user("post-load"));
+    assert!(r2.entries().iter().filter(|e| e.id == new_id).count() == 1);
+    assert_eq!(r2.entries().len(), 4);
+}
+
+#[test]
+fn from_jsonl_reports_bad_line() {
+    let err = Session::from_jsonl("not json").unwrap_err();
+    match err {
+        SessionError::Parse { line, .. } => assert_eq!(line, 1),
+        other => panic!("expected Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_messages_builds_linear_session() {
+    let s = Session::from_messages(&[user("a"), user("b"), user("c")]);
+    assert_eq!(s.entries().len(), 3);
+    assert_eq!(s.path_messages().len(), 3);
+    assert_eq!(s.branch_tips().len(), 1);
+}
+
+#[tokio::test]
+async fn fork_edit_rerun_with_agent() {
+    // Turn 1: run the agent, record into the session.
+    let provider = MockProvider::new(vec![
+        MockResponse::Text("answer one".into()),
+        MockResponse::Text("answer two".into()),
+    ]);
+    let mut agent = Agent::from_provider(provider, yoagent::provider::ModelConfig::mock());
+    let mut rx = agent.prompt("question A").await;
+    while rx.recv().await.is_some() {}
+    agent.finish().await;
+
+    let mut session = Session::new();
+    session.append_new(agent.messages());
+    assert_eq!(session.entries().len(), 2); // user + assistant
+    session.checkpoint("turn-1").unwrap();
+
+    // "Edit" the first user message: fork from BEFORE it (root fork = seek to
+    // nothing is not a thing — fork from the first entry's parent by starting
+    // a sibling of the user message). Here: fork from turn-1's assistant to
+    // ask a different follow-up on one branch...
+    let mut rx = agent.prompt("follow-up B").await;
+    while rx.recv().await.is_some() {}
+    agent.finish().await;
+    session.append_new(agent.messages());
+    assert_eq!(session.entries().len(), 4);
+    let tip_b = session.head().unwrap().to_string();
+
+    // ...then rewind to the checkpoint and take a different direction.
+    session.seek_checkpoint("turn-1").unwrap();
+    let branch_history = session.path_messages();
+    assert_eq!(branch_history.len(), 2); // the pre-fork history
+
+    let provider2 = MockProvider::text("answer C");
+    let mut agent2 = Agent::from_provider(provider2, yoagent::provider::ModelConfig::mock())
+        .with_messages(branch_history);
+    let mut rx = agent2.prompt("follow-up C").await;
+    while rx.recv().await.is_some() {}
+    agent2.finish().await;
+    session.append_new(agent2.messages());
+
+    // Two branches: B's tip and C's tip; both intact.
+    assert_eq!(session.entries().len(), 6);
+    let tips = session.branch_tips();
+    assert_eq!(tips.len(), 2);
+    assert!(tips.contains(&tip_b.as_str()));
+
+    // The current path is the C branch: 4 messages ending in C's answer.
+    let path = session.path_messages();
+    assert_eq!(path.len(), 4);
+    match path.last().unwrap() {
+        AgentMessage::Llm(Message::Assistant { content, .. }) => match &content[0] {
+            Content::Text { text } => assert_eq!(text, "answer C"),
+            other => panic!("unexpected content {other:?}"),
+        },
+        other => panic!("unexpected message {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

Phase **C2(a)**: conversation history as a **tree**, not a list — the pi-style id/parentId session structure, and one of the two features the roadmap's competitive audit flagged as pi's signature advantages we lacked.

```rust
let mut session = Session::new();
// run agent → record
session.append_new(agent.messages());
session.checkpoint("first-draft")?;
// ...later: rewind and branch
session.seek_checkpoint("first-draft")?;
let mut agent = Agent::from_config(cfg).with_messages(session.path_messages());
// prompt again → append_new records the NEW branch; the old one is intact
assert_eq!(session.branch_tips().len(), 2);
```

## Design

- **Freestanding module — zero loop changes.** `Session` composes with the existing `Agent::with_messages`/`messages()` API; nothing in the loop knows about trees.
- **Append-only forking**: `seek` + `append` branches; history is never overwritten or deleted.
- **JSONL persistence** — one entry per line, append- and diff-friendly. Head restores as the last line's entry (documented); loaded ids can't collide with future appends.
- **GASP**: this is the shape of the `transcripts/` tier. The semantic event-log adapter (C2b) comes later, layered on the `AgentEvent` stream — per the agreed design, GASP itself stays out of yoagent core.
- Flat `save_messages()`/`restore_messages()` remain for single-branch persistence.

## Tests (8 new, 351 total green)

Linear chain · fork preserves old branch (tips + children asserted) · unknown-seek error · checkpoint label/seek/missing/empty · JSONL roundtrip with branches + id-collision guard · parse error carries line number · `from_messages` · end-to-end fork-edit-rerun with two Agents on one session.

## Verification

clippy `-Dwarnings --all-features` clean · 351 passed / 0 failed · docs `-Dwarnings` clean · new mdBook page `concepts/session-trees.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)