### PR TITLE
feat: cross-provider thinking — 7/7 protocols (C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Cross-provider thinking (7/7)** — `thinking_level` is now honored by
+  every protocol: Gemini and Vertex send `thinkingConfig` (with thought
+  summaries streamed back as `Content::Thinking`), Bedrock sends
+  Anthropic-style `additionalModelRequestFields.thinking` (reasoning deltas
+  and signatures streamed back), Azure sends Responses-style reasoning
+  effort. The "not yet wired" warnings are gone.
+
 - **Session trees** — `Session`: branching conversation history with
   `append`/`seek`/`checkpoint`, fork-preserving edits, `path_messages()` for
   branch resume, and JSONL persistence. The pi-style id/parentId tree; maps

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Everything is observable via events. Supports 7 API protocols covering 20+ LLM p
 - 7 API protocols, 20+ providers behind one `StreamProvider` trait
 - One OpenAI-compatible implementation covers OpenAI, xAI, Groq, Cerebras, OpenRouter, Mistral, and more
 - Per-provider quirk flags (`OpenAiCompat`, `AnthropicCompat`) handle auth, reasoning format, and tool handling differences
-- Capability notes: thinking/reasoning controls are wired for Anthropic and for OpenAI-compatible providers whose `ModelConfig` opts in (the `openai()`/`deepseek()` presets do; other compat presets silently drop `thinking_level`). Gemini, Vertex, Bedrock, and Azure are planned — setting `thinking_level` there logs a warning. Client-side prompt-cache breakpoints are Anthropic-specific; most other providers cache server-side automatically, but Bedrock has no automatic caching
+- Capability notes: thinking/reasoning controls are wired for **all 7 protocols** — Anthropic (adaptive/budget), OpenAI-compatible where the `ModelConfig` opts in (the `openai()`/`deepseek()` presets do; other compat presets silently drop `thinking_level`), OpenAI Responses & Azure (reasoning effort), Gemini & Vertex (`thinkingConfig` with thought summaries streamed back), Bedrock (Anthropic-style budgets, reasoning deltas streamed back). Client-side prompt-cache breakpoints are Anthropic-specific; most other providers cache server-side automatically, but Bedrock has no automatic caching
 
 **Built-in Tools**
 - `bash` — Shell execution with timeout, output truncation, command deny patterns

--- a/src/provider/azure_openai.rs
+++ b/src/provider/azure_openai.rs
@@ -34,11 +34,6 @@ impl StreamProvider for AzureOpenAiProvider {
                 "structured outputs are not yet wired for the Azure OpenAI provider; output_schema will be ignored"
             );
         }
-        if config.thinking_level != ThinkingLevel::Off {
-            warn!(
-                "thinking_level is not yet wired for the Azure OpenAI provider and will be ignored"
-            );
-        }
         let model_config = config
             .model_config
             .as_ref()
@@ -346,6 +341,18 @@ fn build_azure_request_body(config: &StreamConfig) -> serde_json::Value {
         body["temperature"] = serde_json::json!(temp);
     }
 
+    // Thinking: the Responses API's reasoning effort (same mapping as the
+    // first-party OpenAI Responses provider).
+    if config.thinking_level != ThinkingLevel::Off {
+        let effort = match config.thinking_level {
+            ThinkingLevel::Minimal | ThinkingLevel::Low => "low",
+            ThinkingLevel::Medium => "medium",
+            ThinkingLevel::High => "high",
+            ThinkingLevel::Off => unreachable!(),
+        };
+        body["reasoning"] = serde_json::json!({"effort": effort});
+    }
+
     body
 }
 
@@ -383,4 +390,37 @@ struct AzureUsage {
     output_tokens: u64,
     #[serde(default)]
     total_tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(level: ThinkingLevel) -> StreamConfig {
+        StreamConfig {
+            model: "gpt-5.5".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: level,
+            api_key: "key".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        }
+    }
+
+    #[test]
+    fn thinking_level_sets_reasoning_effort() {
+        let body = build_azure_request_body(&config(ThinkingLevel::Medium));
+        assert_eq!(body["reasoning"]["effort"], "medium");
+    }
+
+    #[test]
+    fn thinking_off_omits_reasoning() {
+        let body = build_azure_request_body(&config(ThinkingLevel::Off));
+        assert!(body["reasoning"].is_null());
+    }
 }

--- a/src/provider/bedrock.rs
+++ b/src/provider/bedrock.rs
@@ -37,11 +37,6 @@ impl StreamProvider for BedrockProvider {
                 "structured outputs are not yet wired for the Amazon Bedrock provider; output_schema will be ignored"
             );
         }
-        if config.thinking_level != ThinkingLevel::Off {
-            warn!(
-                "thinking_level is not yet wired for the Amazon Bedrock provider and will be ignored"
-            );
-        }
         let model_config = config
             .model_config
             .as_ref()
@@ -157,6 +152,28 @@ impl StreamProvider for BedrockProvider {
                                                 delta: tool_use.input,
                                             });
                                         }
+                                        if let Some(reasoning) = delta.reasoning_content {
+                                            let think_idx = content.iter().position(|c| matches!(c, Content::Thinking { .. }));
+                                            let idx = match think_idx {
+                                                Some(i) => i,
+                                                None => {
+                                                    content.push(Content::thinking(String::new()));
+                                                    content.len() - 1
+                                                }
+                                            };
+                                            if let Some(Content::Thinking { thinking, signature }) = content.get_mut(idx) {
+                                                if let Some(text) = reasoning.text {
+                                                    thinking.push_str(&text);
+                                                    let _ = tx.send(StreamEvent::ThinkingDelta {
+                                                        content_index: idx,
+                                                        delta: text,
+                                                    });
+                                                }
+                                                if reasoning.signature.is_some() {
+                                                    *signature = reasoning.signature;
+                                                }
+                                            }
+                                        }
                                     }
                                     BedrockEvent::ContentBlockStart { start, .. } => {
                                         if let Some(tool_use) = start.tool_use {
@@ -218,6 +235,17 @@ impl StreamProvider for BedrockProvider {
             message: message.clone(),
         });
         Ok(message)
+    }
+}
+
+/// Budget for Bedrock's Anthropic-style thinking per level (matches the
+/// legacy Anthropic budget mapping).
+fn bedrock_thinking_budget(level: ThinkingLevel) -> u32 {
+    match level {
+        ThinkingLevel::Off => 0,
+        ThinkingLevel::Minimal | ThinkingLevel::Low => 1024,
+        ThinkingLevel::Medium => 2048,
+        ThinkingLevel::High => 8192,
     }
 }
 
@@ -291,6 +319,18 @@ fn build_bedrock_body(config: &StreamConfig) -> serde_json::Value {
     }
     if inference_config != serde_json::json!({}) {
         body["inferenceConfig"] = inference_config;
+    }
+
+    // Thinking: Claude models on Bedrock take Anthropic's budget-based
+    // thinking via additionalModelRequestFields (same budgets as the
+    // pre-adaptive Anthropic path).
+    if config.thinking_level != ThinkingLevel::Off {
+        body["additionalModelRequestFields"] = serde_json::json!({
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": bedrock_thinking_budget(config.thinking_level),
+            }
+        });
     }
 
     if !config.tools.is_empty() {
@@ -372,6 +412,16 @@ struct BedrockDelta {
     text: Option<String>,
     #[serde(default, rename = "toolUse")]
     tool_use: Option<BedrockToolUseDelta>,
+    #[serde(default, rename = "reasoningContent")]
+    reasoning_content: Option<BedrockReasoningDelta>,
+}
+
+#[derive(Deserialize)]
+struct BedrockReasoningDelta {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    signature: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -403,6 +453,46 @@ struct BedrockUsage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thinking_level_sets_additional_model_request_fields() {
+        let config = StreamConfig {
+            model: "anthropic.claude-sonnet".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::High,
+            api_key: "a:b".into(),
+            max_tokens: Some(1024),
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        };
+        let body = build_bedrock_body(&config);
+        let thinking = &body["additionalModelRequestFields"]["thinking"];
+        assert_eq!(thinking["type"], "enabled");
+        assert_eq!(thinking["budget_tokens"], 8192);
+    }
+
+    #[test]
+    fn thinking_off_omits_additional_fields() {
+        let config = StreamConfig {
+            model: "anthropic.claude-sonnet".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "a:b".into(),
+            max_tokens: Some(1024),
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        };
+        let body = build_bedrock_body(&config);
+        assert!(body["additionalModelRequestFields"].is_null());
+    }
 
     #[test]
     fn test_build_bedrock_body() {

--- a/src/provider/google.rs
+++ b/src/provider/google.rs
@@ -25,11 +25,6 @@ impl StreamProvider for GoogleProvider {
         tx: mpsc::UnboundedSender<StreamEvent>,
         cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Message, ProviderError> {
-        if config.thinking_level != ThinkingLevel::Off {
-            warn!(
-                "thinking_level is not yet wired for the Google Gemini provider and will be ignored"
-            );
-        }
         let model_config = config
             .model_config
             .as_ref()
@@ -125,6 +120,25 @@ impl StreamProvider for GoogleProvider {
                                     if let Some(c) = &candidate.content {
                                         for part in &c.parts {
                                             if let Some(text) = part_text(part) {
+                                                if part.thought.unwrap_or(false) {
+                                                    // Thought summary part → Thinking content.
+                                                    let think_idx = content.iter().position(|c| matches!(c, Content::Thinking { .. }));
+                                                    let idx = match think_idx {
+                                                        Some(i) => i,
+                                                        None => {
+                                                            content.push(Content::thinking(String::new()));
+                                                            content.len() - 1
+                                                        }
+                                                    };
+                                                    if let Some(Content::Thinking { thinking, .. }) = content.get_mut(idx) {
+                                                        thinking.push_str(text);
+                                                    }
+                                                    let _ = tx.send(StreamEvent::ThinkingDelta {
+                                                        content_index: idx,
+                                                        delta: text.to_string(),
+                                                    });
+                                                    continue;
+                                                }
                                                 let text_idx = content.iter().position(|c| matches!(c, Content::Text { .. }));
                                                 let idx = match text_idx {
                                                     Some(i) => i,
@@ -265,6 +279,16 @@ fn part_text(part: &GooglePart) -> Option<&str> {
     part.text.as_deref().filter(|t| !t.is_empty())
 }
 
+/// Token budget for Gemini's thinkingConfig per level.
+fn gemini_thinking_budget(level: ThinkingLevel) -> u32 {
+    match level {
+        ThinkingLevel::Off => 0,
+        ThinkingLevel::Minimal | ThinkingLevel::Low => 1024,
+        ThinkingLevel::Medium => 8192,
+        ThinkingLevel::High => 24576,
+    }
+}
+
 fn build_request_body(config: &StreamConfig) -> serde_json::Value {
     let mut contents: Vec<serde_json::Value> = Vec::new();
 
@@ -346,6 +370,15 @@ fn build_request_body(config: &StreamConfig) -> serde_json::Value {
     if let Some(schema) = &config.output_schema {
         generation_config["responseMimeType"] = serde_json::json!("application/json");
         generation_config["responseSchema"] = schema.schema.clone();
+    }
+
+    // Thinking: Gemini 2.5's thinkingConfig. Budget scales with the level;
+    // includeThoughts streams thought summaries back as thought parts.
+    if config.thinking_level != ThinkingLevel::Off {
+        generation_config["thinkingConfig"] = serde_json::json!({
+            "thinkingBudget": gemini_thinking_budget(config.thinking_level),
+            "includeThoughts": true,
+        });
     }
 
     if generation_config != serde_json::json!({}) {
@@ -433,6 +466,9 @@ struct GoogleContent {
 struct GooglePart {
     #[serde(default)]
     text: Option<String>,
+    /// True when this part is a thought summary (thinkingConfig.includeThoughts).
+    #[serde(default)]
+    thought: Option<bool>,
     #[serde(default, rename = "functionCall")]
     function_call: Option<GoogleFunctionCall>,
     #[serde(default, rename = "thoughtSignature")]
@@ -463,6 +499,51 @@ struct GoogleUsageMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thinking_level_sets_thinking_config() {
+        let config = StreamConfig {
+            model: "gemini-2.5-pro".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Medium,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        };
+        let body = build_request_body(&config);
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingBudget"],
+            8192
+        );
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["includeThoughts"],
+            true
+        );
+    }
+
+    #[test]
+    fn thinking_off_omits_thinking_config() {
+        let config = StreamConfig {
+            model: "gemini-2.5-pro".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        };
+        let body = build_request_body(&config);
+        assert!(body["generationConfig"]["thinkingConfig"].is_null());
+    }
 
     #[test]
     fn structured_output_sets_response_schema() {

--- a/src/provider/google_vertex.rs
+++ b/src/provider/google_vertex.rs
@@ -42,11 +42,6 @@ impl StreamProvider for GoogleVertexProvider {
                 "structured outputs are not yet wired for the Google Vertex provider; output_schema will be ignored"
             );
         }
-        if config.thinking_level != ThinkingLevel::Off {
-            tracing::warn!(
-                "thinking_level is not yet wired for the Google Vertex provider and will be ignored"
-            );
-        }
         let model_config = config
             .model_config
             .as_ref()
@@ -183,6 +178,8 @@ async fn parse_google_sse_response(
                             struct Part {
                                 #[serde(default)]
                                 text: Option<String>,
+                                #[serde(default)]
+                                thought: Option<bool>,
                                 #[serde(default, rename = "functionCall")]
                                 function_call: Option<FCall>,
                             }
@@ -216,6 +213,24 @@ async fn parse_google_sse_response(
                                 if let Some(c) = candidate.content {
                                     for part in c.parts {
                                         if let Some(text) = part.text {
+                                            if part.thought.unwrap_or(false) {
+                                                let think_idx = content.iter().position(|c| matches!(c, Content::Thinking { .. }));
+                                                let idx = match think_idx {
+                                                    Some(i) => i,
+                                                    None => {
+                                                        content.push(Content::thinking(String::new()));
+                                                        content.len() - 1
+                                                    }
+                                                };
+                                                if let Some(Content::Thinking { thinking, .. }) = content.get_mut(idx) {
+                                                    thinking.push_str(&text);
+                                                }
+                                                let _ = tx.send(StreamEvent::ThinkingDelta {
+                                                    content_index: idx,
+                                                    delta: text,
+                                                });
+                                                continue;
+                                            }
                                             let idx = content.iter().position(|c| matches!(c, Content::Text { .. }));
                                             let idx = match idx {
                                                 Some(i) => i,
@@ -296,6 +311,16 @@ async fn parse_google_sse_response(
 }
 
 /// Build the request body for Vertex AI (same format as Google GenAI).
+/// Token budget for Vertex's thinkingConfig per level (same scale as Gemini).
+fn vertex_thinking_budget(level: ThinkingLevel) -> u32 {
+    match level {
+        ThinkingLevel::Off => 0,
+        ThinkingLevel::Minimal | ThinkingLevel::Low => 1024,
+        ThinkingLevel::Medium => 8192,
+        ThinkingLevel::High => 24576,
+    }
+}
+
 fn build_vertex_request_body(config: &StreamConfig) -> serde_json::Value {
     // Same format as Google GenAI
     let mut contents: Vec<serde_json::Value> = Vec::new();
@@ -376,6 +401,13 @@ fn build_vertex_request_body(config: &StreamConfig) -> serde_json::Value {
     if let Some(temp) = config.temperature {
         gen_config["temperature"] = serde_json::json!(temp);
     }
+    // Thinking: same thinkingConfig as the Gemini API.
+    if config.thinking_level != ThinkingLevel::Off {
+        gen_config["thinkingConfig"] = serde_json::json!({
+            "thinkingBudget": vertex_thinking_budget(config.thinking_level),
+            "includeThoughts": true,
+        });
+    }
     if gen_config != serde_json::json!({}) {
         body["generationConfig"] = gen_config;
     }
@@ -396,4 +428,44 @@ fn build_vertex_request_body(config: &StreamConfig) -> serde_json::Value {
     }
 
     body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(level: ThinkingLevel) -> StreamConfig {
+        StreamConfig {
+            model: "gemini-2.5-pro".into(),
+            system_prompt: "".into(),
+            messages: vec![Message::user("hi")],
+            tools: vec![],
+            thinking_level: level,
+            api_key: "token".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+            output_schema: None,
+        }
+    }
+
+    #[test]
+    fn thinking_level_sets_thinking_config() {
+        let body = build_vertex_request_body(&config(ThinkingLevel::High));
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingBudget"],
+            24576
+        );
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["includeThoughts"],
+            true
+        );
+    }
+
+    #[test]
+    fn thinking_off_omits_thinking_config() {
+        let body = build_vertex_request_body(&config(ThinkingLevel::Off));
+        assert!(body["generationConfig"]["thinkingConfig"].is_null());
+    }
 }

--- a/tests/google_stream_test.rs
+++ b/tests/google_stream_test.rs
@@ -346,3 +346,46 @@ async fn cached_tokens_are_not_double_counted_in_usage() {
     assert_eq!(usage.output, 5);
     assert_eq!(usage.input + usage.cache_read + usage.output, 105);
 }
+
+/// Thought-summary parts (thinkingConfig.includeThoughts) must stream as
+/// ThinkingDelta and land as Content::Thinking — separate from the answer.
+#[tokio::test]
+async fn thought_parts_map_to_thinking_content() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1beta/models/{}:streamGenerateContent",
+            MODEL
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse(&[
+                r#"{"candidates":[{"content":{"parts":[{"text":"Considering the options...","thought":true}],"role":"model"},"index":0}]}"#,
+                r#"{"candidates":[{"content":{"parts":[{"text":"The answer is 4."}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#,
+            ]),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), vec![Message::user("2+2?")])).await;
+
+    let Message::Assistant { content, .. } = &message else {
+        panic!("expected assistant message");
+    };
+    let thinking = content
+        .iter()
+        .find_map(|c| match c {
+            Content::Thinking { thinking, .. } => Some(thinking.clone()),
+            _ => None,
+        })
+        .expect("thought part must become Thinking content");
+    assert!(thinking.contains("Considering the options"));
+    let text = content
+        .iter()
+        .find_map(|c| match c {
+            Content::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .expect("answer text");
+    assert_eq!(text, "The answer is 4.");
+}


### PR DESCRIPTION
## What

Phase **C4**: `thinking_level` is now honored by **every protocol** (was 3/7). The Phase-A "not yet wired" warnings are deleted — the capability matrix's biggest asterisk is gone.

| Provider | Request wiring | Response wiring |
|---|---|---|
| Gemini | `generationConfig.thinkingConfig {thinkingBudget, includeThoughts}` (1024/8192/24576 by level) | thought parts (`"thought": true`) → `ThinkingDelta` + `Content::Thinking` |
| Vertex | same `thinkingConfig` | same thought-part parsing |
| Bedrock | `additionalModelRequestFields.thinking {type: enabled, budget_tokens}` (legacy Anthropic budgets) | `reasoningContent` deltas → `ThinkingDelta`; signatures captured |
| Azure OpenAI | `reasoning: {effort}` (same mapping as the first-party Responses provider) | — (Responses reasoning summaries not streamed v1) |

## Tests (9 new, 360 total green)

Per-provider body assertions (budget/effort correct; `Off` omits the field entirely) · Gemini wiremock stream test proving a thought part lands as `Content::Thinking` while the answer stays `Text` · first-ever test modules for `azure_openai.rs` and `google_vertex.rs`.

## Verification

clippy `-Dwarnings --all-features` clean · 360 passed / 0 failed · docs `-Dwarnings` clean · README capability note updated to claim 7/7 honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)