### PR TITLE
release: 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.11.0
 
 ### Fixed (pre-release review of the items below)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = "0.10"
+yoagent = "0.11"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-yoagent = "0.10"
+yoagent = "0.11"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -40,5 +40,5 @@ Enable in `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = { version = "0.10", features = ["openapi"] }
+yoagent = { version = "0.11", features = ["openapi"] }
 ```


### PR DESCRIPTION
## What

Version bump to **0.11.0** — the Phase C release. Everything is already merged and review-clean on main; this PR only bumps `Cargo.toml`, version refs in README/docs, and retitles the CHANGELOG's Unreleased section.

## In this release

- **Tool middleware** (#61) — async approve/deny/modify hooks gating every tool call
- **Structured outputs** (#62) — `prompt_structured::<T>()` with native schema enforcement
- **Session trees** (#63) — branching history with fork, checkpoints, JSONL
- **Cross-provider thinking** (#64) — `thinking_level` honored on all 7 protocols
- **Telemetry** (#65) — `tracing` spans with token/cost fields
- **Review-fix batch** (#66) — five-agent review findings, all fixed

Full notes with the migration-relevant details in [CHANGELOG.md](CHANGELOG.md).

## Verification

- `cargo publish --dry-run` clean
- 376 tests green, clippy/docs `-Dwarnings` clean (verified on #66's CI)

## After merge

Tag `v0.11.0` + GitHub Release (triggers `publish.yml` → crates.io) — held for explicit maintainer go, per the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)