### PR TITLE
fix: restore --all-features MSRV coverage via yoagent-state 0.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.86
       - uses: Swatinem/rust-cache@v2
       - name: Check
-        # The optional `gasp` feature is excluded: yoagent-state currently
-        # requires a newer rustc (let-chains) than the crate's 1.86 MSRV.
-        run: cargo check --features openapi
+        run: cargo check --all-features
 
   # yoagent claims to be a tested GASP-conformant runtime — this job is the
   # test: emit an agent repo with the gasp bridge (mock provider, no network)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ rand = "0.10.0"
 base64 = "0.22"
 openapiv3 = { version = "2", optional = true }
 serde_yaml_ng = { version = "0.10", optional = true }
-yoagent-state = { version = "0.4.1", optional = true }
+# 0.4.2 floor: 0.4.1 declared MSRV 1.85 but required 1.88 (let-chain)
+yoagent-state = { version = "0.4.2", optional = true }
 
 [features]
 openapi = ["dep:openapiv3", "dep:serde_yaml_ng", "reqwest/query"]

--- a/docs/concepts/gasp.md
+++ b/docs/concepts/gasp.md
@@ -16,9 +16,6 @@ agent-loop changes**:
 yoagent = { version = "0.11", features = ["gasp"] }
 ```
 
-> The `gasp` feature currently requires a newer Rust than the crate's 1.86
-> MSRV (its `yoagent-state` dependency uses let-chains, stable since 1.88).
-
 
 ```rust
 use yoagent::gasp::{GaspRecorder, GoalRef};


### PR DESCRIPTION
## What

Closes the loop on the #68 MSRV carve-out. Upstream [yoagent-state#1](https://github.com/yologdev/yoagent-state/pull/1) removed the let-chain that made its declared 1.85 MSRV untrue; **0.4.2 is on crates.io**. This PR:

- Bumps the dep floor to `0.4.2` (so a 1.86 toolchain can never resolve the broken 0.4.1)
- Restores `cargo check --all-features` on the MSRV (1.86) job — the `gasp` feature is MSRV-covered again
- Removes the stale docs caveat

## Downstream verification (done before the upstream release)

| Consumer | Result |
|---|---|
| yoagent, full suite vs patched crate | **392 passed / 0 failed** |
| yoyo-evolve `tools/gasp-emit` vs patched crate | compiles clean |
| yyds-harness (`yoagent-state = "0.2.0"`) | resolves at 0.2.0 — 0.4.x provably unreachable |

## The verdict is this PR's own CI

Declared MSRVs can lie (that's how we got here) — the **MSRV job on this PR** is the real test of 1.86 + `--all-features`. If it's red, we revert the job line and keep the carve-out; nothing shipped changes either way. Known-safe residual: `wasip2` (1.87) remains in the resolve but is wasm-only and never built on the CI target (same as since Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)