### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.12.0
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = "0.11"
+yoagent = "0.12"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/concepts/gasp.md
+++ b/docs/concepts/gasp.md
@@ -13,7 +13,7 @@ runtime). The bridge is a consumer of the [`AgentEvent`] stream — **zero
 agent-loop changes**:
 
 ```toml
-yoagent = { version = "0.11", features = ["gasp"] }
+yoagent = { version = "0.12", features = ["gasp"] }
 ```
 
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-yoagent = "0.11"
+yoagent = "0.12"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -40,5 +40,5 @@ Enable in `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = { version = "0.11", features = ["openapi"] }
+yoagent = { version = "0.12", features = ["openapi"] }
 ```


### PR DESCRIPTION
## What

Version bump to **0.12.0**. Everything is merged and review-clean on main; this PR bumps `Cargo.toml`, version refs (README, installation, gasp docs), and retitles the CHANGELOG section.

## In this release

- **GASP bridge** (#68) — `gasp::GaspRecorder`: record runs into a GASP agent repo; **the first tested GASP-conformant runtime** (7-check suite runs in CI against a fresh clone)
- **Meta Model API** (#69) — day-one Muse Spark 1.1 preset, fact-checked against Meta's official docs
- **MSRV closure** (#70) — `--all-features` restored on the 1.86 job via yoagent-state 0.4.2

## Verification

`cargo publish --dry-run` clean · all CI green on main · CHANGELOG ready.

## After merge

Tag `v0.12.0` + GitHub Release (triggers `publish.yml` → crates.io) — proceeding on the maintainer's explicit "release 0.12.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)