### PR TITLE
fix: review follow-ups for #76 — logging, wording, usage-shape test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ adheres to [Semantic Versioning](https://semver.org/).
   OpenAI-standard `data: [DONE]` terminator (MiniMax confirmed in the field)
   no longer return `ProviderError::Other("Stream ended")` after the complete
   response already streamed. A `StreamEnded` with no `finish_reason` remains
-  an error — genuine mid-stream truncation still surfaces and retries.
+  an error — genuine truncation still surfaces (network-level drops retry;
+  deliberate server closes fail fast).
 
 ## 0.13.0
 

--- a/src/provider/openai_compat.rs
+++ b/src/provider/openai_compat.rs
@@ -196,10 +196,13 @@ impl StreamProvider for OpenAiCompatProvider {
                         // Some providers (e.g. MiniMax) close the connection
                         // without the OpenAI-standard `data: [DONE]` terminator.
                         // If a finish_reason was already received, the response
-                        // is complete — treat as clean EOF, same as the graceful
-                        // `None` case. A StreamEnded with NO finish_reason is
-                        // genuine mid-stream truncation and stays an error.
+                        // is complete — treat as clean EOF. (This eventsource
+                        // surfaces every body close as StreamEnded; network
+                        // drops surface as Transport instead.) A StreamEnded
+                        // with NO finish_reason is genuine truncation and
+                        // stays an error.
                         Some(Err(reqwest_eventsource::Error::StreamEnded)) if saw_finish_reason => {
+                            debug!("provider closed stream without [DONE] after finish_reason");
                             break;
                         }
                         Some(Err(e)) => {
@@ -214,8 +217,16 @@ impl StreamProvider for OpenAiCompatProvider {
 
         // Finalize tool calls
         for buf in &tool_call_buffers {
-            let args = serde_json::from_str(&buf.arguments)
-                .unwrap_or(serde_json::Value::Object(Default::default()));
+            let args = serde_json::from_str(&buf.arguments).unwrap_or_else(|e| {
+                if !buf.arguments.is_empty() {
+                    warn!(
+                        tool = %buf.name,
+                        len = buf.arguments.len(),
+                        "tool-call arguments failed to parse ({e}); using empty object"
+                    );
+                }
+                serde_json::Value::Object(Default::default())
+            });
             content.push(Content::ToolCall {
                 provider_metadata: None,
                 id: buf.id.clone(),

--- a/tests/openai_compat_stream_test.rs
+++ b/tests/openai_compat_stream_test.rs
@@ -100,3 +100,37 @@ async fn test_stream_ended_without_finish_reason_is_error() {
         "truncation before finish_reason must stay an error, got {result:?}"
     );
 }
+
+/// DONE-less close where a usage chunk arrives AFTER finish_reason (the
+/// OpenAI `stream_options.include_usage` shape): usage must be captured.
+#[tokio::test]
+async fn test_usage_chunk_after_finish_reason_survives_doneless_close() {
+    let server = MockServer::start().await;
+    let body = [
+        chunk(r#"{"choices":[{"delta":{"content":"Hi"},"index":0}]}"#),
+        chunk(r#"{"choices":[{"delta":{},"finish_reason":"stop","index":0}]}"#),
+        chunk(r#"{"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3}}"#),
+    ]
+    .concat();
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(body, "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let msg = run_stream(stream_config(&server.uri()))
+        .await
+        .expect("clean");
+    let Message::Assistant { usage, .. } = &msg else {
+        panic!("expected assistant");
+    };
+    assert_eq!(
+        usage.input, 7,
+        "usage chunk after finish_reason must be captured"
+    );
+    assert_eq!(usage.output, 3);
+}


### PR DESCRIPTION
Two-agent post-merge review of #77. Verdict: the guard is sound (vendored eventsource surfaces body close ONLY as StreamEnded; network drops go Transport→Network→retryable, so the clean-EOF is not over-broad), and the usage-after-finish_reason shape is captured — now proven by a test. Surviving findings applied:

1. `debug!` on the DONE-less break + corrected comment (graceful `None` is unreachable for body close in this lib)
2. `warn!` when non-empty tool-call args fail to parse (pre-existing silent `unwrap_or({})` — truncated args no longer vanish traceless)
3. CHANGELOG retry wording fixed: deliberate closes fail fast (`Other`, non-retryable); network drops retry
4. New test: `include_usage`-shaped stream (usage chunk after finish_reason, no [DONE]) → usage captured

3/3 tests green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)