### PR TITLE
feat: add first-class claude_opus_5() preset (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+- **`ModelConfig::claude_opus_5()` preset** (#85). Consumers mapping model
+  strings to presets had no constructor for `claude-opus-5` and fell through
+  to the generic `ModelConfig::anthropic()`, losing cost tracking and context
+  metadata. The preset sets a 1M context window, a 64K default `max_tokens`
+  (of the model's 128K ceiling), and $5 / $25 per M input/output with
+  $0.50 / $6.25 cache read/write — the same base rates as Opus 4.8. No new
+  compat flag was needed: Opus 5 accepts the same adaptive-thinking encoding
+  as Opus 4.7/4.8, which `AnthropicCompat::default()` already emits whenever
+  a thinking level is set. Note that Opus 5 thinks server-side when a request
+  omits `thinking`, so `ThinkingLevel::Off` does not disable thinking on this
+  model — see the preset's doc comment.
+
 ## 0.13.1
 
 ### Fixed

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -27,8 +27,8 @@ Uses `reqwest-eventsource` to parse Anthropic's SSE stream. Events handled:
 
 Set `thinking_level` to enable thinking. By default the provider sends
 **adaptive thinking** (`thinking: {"type": "adaptive"}`), which the current
-model generation requires (Claude Fable 5, Opus 4.7/4.8, Sonnet 5 reject
-budget-based thinking with a 400). The level maps to an `output_config.effort`
+model generation requires (Claude Fable 5, Opus 5, Opus 4.7/4.8, Sonnet 5
+reject budget-based thinking with a 400). The level maps to an `output_config.effort`
 hint:
 
 | Level | Effort |

--- a/docs/providers/model-presets.md
+++ b/docs/providers/model-presets.md
@@ -10,6 +10,7 @@ Use a preset when the provider is listed here. Use a custom `ModelConfig` when y
 |-------------|----------|----------|------------------|---------|--------------------|
 | `ModelConfig::anthropic(id, name)` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 200K | 16,000 |
 | `ModelConfig::claude_fable_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
+| `ModelConfig::claude_opus_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
 | `ModelConfig::claude_opus_4_8()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
 | `ModelConfig::claude_sonnet_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 1M | 64,000 |
 | `ModelConfig::claude_haiku_4_5()` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com/v1` | 200K | 32,000 |
@@ -32,7 +33,7 @@ Use a preset when the provider is listed here. Use a custom `ModelConfig` when y
 
 The constructors do not validate model IDs. They send the `id` you pass through to the provider, which lets you use newly released model IDs before yoagent updates its examples.
 
-The named presets (`claude_fable_5`, `claude_opus_4_8`, `claude_sonnet_5`, `claude_haiku_4_5`, `gpt_5_5`) also fill in real `CostConfig` pricing. The OpenCode presets select the API protocol from the model id — see [OpenCode Zen & Go](opencode.md).
+The named presets (`claude_fable_5`, `claude_opus_5`, `claude_opus_4_8`, `claude_sonnet_5`, `claude_haiku_4_5`, `gpt_5_5`) also fill in real `CostConfig` pricing. The OpenCode presets select the API protocol from the model id — see [OpenCode Zen & Go](opencode.md).
 
 ## OpenAI-Compatible Presets
 

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -258,8 +258,8 @@ impl OpenAiCompat {
 #[serde(default)]
 pub struct AnthropicCompat {
     /// Use adaptive thinking (`thinking: {"type": "adaptive"}` plus
-    /// `output_config.effort`). Required by Claude Fable 5, Opus 4.7/4.8, and
-    /// Sonnet 5; recommended on Opus 4.6 / Sonnet 4.6. Set to `false` for
+    /// `output_config.effort`). Required by Claude Fable 5, Opus 5, Opus 4.7/4.8,
+    /// and Sonnet 5; recommended on Opus 4.6 / Sonnet 4.6. Set to `false` for
     /// pre-4.6 models, which only accept `{"type": "enabled", "budget_tokens": N}`.
     pub adaptive_thinking: bool,
     /// Send the API key as `Authorization: Bearer {key}` instead of the
@@ -445,6 +445,27 @@ impl ModelConfig {
                 cache_write_per_million: 12.5,
             },
             ..Self::anthropic("claude-fable-5", "Claude Fable 5")
+        }
+    }
+
+    /// Claude Opus 5. 1M context; defaults to 64K of the model's 128K max output.
+    ///
+    /// Opus 5 thinks whenever a request omits `thinking`, so `ThinkingLevel::Off`
+    /// does not disable thinking here — the provider omits the field rather than
+    /// sending `{"type": "disabled"}`, and those tokens still count against
+    /// `max_tokens`. Any other level takes the adaptive path that
+    /// `AnthropicCompat::default()` selects, which Opus 5 accepts unchanged.
+    pub fn claude_opus_5() -> Self {
+        Self {
+            context_window: 1_000_000,
+            max_tokens: 64_000,
+            cost: CostConfig {
+                input_per_million: 5.0,
+                output_per_million: 25.0,
+                cache_read_per_million: 0.5,
+                cache_write_per_million: 6.25,
+            },
+            ..Self::anthropic("claude-opus-5", "Claude Opus 5")
         }
     }
 
@@ -941,6 +962,17 @@ mod tests {
         assert_eq!(fable.context_window, 1_000_000);
         assert_eq!(fable.cost.input_per_million, 10.0);
         assert_eq!(fable.cost.output_per_million, 50.0);
+
+        let opus_5 = ModelConfig::claude_opus_5();
+        assert_eq!(opus_5.id, "claude-opus-5");
+        assert_eq!(opus_5.api, ApiProtocol::AnthropicMessages);
+        assert_eq!(opus_5.context_window, 1_000_000);
+        assert_eq!(opus_5.max_tokens, 64_000);
+        assert_eq!(opus_5.cost.input_per_million, 5.0);
+        assert_eq!(opus_5.cost.output_per_million, 25.0);
+        // Derived rates: cache reads bill at 0.1x input, writes at 1.25x.
+        assert_eq!(opus_5.cost.cache_read_per_million, 0.5);
+        assert_eq!(opus_5.cost.cache_write_per_million, 6.25);
 
         let opus = ModelConfig::claude_opus_4_8();
         assert_eq!(opus.id, "claude-opus-4-8");


### PR DESCRIPTION
Closes #85.

## What

Adds `ModelConfig::claude_opus_5()`. Consumers mapping model strings to presets had no constructor for `claude-opus-5` and fell through to the generic `ModelConfig::anthropic()`, losing cost tracking and context metadata.

| Field | Value |
|---|---|
| `id` / `name` | `claude-opus-5` / `Claude Opus 5` |
| `context_window` | 1,000,000 |
| `max_tokens` | 64,000 (of the model's 128K ceiling) |
| `cost` | $5 / $25 per M in/out; $0.50 / $6.25 cache read/write |

## Decisions on the issue's two open points

- **Cache rates confirmed.** $0.50 / $6.25 are the standard 0.1x / 1.25x multiples of the $5 input rate, matching what `claude_opus_4_8()` already carries — Opus 5 ships at Opus 4.8's pricing.
- **`max_tokens` kept at 64K.** The issue floated raising it for thinking headroom, but `claude_fable_5()` is the closest analogue (1M context, 128K ceiling, thinking always on) and uses 64K. Diverging would make Opus 5 the only preset with a different fraction of its ceiling; callers wanting the full 128K can set it per-config.

## Thinking behavior

No new compat flag was needed — Opus 5 accepts the same adaptive-thinking encoding as Opus 4.7/4.8, which `AnthropicCompat::default()` already emits whenever a thinking level is set.

Worth knowing: **`ThinkingLevel::Off` does not disable thinking on Opus 5.** The provider omits the `thinking` field rather than sending `{"type": "disabled"}` (`anthropic.rs:515`), and Opus 5 thinks server-side when the field is absent — so those tokens still bill against `max_tokens`. This diverges from the otherwise byte-identical `claude_opus_4_8()`, so it's documented on the preset.

The issue's warning about `{"type":"disabled"}` + `xhigh`/`max` effort returning a 400 is unreachable here: `output_config.effort` is emitted at exactly one site, *inside* the thinking branch, so the loop structurally cannot produce that combination.

## Also

Adds Opus 5 to the two adaptive-thinking enumerations that went stale once it gained a first-class preset — the `AnthropicCompat::adaptive_thinking` field docs and `docs/providers/anthropic.md`. These are the only two such sites repo-wide.

## Testing

`test_new_generation_presets` extended with id, protocol, context window, `max_tokens`, and all four cost rates. The cache-rate assertions follow the newer `meta_preset_matches_launch_specs` precedent (#69) rather than the older convention in that test, since a zeroed cache rate is a silent cost under-report that `is_configured()` (an OR across all four rates) would not catch.

`cargo fmt --check`, `cargo clippy --all-targets` under `-Dwarnings`, `cargo doc --no-deps`, and all 18 test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)