### PR TITLE
release: 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.13.2
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Version bump for the `ModelConfig::claude_opus_5()` preset (#85, merged in #86).

- `Cargo.toml`: `0.13.1` → `0.13.2`
- `CHANGELOG.md`: `## Unreleased` → `## 0.13.2`

Patch bump per maintainer's call. Worth noting for the record: the change adds a new public constructor, which under semver would normally warrant a minor bump — downstream crates pinning `0.13.x` will pick this up automatically.

Merging this triggers the tag + GitHub Release, which in turn fires `.github/workflows/publish.yml` to publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)