### PR TITLE
release: 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.13.3
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Version bump for the three fixes reported by @markokocic, merged in #88.

- `Cargo.toml`: `0.13.2` → `0.13.3`
- `CHANGELOG.md`: `## Unreleased` → `## 0.13.3`

Fixes #81 (provider attribution), #83 (SSE truncation retry), #84 (Agent drop), plus the review follow-ups: the `saw_stop_reason` guard, the `response.incomplete`/`response.failed` re-bill, and the `message_delta` usage-field parse failure.

One behavior change is called out in the changelog rather than buried: **a dropped `Agent` now kills its run.** Callers must keep the `Agent` alive until the receiver is drained; dropping early closes the channel without an `AgentEnd` event. It logs a warning when this happens.

Merging this triggers the tag + GitHub Release, which fires `publish.yml` to publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)