### PR TITLE
feat: MCP HttpTransport handles Streamable HTTP responses (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+- **MCP `HttpTransport` speaks the request/response subset of Streamable HTTP**
+  (#82). Servers returning `text/event-stream` — the emerging MCP standard, used
+  by exa among others — previously failed with `Response parse error`, because
+  the body was parsed as a single JSON object. `HttpTransport` now parses the
+  JSON-RPC payload out of SSE frames (walking past comments, `event:`/`id:`
+  lines, and unrelated frames), advertises
+  `Accept: application/json, text/event-stream`, captures the `Mcp-Session-Id`
+  assigned on `initialize` and replays it on later requests, releases it with a
+  best-effort `DELETE` on close, and treats `202 Accepted` with an empty body as
+  a success rather than a parse failure. Plain JSON-RPC bodies take the same
+  path they always did.
+
+  No API changes: `McpTransport` is unchanged, `HttpTransport`'s fields were
+  already private, and `McpClient::connect_http` is untouched. The `GET`
+  server→client stream and `Last-Event-ID` resumability are out of scope —
+  `McpTransport` is request/response, so a server-initiated message has nowhere
+  to go, and supporting it would need a different trait.
+
+  Reported by @markokocic.
+
 ## 0.13.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,40 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **MCP `HttpTransport` speaks the request/response subset of Streamable HTTP**
-  (#82). Servers returning `text/event-stream` — the emerging MCP standard, used
-  by exa among others — previously failed with `Response parse error`, because
-  the body was parsed as a single JSON object. `HttpTransport` now parses the
-  JSON-RPC payload out of SSE frames (walking past comments, `event:`/`id:`
-  lines, and unrelated frames), advertises
-  `Accept: application/json, text/event-stream`, captures the `Mcp-Session-Id`
-  assigned on `initialize` and replays it on later requests, releases it with a
-  best-effort `DELETE` on close, and treats `202 Accepted` with an empty body as
-  a success rather than a parse failure. Plain JSON-RPC bodies take the same
-  path they always did.
+  (#82). Servers that answer a POST with a `text/event-stream` body — the
+  transport introduced in MCP revision 2025-03-26 — previously failed with
+  `Response parse error`, because the body was parsed as a single JSON object.
 
-  No API changes: `McpTransport` is unchanged, `HttpTransport`'s fields were
-  already private, and `McpClient::connect_http` is untouched. The `GET`
-  server→client stream and `Last-Event-ID` resumability are out of scope —
-  `McpTransport` is request/response, so a server-initiated message has nowhere
-  to go, and supporting it would need a different trait.
+  `HttpTransport` now parses the JSON-RPC payload out of SSE events (joining
+  each event's `data:` lines per the SSE spec), advertises
+  `Accept: application/json, text/event-stream`, captures the `Mcp-Session-Id`
+  the server assigns and replays it on later requests, releases it with a
+  best-effort `DELETE` on `McpClient::close()`, and treats `202`/`204` with an
+  empty body as an acknowledgement rather than a parse failure.
+
+  Response selection is structural, not "first frame that parses": a frame is
+  this request's response only if it carries no `method`, carries a `result` or
+  an `error`, and its id matches. That matters because every field of
+  `JsonRpcResponse` except `jsonrpc` is optional, so the `notifications/progress`
+  and `notifications/message` frames a server emits *ahead of* the result
+  deserialize into an empty response — accepting the first frame that parsed
+  would have returned the notification and discarded the answer.
+
+  Diagnostics improve alongside: a non-2xx now carries the server's explanation
+  instead of a bare status, an empty 2xx that is not an acknowledgement is
+  reported rather than dressed up as success, and a `404` on a session-bearing
+  request clears the dead session and says it expired instead of failing every
+  later call with what looks like a bad URL.
+
+  No API-surface changes — `McpTransport` is unchanged, `HttpTransport`'s fields
+  were already private, and `McpClient::connect_http` is untouched. Behavior on
+  the wire does change: every POST now carries an `Accept` header (plus
+  `Mcp-Session-Id` once assigned), and `close()` went from a pure no-op to a
+  network round-trip.
+
+  Not covered: the `GET` server→client stream and `Last-Event-ID` resumability.
+  `McpTransport` is `send`/`close` only, so a server-initiated message has
+  nowhere to be delivered.
 
   Reported by @markokocic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ adheres to [Semantic Versioning](https://semver.org/).
   `Mcp-Session-Id` once assigned), and `close()` went from a pure no-op to a
   network round-trip.
 
+  The body is parsed incrementally: a call returns at the frame carrying its
+  response rather than at end-of-stream, so a server that holds the POST stream
+  open after answering (which the spec permits) does not block it, and a long
+  `tools/call` streaming progress frames returns the moment its result lands.
+
   Not covered: the `GET` server→client stream and `Last-Event-ID` resumability.
   `McpTransport` is `send`/`close` only, so a server-initiated message has
   nowhere to be delivered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,16 +34,20 @@ adheres to [Semantic Versioning](https://semver.org/).
   request clears the dead session and says it expired instead of failing every
   later call with what looks like a bad URL.
 
+  The body is parsed incrementally: a call returns at the blank-line-terminated
+  frame carrying its response rather than at end-of-stream, so a server that
+  holds the POST stream open after answering does not block it, and a long
+  `tools/call` streaming progress frames returns the moment its result lands. A
+  stalled server is bounded by an idle read timeout (120s, reset on every read,
+  so a slow-but-progressing call is never cut off) rather than hanging.
+
   No API-surface changes — `McpTransport` is unchanged, `HttpTransport`'s fields
   were already private, and `McpClient::connect_http` is untouched. Behavior on
   the wire does change: every POST now carries an `Accept` header (plus
-  `Mcp-Session-Id` once assigned), and `close()` went from a pure no-op to a
-  network round-trip.
-
-  The body is parsed incrementally: a call returns at the frame carrying its
-  response rather than at end-of-stream, so a server that holds the POST stream
-  open after answering (which the spec permits) does not block it, and a long
-  `tools/call` streaming progress frames returns the moment its result lands.
+  `Mcp-Session-Id` once assigned), `close()` went from a pure no-op to a network
+  round-trip, and returning mid-body means an SSE response forgoes connection
+  reuse unless the server had already closed the body — a fresh connection, and
+  TLS handshake, on the next call to such a server.
 
   Not covered: the `GET` server→client stream and `Last-Event-ID` resumability.
   `McpTransport` is `send`/`close` only, so a server-initiated message has

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -80,13 +80,18 @@ an SSE-framed response and then close the stream:
   reported as an error, since it usually means a proxy answered instead of the
   MCP server.
 
+- The body is parsed incrementally, so a call returns at the frame carrying its
+  response rather than at end-of-stream. A server that holds the POST stream
+  open after answering — which Streamable HTTP permits — does not block it.
+
 **Not supported:** the `GET` server→client stream and `Last-Event-ID`
 resumability. `McpTransport` is `send`/`close` only, with nowhere to deliver a
 server-initiated message — supporting them would mean growing the trait an
-inbound channel. Note also that the response body is read to completion, so a
-server that holds the POST stream open after answering will block rather than
-return, and the handshake still negotiates `protocolVersion: 2024-11-05` (the
-revision predating Streamable HTTP), which servers generally accept.
+inbound channel. Notifications arriving on the POST stream *before* the response
+are read and skipped; any that trail it are not, since the call has already
+returned. Note also that the handshake still negotiates
+`protocolVersion: 2024-11-05` (the revision predating Streamable HTTP), which
+servers generally accept.
 
 `McpClient::close()` is what sends the `DELETE`. `Agent::with_mcp_server_http`
 does not call it, so sessions opened that way are released by the server's own

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -5,7 +5,8 @@
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is a JSON-RPC 2.0 protocol that lets AI agents discover and call tools from external servers. It defines a standard way for agents to connect to tool providers over two transports:
 
 - **Stdio** — spawn a child process, communicate via stdin/stdout (newline-delimited JSON)
-- **HTTP** — POST JSON-RPC requests to an HTTP endpoint
+- **HTTP** — POST JSON-RPC requests to an HTTP endpoint, including the
+  request/response subset of Streamable HTTP
 
 ## Connecting to MCP Servers
 
@@ -56,6 +57,25 @@ let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Claude
     .with_mcp_server_http("http://localhost:8080/mcp")
     .await?;
 ```
+
+`HttpTransport` handles both the plain JSON-RPC-over-POST shape and the
+**request/response subset of Streamable HTTP**:
+
+- Responses framed as `text/event-stream` are parsed out of their SSE frames,
+  so servers following the Streamable HTTP spec work without a custom transport.
+- Requests advertise `Accept: application/json, text/event-stream`, letting the
+  server pick its framing.
+- An `Mcp-Session-Id` returned on `initialize` is captured and replayed on every
+  later request, and released with a `DELETE` when the client closes. Servers
+  that reject `DELETE` are tolerated — teardown is best-effort.
+- `202 Accepted` with an empty body (how notifications are acknowledged) is a
+  success, not a parse failure.
+
+**Not supported:** the `GET` server→client stream and `Last-Event-ID`
+resumability. `McpTransport` is strictly request/response, so a server-initiated
+message has nowhere to be delivered — those would need a different transport
+trait. In practice this only matters for servers that push notifications
+unprompted; ordinary tool discovery and invocation are unaffected.
 
 ## How MCP Tools Work
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -60,7 +60,7 @@ let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Claude
 
 `HttpTransport` handles both the plain JSON-RPC-over-POST shape and the
 **request/response subset of Streamable HTTP** — servers that answer a POST with
-an SSE-framed response and then close the stream:
+an SSE-framed response, whether or not they then close the stream:
 
 - Responses framed as `text/event-stream` are parsed out of their SSE frames,
   joining each event's `data:` lines as the SSE spec requires.
@@ -79,19 +79,25 @@ an SSE-framed response and then close the stream:
   acknowledged — is a success, not a parse failure. Any *other* empty 2xx is
   reported as an error, since it usually means a proxy answered instead of the
   MCP server.
-
-- The body is parsed incrementally, so a call returns at the frame carrying its
-  response rather than at end-of-stream. A server that holds the POST stream
-  open after answering — which Streamable HTTP permits — does not block it.
+- The body is parsed incrementally, so a call returns at the blank-line-terminated
+  frame carrying its response rather than at end-of-stream. A server that holds
+  the POST stream open after answering does not block it. Two trade-offs come
+  with that: returning mid-body forgoes connection reuse (a fresh connection,
+  and TLS handshake, on the next call to such a server), and a plain JSON-RPC
+  body has no frames to return early at, so it is read to the end as before.
+- A stalled server — one that accepts the POST then sends nothing — is bounded
+  by an idle read timeout (120s) rather than hanging. The timer resets on every
+  read, so a long `tools/call` streaming progress frames is never cut off.
 
 **Not supported:** the `GET` server→client stream and `Last-Event-ID`
 resumability. `McpTransport` is `send`/`close` only, with nowhere to deliver a
 server-initiated message — supporting them would mean growing the trait an
 inbound channel. Notifications arriving on the POST stream *before* the response
 are read and skipped; any that trail it are not, since the call has already
-returned. Note also that the handshake still negotiates
-`protocolVersion: 2024-11-05` (the revision predating Streamable HTTP), which
-servers generally accept.
+returned — so a server that blocks awaiting a reply to a `sampling/createMessage`
+it sent on this stream will time out rather than be answered. Note also that the
+handshake still negotiates `protocolVersion: 2024-11-05` (the revision predating
+Streamable HTTP), which servers generally accept.
 
 `McpClient::close()` is what sends the `DELETE`. `Agent::with_mcp_server_http`
 does not call it, so sessions opened that way are released by the server's own

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -59,23 +59,38 @@ let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Claude
 ```
 
 `HttpTransport` handles both the plain JSON-RPC-over-POST shape and the
-**request/response subset of Streamable HTTP**:
+**request/response subset of Streamable HTTP** — servers that answer a POST with
+an SSE-framed response and then close the stream:
 
 - Responses framed as `text/event-stream` are parsed out of their SSE frames,
-  so servers following the Streamable HTTP spec work without a custom transport.
+  joining each event's `data:` lines as the SSE spec requires.
+- A server may interleave `notifications/progress` and `notifications/message`
+  frames ahead of the result — that is how it reports progress during a
+  `tools/call`. Those are skipped: a frame is this request's response only if it
+  carries no `method`, carries a `result` or an `error`, and its id matches.
 - Requests advertise `Accept: application/json, text/event-stream`, letting the
   server pick its framing.
-- An `Mcp-Session-Id` returned on `initialize` is captured and replayed on every
-  later request, and released with a `DELETE` when the client closes. Servers
-  that reject `DELETE` are tolerated — teardown is best-effort.
-- `202 Accepted` with an empty body (how notifications are acknowledged) is a
-  success, not a parse failure.
+- An `Mcp-Session-Id` returned by the server is captured and replayed on every
+  later request, and released with a `DELETE` on `McpClient::close()`. Servers
+  that reject `DELETE` are tolerated — teardown is best-effort. A `404` on a
+  session-bearing request clears the session and reports that it expired, so a
+  caller can rebuild the client.
+- `202 Accepted` (or `204`) with an empty body — how a notification is
+  acknowledged — is a success, not a parse failure. Any *other* empty 2xx is
+  reported as an error, since it usually means a proxy answered instead of the
+  MCP server.
 
 **Not supported:** the `GET` server→client stream and `Last-Event-ID`
-resumability. `McpTransport` is strictly request/response, so a server-initiated
-message has nowhere to be delivered — those would need a different transport
-trait. In practice this only matters for servers that push notifications
-unprompted; ordinary tool discovery and invocation are unaffected.
+resumability. `McpTransport` is `send`/`close` only, with nowhere to deliver a
+server-initiated message — supporting them would mean growing the trait an
+inbound channel. Note also that the response body is read to completion, so a
+server that holds the POST stream open after answering will block rather than
+return, and the handshake still negotiates `protocolVersion: 2024-11-05` (the
+revision predating Streamable HTTP), which servers generally accept.
+
+`McpClient::close()` is what sends the `DELETE`. `Agent::with_mcp_server_http`
+does not call it, so sessions opened that way are released by the server's own
+timeout rather than explicitly.
 
 ## How MCP Tools Work
 

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -3,7 +3,7 @@
 use super::types::*;
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
@@ -122,21 +122,31 @@ impl McpTransport for StdioTransport {
 /// Communicates with an MCP server via HTTP POST (JSON-RPC over HTTP).
 ///
 /// Covers the **request/response subset of Streamable HTTP** — servers that
-/// answer a POST with an SSE-framed response and then close the stream:
-/// `text/event-stream` bodies, `Mcp-Session-Id` capture and replay, `202`/`204`
-/// acknowledgements, and session teardown on [`close`](McpTransport::close).
-/// Plain JSON-RPC bodies keep working.
+/// answer a POST with an SSE-framed response, whether or not they then close
+/// the stream: `text/event-stream` bodies, `Mcp-Session-Id` capture and replay,
+/// `202`/`204` acknowledgements, and session teardown on
+/// [`close`](McpTransport::close). Plain JSON-RPC bodies keep working.
 ///
 /// The body is parsed incrementally and [`send`](McpTransport::send) returns at
-/// the frame carrying this request's response, so a server that keeps the POST
-/// stream open after answering does not block the call.
+/// the blank-line-terminated frame carrying this request's response, so a
+/// server that keeps the POST stream open after answering does not block the
+/// call. Two consequences worth knowing: returning mid-body forgoes connection
+/// reuse (a server that has not already closed the body costs a fresh
+/// connection, and TLS handshake, next call), and a plain JSON-RPC body has no
+/// frames to return early at, so it is read to the end as before.
+///
+/// A stalled server — one that accepts the POST and then sends nothing — is
+/// bounded by an idle read timeout (120s) rather than hanging. The timer resets
+/// on every read, so a slow-but-progressing call is never cut off.
 ///
 /// Not covered: the `GET` server→client stream and `Last-Event-ID`
 /// resumability. [`McpTransport`] is `send`/`close` only, so a server-initiated
 /// message has nowhere to be delivered — supporting them would mean growing the
 /// trait an inbound channel. Notifications that arrive on the POST stream
 /// *before* the response are read and skipped; any that trail it are not, since
-/// the call has already returned by then.
+/// the call has already returned by then. A server that blocks awaiting a reply
+/// to a `sampling/createMessage` it sent on this stream will therefore time out
+/// rather than be answered.
 pub struct HttpTransport {
     client: reqwest::Client,
     base_url: String,
@@ -146,9 +156,22 @@ pub struct HttpTransport {
 }
 
 impl HttpTransport {
+    /// Idle bound between reads, not a bound on the whole call.
+    ///
+    /// A `tools/call` may legitimately run for minutes; what must not be
+    /// tolerated is a server that accepts the POST and then sends *nothing*.
+    /// `read_timeout` resets on every successful read, so a long call that
+    /// streams progress frames keeps its connection alive while a stalled one
+    /// is cut. (A whole-request `timeout` cannot tell those apart, which is why
+    /// it is deliberately not used here.)
+    const READ_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
     /// Create a new HTTP transport.
     pub fn new(url: &str) -> Result<Self, McpError> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .read_timeout(Self::READ_IDLE_TIMEOUT)
+            .build()
+            .map_err(|e| McpError::Transport(format!("Failed to build HTTP client: {e}")))?;
         Ok(Self {
             client,
             base_url: url.trim_end_matches('/').to_string(),
@@ -168,11 +191,11 @@ impl HttpTransport {
     /// notification and silently discard the answer.
     fn response_for(payload: &str, request_id: u64) -> Option<JsonRpcResponse> {
         let value: serde_json::Value = serde_json::from_str(payload).ok()?;
-        // Responses never carry `method`; notifications and server→client
-        // requests always do. Redundant with the result-or-error check below
-        // for every frame shape seen in practice — kept because it states the
-        // JSON-RPC invariant directly, so the next reader does not have to
-        // derive it.
+        // Responses never carry `method`. The result-or-error check below
+        // happens to reject every *well-formed* frame this one does; what this
+        // still catches is a malformed frame carrying both — a server that
+        // conflates the two shapes. Cheap insurance, and pinned by
+        // `frame_with_both_method_and_result_is_not_the_response`.
         if value.get("method").is_some() {
             return None;
         }
@@ -211,60 +234,190 @@ impl HttpTransport {
         (!payload.is_empty()).then_some(payload)
     }
 
-    /// Note a frame that was valid JSON-RPC but not our answer, so a call that
-    /// never finds its response can say what it saw instead.
-    fn note_skipped(payload: &str, method: &str, skipped: &mut Vec<String>) {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
-            let what = match value.get("method").and_then(|m| m.as_str()) {
+    /// Note a frame that was valid JSON-RPC but not our answer.
+    ///
+    /// Counted by kind rather than collected verbatim: this ends up in an error
+    /// string that `McpToolAdapter` hands to the model as a tool result, and a
+    /// progress-heavy stream can emit thousands of identical frame names.
+    /// Reaches a caller only on the EOF path — a mid-stream read error reports
+    /// its own cause instead.
+    fn note_skipped(payload: &str, method: &str, skipped: &mut BTreeMap<String, usize>) {
+        let what = match serde_json::from_str::<serde_json::Value>(payload) {
+            Ok(value) => match value.get("method").and_then(|m| m.as_str()) {
                 Some(m) => m.to_string(),
                 None => match value.get("id").and_then(|i| i.as_u64()) {
                     Some(id) => format!("response for id {id}"),
                     None => "unrecognized JSON-RPC frame".to_string(),
                 },
-            };
-            debug!("skipping SSE frame that is not the response to '{method}': {what}");
-            skipped.push(what);
+            },
+            // No `else`-less `if let` here: a frame that is not valid JSON may
+            // be the server's own answer, truncated mid-write. Dropping it
+            // unrecorded is how that becomes undiagnosable.
+            Err(e) => {
+                warn!(
+                    "SSE frame on '{method}' is not valid JSON ({} bytes): {e}; \
+                     a truncated frame may be the server's real answer",
+                    payload.len()
+                );
+                format!("malformed non-JSON frame ({} bytes)", payload.len())
+            }
+        };
+        debug!("skipping SSE frame that is not the response to '{method}': {what}");
+        *skipped.entry(what).or_default() += 1;
+    }
+
+    /// Render the skipped-frame tally for an error message.
+    fn describe_skipped(skipped: &BTreeMap<String, usize>) -> String {
+        if skipped.is_empty() {
+            return String::new();
         }
+        let total: usize = skipped.values().sum();
+        let listed: Vec<String> = skipped
+            .iter()
+            .take(10)
+            .map(|(what, n)| {
+                if *n > 1 {
+                    format!("{what} x{n}")
+                } else {
+                    what.clone()
+                }
+            })
+            .collect();
+        let more = skipped.len().saturating_sub(listed.len());
+        let tail = if more > 0 {
+            format!(", and {more} other kind(s)")
+        } else {
+            String::new()
+        };
+        format!(" (skipped {total} frame(s): {}{tail})", listed.join(", "))
+    }
+
+    /// Decode an event slice, refusing rather than substituting on bad UTF-8.
+    ///
+    /// Lossy decoding would replace invalid bytes with U+FFFD, and since that
+    /// is legal JSON string content the frame would go on to parse and be
+    /// returned as a successful — but silently mutated — tool result.
+    fn decode(bytes: &[u8], method: &str) -> Result<String, McpError> {
+        std::str::from_utf8(bytes).map(str::to_owned).map_err(|e| {
+            McpError::Transport(format!(
+                "invalid UTF-8 in the response body on '{method}' at byte {}: {e}",
+                e.valid_up_to()
+            ))
+        })
     }
 
     /// Read the response body, returning as soon as this request's answer
     /// arrives rather than draining to EOF.
     ///
     /// The early return is the point: Streamable HTTP permits a server to keep
-    /// the POST stream open after answering (to deliver further notifications),
-    /// so buffering the whole body would block until the server gave up. It
-    /// also means a long `tools/call` that streams progress frames returns the
-    /// moment the result lands, instead of waiting out the trailing traffic.
+    /// the POST stream open after answering, so buffering the whole body would
+    /// block until the server gave up. It also means a long `tools/call` that
+    /// streams progress frames returns the moment the result lands, instead of
+    /// waiting out the trailing traffic.
     ///
-    /// A plain JSON-RPC body has no event boundaries, so it falls through to
-    /// the whole-body parse at EOF — the same result as before, and the shape
-    /// that made `resp.json()` sufficient until now.
+    /// Two costs come with it, both deliberate. Returning mid-body prevents the
+    /// connection from being pooled, so a server that has not already closed
+    /// the body costs a fresh connection (and TLS handshake) on the next call.
+    /// And the early return only fires on a **blank-line-terminated** frame: an
+    /// unterminated final event is recovered at EOF instead, so a server that
+    /// neither terminates the frame nor closes the stream is bounded by the
+    /// client's read timeout rather than returning promptly.
+    ///
+    /// A plain JSON-RPC body yields no `data:`-prefixed lines — a raw newline is
+    /// illegal inside a JSON string, so no line can begin mid-string — and so
+    /// never produces an event payload. It falls through to the whole-body parse
+    /// at EOF. Note this reverses the previous ordering: JSON bodies now
+    /// traverse the SSE scan first.
     async fn read_response(
         resp: reqwest::Response,
         request_id: u64,
         method: &str,
         status: reqwest::StatusCode,
     ) -> Result<JsonRpcResponse, McpError> {
+        // Both `application/json` and `text/event-stream` mandate UTF-8, and
+        // reading the body as a byte stream gives up the charset transcoding
+        // `Response::text()` would have done. Refuse a declared non-UTF-8
+        // charset rather than hand back mangled text.
+        if let Some(charset) = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|ct| {
+                ct.split(';').skip(1).find_map(|p| {
+                    p.trim()
+                        .strip_prefix("charset=")
+                        .map(|c| c.trim_matches('"').to_ascii_lowercase())
+                })
+            })
+        {
+            if !matches!(charset.as_str(), "utf-8" | "utf8" | "us-ascii" | "ascii") {
+                return Err(McpError::Transport(format!(
+                    "unsupported charset '{charset}' on '{method}': MCP bodies are UTF-8 \
+                     (both application/json and text/event-stream mandate it)"
+                )));
+            }
+        }
+
         // Scanning happens on bytes, not text: a chunk boundary can split a
         // multi-byte character, and decoding each chunk independently would
-        // corrupt it. Whole events decode cleanly.
+        // corrupt it. Whole events decode cleanly, and 0x0D can never appear
+        // inside a multi-byte sequence (continuation bytes are >= 0x80), which
+        // is what makes the CR normalization below safe to do pre-decode.
+        //
+        // `buf` is never compacted — `scanned` is a read cursor — so a stream
+        // of discarded progress frames is retained for the life of the call.
         let mut buf: Vec<u8> = Vec::new();
         let mut scanned = 0usize;
-        let mut skipped: Vec<String> = Vec::new();
+        // Boundary-free below this point; a new 2-byte window can only be
+        // completed by a newly-appended byte. Without it, a body with no
+        // boundary (a plain JSON body, or one large SSE frame) rescans
+        // everything on every chunk — quadratic, and seconds of CPU on a
+        // multi-megabyte result.
+        let mut searched = 0usize;
+        let mut skipped: BTreeMap<String, usize> = BTreeMap::new();
+        let mut pending_cr = false;
         let mut stream = resp.bytes_stream();
 
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| {
-                McpError::Transport(format!("Response read error on '{method}': {e}"))
+                McpError::Transport(format!(
+                    "Response read error on '{method}' after {} byte(s){}: {e}",
+                    buf.len(),
+                    Self::describe_skipped(&skipped)
+                ))
             })?;
-            // Drop CR so event boundaries are plain `\n\n` whichever framing the
-            // server uses. A raw CR is illegal inside a JSON string, so this
-            // cannot corrupt a payload.
-            buf.extend(chunk.iter().copied().filter(|b| *b != b'\r'));
 
-            while let Some(pos) = buf[scanned..].windows(2).position(|w| w == b"\n\n") {
-                let event = String::from_utf8_lossy(&buf[scanned..scanned + pos]).into_owned();
-                scanned += pos + 2;
+            // SSE accepts CRLF, LF, or a bare CR as a line terminator.
+            // Normalize all three to LF so boundaries are plain `\n\n`.
+            // `pending_cr` carries the state across a chunk that ends mid-CRLF.
+            // Within a JSON payload a raw CR is legal only as inter-token
+            // whitespace (it is illegal unescaped inside a string, and a `\r`
+            // escape is two ASCII bytes), so rewriting it cannot alter a value.
+            for &b in chunk.iter() {
+                if b == b'\r' {
+                    buf.push(b'\n');
+                    pending_cr = true;
+                } else {
+                    if pending_cr && b == b'\n' {
+                        pending_cr = false;
+                        continue;
+                    }
+                    pending_cr = false;
+                    buf.push(b);
+                }
+            }
+
+            loop {
+                let from = scanned.max(searched);
+                let Some(pos) = buf[from..].windows(2).position(|w| w == b"\n\n") else {
+                    // The trailing byte may yet start a boundary.
+                    searched = buf.len().saturating_sub(1);
+                    break;
+                };
+                let end = from + pos;
+                let event = Self::decode(&buf[scanned..end], method)?;
+                scanned = end + 2;
+                searched = scanned;
 
                 let Some(payload) = Self::event_payload(&event) else {
                     continue;
@@ -276,7 +429,11 @@ impl HttpTransport {
             }
         }
 
-        let body = String::from_utf8_lossy(&buf).into_owned();
+        let body = Self::decode(&buf, method)?;
+        // `Response::text()` used to strip a BOM; `from_utf8` does not, and
+        // U+FEFF is not whitespace, so `trim()` leaves it in place to break the
+        // JSON parse below.
+        let body = body.strip_prefix('\u{feff}').unwrap_or(&body).to_string();
 
         if body.trim().is_empty() {
             // 202/204 with no body is how Streamable HTTP acknowledges a
@@ -299,14 +456,14 @@ impl HttpTransport {
             )));
         }
 
-        // Plain JSON-RPC: no event boundaries, so nothing matched above.
+        // Plain JSON-RPC: never yields a `data:` line, so nothing matched above.
         if let Some(response) = Self::response_for(&body, request_id) {
             return Ok(response);
         }
 
         // A final event the server never terminated with a blank line.
         if scanned < buf.len() {
-            let tail = String::from_utf8_lossy(&buf[scanned..]).into_owned();
+            let tail = Self::decode(&buf[scanned..], method)?;
             if let Some(payload) = Self::event_payload(&tail) {
                 if let Some(response) = Self::response_for(&payload, request_id) {
                     return Ok(response);
@@ -315,17 +472,9 @@ impl HttpTransport {
             }
         }
 
-        let seen = if skipped.is_empty() {
-            String::new()
-        } else {
-            format!(
-                " (skipped {} frame(s): {})",
-                skipped.len(),
-                skipped.join(", ")
-            )
-        };
         Err(McpError::Transport(format!(
-            "HTTP {status}: no JSON-RPC response for '{method}' (id {request_id}) in the body{seen}: {}",
+            "HTTP {status}: no JSON-RPC response for '{method}' (id {request_id}) in the body{}: {}",
+            Self::describe_skipped(&skipped),
             body.chars().take(200).collect::<String>()
         )))
     }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -118,9 +118,22 @@ impl McpTransport for StdioTransport {
 // ---------------------------------------------------------------------------
 
 /// Communicates with an MCP server via HTTP POST (JSON-RPC over HTTP).
+///
+/// Covers the **request/response subset of Streamable HTTP**: responses framed
+/// as `text/event-stream`, `Mcp-Session-Id` capture and replay, `202 Accepted`
+/// with no body, and session teardown on [`close`](McpTransport::close). Plain
+/// JSON-RPC bodies keep working unchanged.
+///
+/// Not covered: the `GET` server→client stream and `Last-Event-ID`
+/// resumability. [`McpTransport`] is strictly request/response, so a
+/// server-initiated message has nowhere to be delivered; supporting those would
+/// need a different transport trait.
 pub struct HttpTransport {
     client: reqwest::Client,
     base_url: String,
+    /// Session assigned by the server on `initialize`, replayed on subsequent
+    /// requests. `Mutex` because [`McpTransport::send`] takes `&self`.
+    session_id: Mutex<Option<String>>,
 }
 
 impl HttpTransport {
@@ -130,17 +143,59 @@ impl HttpTransport {
         Ok(Self {
             client,
             base_url: url.trim_end_matches('/').to_string(),
+            session_id: Mutex::new(None),
         })
+    }
+
+    /// Extract a JSON-RPC response from a body that may be raw JSON or SSE.
+    ///
+    /// Tries JSON first so plain JSON-RPC servers take the same path they
+    /// always did. Otherwise walks SSE frames for the first `data:` line that
+    /// parses — servers may interleave comments, `event:`, and `id:` lines.
+    fn parse_body(body: &str) -> Result<JsonRpcResponse, McpError> {
+        if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(body) {
+            return Ok(response);
+        }
+
+        for frame in body.split("\n\n") {
+            for line in frame.lines() {
+                let Some(data) = line
+                    .strip_prefix("data:")
+                    .map(|d| d.trim_start_matches(' ').trim())
+                else {
+                    continue;
+                };
+                if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(data) {
+                    return Ok(response);
+                }
+            }
+        }
+
+        Err(McpError::Transport(format!(
+            "could not parse a JSON-RPC response from the body (tried JSON and SSE frames): {}",
+            body.chars().take(200).collect::<String>()
+        )))
     }
 }
 
 #[async_trait]
 impl McpTransport for HttpTransport {
     async fn send(&self, request: JsonRpcRequest) -> Result<JsonRpcResponse, McpError> {
-        let resp = self
+        let request_id = request.id;
+
+        let mut builder = self
             .client
             .post(&self.base_url)
-            .json(&request)
+            // Streamable HTTP servers pick their framing from this; JSON-only
+            // servers still match `application/json`.
+            .header("Accept", "application/json, text/event-stream")
+            .json(&request);
+
+        if let Some(session) = self.session_id.lock().await.as_ref() {
+            builder = builder.header("Mcp-Session-Id", session);
+        }
+
+        let resp = builder
             .send()
             .await
             .map_err(|e| McpError::Transport(format!("HTTP error: {}", e)))?;
@@ -152,15 +207,51 @@ impl McpTransport for HttpTransport {
             )));
         }
 
-        let response: JsonRpcResponse = resp
-            .json()
+        // The server assigns the session on `initialize`; hold it for the rest
+        // of the connection.
+        if let Some(session) = resp
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+        {
+            *self.session_id.lock().await = Some(session);
+        }
+
+        let body = resp
+            .text()
             .await
-            .map_err(|e| McpError::Transport(format!("Response parse error: {}", e)))?;
-        Ok(response)
+            .map_err(|e| McpError::Transport(format!("Response read error: {}", e)))?;
+
+        // 202 Accepted with no body is how Streamable HTTP acknowledges a
+        // notification. There is no JSON-RPC response to return, so synthesize
+        // an empty success rather than fail a call that did succeed.
+        if body.trim().is_empty() {
+            return Ok(JsonRpcResponse {
+                jsonrpc: "2.0".into(),
+                id: Some(request_id),
+                result: None,
+                error: None,
+            });
+        }
+
+        Self::parse_body(&body)
     }
 
     async fn close(&self) -> Result<(), McpError> {
-        // HTTP is stateless; nothing to close.
+        // Without a session there is nothing server-side to release.
+        let session = self.session_id.lock().await.take();
+        if let Some(session) = session {
+            // Best-effort: session teardown is optional in the spec and plenty
+            // of servers reject DELETE. Failing close() over it would turn a
+            // successful run into an error.
+            let _ = self
+                .client
+                .delete(&self.base_url)
+                .header("Mcp-Session-Id", session)
+                .send()
+                .await;
+        }
         Ok(())
     }
 }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
+use tracing::{debug, warn};
 
 /// Transport trait for MCP communication.
 #[async_trait]
@@ -119,15 +120,19 @@ impl McpTransport for StdioTransport {
 
 /// Communicates with an MCP server via HTTP POST (JSON-RPC over HTTP).
 ///
-/// Covers the **request/response subset of Streamable HTTP**: responses framed
-/// as `text/event-stream`, `Mcp-Session-Id` capture and replay, `202 Accepted`
-/// with no body, and session teardown on [`close`](McpTransport::close). Plain
-/// JSON-RPC bodies keep working unchanged.
+/// Covers the **request/response subset of Streamable HTTP** — servers that
+/// answer a POST with an SSE-framed response and then close the stream:
+/// `text/event-stream` bodies, `Mcp-Session-Id` capture and replay, `202`/`204`
+/// acknowledgements, and session teardown on [`close`](McpTransport::close).
+/// Plain JSON-RPC bodies keep working.
 ///
 /// Not covered: the `GET` server→client stream and `Last-Event-ID`
-/// resumability. [`McpTransport`] is strictly request/response, so a
-/// server-initiated message has nowhere to be delivered; supporting those would
-/// need a different transport trait.
+/// resumability. [`McpTransport`] is `send`/`close` only, so a server-initiated
+/// message has nowhere to be delivered — supporting them would mean growing the
+/// trait an inbound channel.
+///
+/// The body is read to completion, so a server that holds the POST stream open
+/// after answering will block rather than return.
 pub struct HttpTransport {
     client: reqwest::Client,
     base_url: String,
@@ -147,32 +152,113 @@ impl HttpTransport {
         })
     }
 
-    /// Extract a JSON-RPC response from a body that may be raw JSON or SSE.
+    /// Decide whether `payload` is *this request's* JSON-RPC response.
     ///
-    /// Tries JSON first so plain JSON-RPC servers take the same path they
-    /// always did. Otherwise walks SSE frames for the first `data:` line that
-    /// parses — servers may interleave comments, `event:`, and `id:` lines.
-    fn parse_body(body: &str) -> Result<JsonRpcResponse, McpError> {
-        if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(body) {
+    /// Selection is structural rather than "does it deserialize". Every field
+    /// of [`JsonRpcResponse`] except `jsonrpc` is optional and unknown keys are
+    /// ignored, so a server→client notification like
+    /// `{"jsonrpc":"2.0","method":"notifications/progress",...}` deserializes
+    /// cleanly into an all-`None` shell. Streamable HTTP servers routinely emit
+    /// progress and logging notifications on the POST stream *ahead of* the
+    /// result, so accepting the first thing that parses would return the
+    /// notification and silently discard the answer.
+    fn response_for(payload: &str, request_id: u64) -> Option<JsonRpcResponse> {
+        let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+        // Responses never carry `method`; notifications and server→client
+        // requests always do. Redundant with the result-or-error check below
+        // for every frame shape seen in practice — kept because it states the
+        // JSON-RPC invariant directly, so the next reader does not have to
+        // derive it.
+        if value.get("method").is_some() {
+            return None;
+        }
+        // A response carries a result or an error. This is the check that also
+        // rejects a bare `{"jsonrpc":"2.0","id":N}` ack, which carries no
+        // method and would otherwise pass.
+        if value.get("result").is_none() && value.get("error").is_none() {
+            return None;
+        }
+        let response: JsonRpcResponse = serde_json::from_value(value).ok()?;
+        // Correlate. An absent id is tolerated: JSON-RPC allows a null id on
+        // errors the server could not attribute to a request.
+        if response.id.is_some_and(|id| id != request_id) {
+            return None;
+        }
+        Some(response)
+    }
+
+    /// Extract this request's response from a body that may be raw JSON or SSE.
+    ///
+    /// Tries the whole body as JSON first so a plain JSON-RPC body never enters
+    /// the SSE walk. Note this is `text()`-then-parse rather than the previous
+    /// `resp.json()`: the body is now charset-decoded, which sniffs a BOM and
+    /// replaces invalid UTF-8 rather than erroring.
+    ///
+    /// Otherwise walks SSE events, joining each event's `data:` lines with
+    /// newlines as the SSE spec requires, and skipping comments, `event:`, and
+    /// `id:` lines.
+    fn parse_body(
+        body: &str,
+        request_id: u64,
+        method: &str,
+        status: reqwest::StatusCode,
+    ) -> Result<JsonRpcResponse, McpError> {
+        // Normalize CRLF so event splitting works on `\r\n\r\n` too.
+        let body = body.replace("\r\n", "\n");
+
+        if let Some(response) = Self::response_for(&body, request_id) {
             return Ok(response);
         }
 
-        for frame in body.split("\n\n") {
-            for line in frame.lines() {
-                let Some(data) = line
-                    .strip_prefix("data:")
-                    .map(|d| d.trim_start_matches(' ').trim())
-                else {
-                    continue;
+        // Frames that were valid JSON-RPC but not our answer, kept for the
+        // error message — a stalled call is otherwise undiagnosable.
+        let mut skipped: Vec<String> = Vec::new();
+
+        for event in body.split("\n\n") {
+            let data: Vec<&str> = event
+                .lines()
+                .filter_map(|line| {
+                    line.strip_prefix("data:")
+                        .map(|d| d.trim_start_matches(' '))
+                })
+                .collect();
+            if data.is_empty() {
+                continue;
+            }
+            let payload = data.join("\n");
+            let payload = payload.trim();
+            if payload.is_empty() {
+                continue;
+            }
+
+            if let Some(response) = Self::response_for(payload, request_id) {
+                return Ok(response);
+            }
+
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
+                let what = match value.get("method").and_then(|m| m.as_str()) {
+                    Some(m) => m.to_string(),
+                    None => match value.get("id").and_then(|i| i.as_u64()) {
+                        Some(id) => format!("response for id {id}"),
+                        None => "unrecognized JSON-RPC frame".to_string(),
+                    },
                 };
-                if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(data) {
-                    return Ok(response);
-                }
+                debug!("skipping SSE frame that is not the response to '{method}': {what}");
+                skipped.push(what);
             }
         }
 
+        let seen = if skipped.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " (skipped {} frame(s): {})",
+                skipped.len(),
+                skipped.join(", ")
+            )
+        };
         Err(McpError::Transport(format!(
-            "could not parse a JSON-RPC response from the body (tried JSON and SSE frames): {}",
+            "HTTP {status}: no JSON-RPC response for '{method}' (id {request_id}) in the body{seen}: {}",
             body.chars().take(200).collect::<String>()
         )))
     }
@@ -182,6 +268,7 @@ impl HttpTransport {
 impl McpTransport for HttpTransport {
     async fn send(&self, request: JsonRpcRequest) -> Result<JsonRpcResponse, McpError> {
         let request_id = request.id;
+        let method = request.method.clone();
 
         let mut builder = self
             .client
@@ -200,57 +287,103 @@ impl McpTransport for HttpTransport {
             .await
             .map_err(|e| McpError::Transport(format!("HTTP error: {}", e)))?;
 
-        if !resp.status().is_success() {
-            return Err(McpError::Transport(format!(
-                "HTTP {} from server",
-                resp.status()
-            )));
+        let status = resp.status();
+        if !status.is_success() {
+            // Per the spec, 404 on a request carrying a session means the
+            // server dropped it. Keeping the dead id would make every later
+            // call fail identically, with an error that reads like a bad URL.
+            if status == reqwest::StatusCode::NOT_FOUND {
+                if let Some(dead) = self.session_id.lock().await.take() {
+                    warn!(
+                        "MCP session {dead} was rejected (HTTP 404); reconnect to start a new one"
+                    );
+                    return Err(McpError::Transport(format!(
+                        "MCP session expired (HTTP 404 on '{method}'); reconnect to start a new session"
+                    )));
+                }
+            }
+            // Carry the body: servers explain themselves in it, and dropping it
+            // leaves the caller with a bare status to guess from.
+            let body = resp.text().await.unwrap_or_default();
+            let detail = body.trim();
+            return Err(McpError::Transport(if detail.is_empty() {
+                format!("HTTP {status} from server on '{method}'")
+            } else {
+                format!(
+                    "HTTP {status} from server on '{method}': {}",
+                    detail.chars().take(200).collect::<String>()
+                )
+            }));
         }
 
-        // The server assigns the session on `initialize`; hold it for the rest
-        // of the connection.
-        if let Some(session) = resp
-            .headers()
-            .get("mcp-session-id")
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned)
-        {
-            *self.session_id.lock().await = Some(session);
+        // Servers assign the session on `initialize`; any response carrying one
+        // updates it.
+        match resp.headers().get("mcp-session-id").map(|v| v.to_str()) {
+            Some(Ok(session)) => *self.session_id.lock().await = Some(session.to_owned()),
+            // A header we cannot read means every later request goes out
+            // sessionless — the server then rejects them or silently starts a
+            // fresh session, discarding the handshake. Only the operator can
+            // fix that, so say so.
+            Some(Err(e)) => warn!("ignoring unreadable Mcp-Session-Id header: {e}"),
+            None => {}
         }
 
         let body = resp
             .text()
             .await
-            .map_err(|e| McpError::Transport(format!("Response read error: {}", e)))?;
+            .map_err(|e| McpError::Transport(format!("Response read error on '{method}': {e}")))?;
 
-        // 202 Accepted with no body is how Streamable HTTP acknowledges a
-        // notification. There is no JSON-RPC response to return, so synthesize
-        // an empty success rather than fail a call that did succeed.
         if body.trim().is_empty() {
-            return Ok(JsonRpcResponse {
-                jsonrpc: "2.0".into(),
-                id: Some(request_id),
-                result: None,
-                error: None,
-            });
+            // 202/204 with no body is how Streamable HTTP acknowledges a
+            // notification — there is no JSON-RPC response to return, so
+            // synthesize an empty success. Any other empty 2xx is a real
+            // failure (a proxy answering instead of the MCP server, a drained
+            // upstream) and must not be dressed up as one.
+            if status == reqwest::StatusCode::ACCEPTED || status == reqwest::StatusCode::NO_CONTENT
+            {
+                return Ok(JsonRpcResponse {
+                    jsonrpc: "2.0".into(),
+                    id: Some(request_id),
+                    result: None,
+                    error: None,
+                });
+            }
+            return Err(McpError::Transport(format!(
+                "HTTP {status} with an empty body on '{method}' (expected a JSON-RPC response; \
+                 an empty 2xx usually means a proxy or gateway answered instead of the MCP server)"
+            )));
         }
 
-        Self::parse_body(&body)
+        Self::parse_body(&body, request_id, &method, status)
     }
 
     async fn close(&self) -> Result<(), McpError> {
-        // Without a session there is nothing server-side to release.
         let session = self.session_id.lock().await.take();
         if let Some(session) = session {
             // Best-effort: session teardown is optional in the spec and plenty
             // of servers reject DELETE. Failing close() over it would turn a
-            // successful run into an error.
-            let _ = self
+            // successful run into an error. Best-effort is not the same as
+            // unobservable, though — a rejection is fine, but a DELETE that
+            // never reached the server leaks the session there, and that only
+            // surfaces later as an unrelated connect failure.
+            match self
                 .client
                 .delete(&self.base_url)
-                .header("Mcp-Session-Id", session)
+                .header("Mcp-Session-Id", &session)
                 .send()
-                .await;
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {}
+                Ok(resp) => debug!(
+                    "MCP session teardown rejected with HTTP {}; it is optional, continuing",
+                    resp.status()
+                ),
+                Err(e) => warn!(
+                    "MCP session {session} teardown did not reach {}: {e}; \
+                     the session may leak server-side",
+                    self.base_url
+                ),
+            }
         }
         Ok(())
     }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -2,6 +2,7 @@
 
 use super::types::*;
 use async_trait::async_trait;
+use futures::StreamExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -126,13 +127,16 @@ impl McpTransport for StdioTransport {
 /// acknowledgements, and session teardown on [`close`](McpTransport::close).
 /// Plain JSON-RPC bodies keep working.
 ///
+/// The body is parsed incrementally and [`send`](McpTransport::send) returns at
+/// the frame carrying this request's response, so a server that keeps the POST
+/// stream open after answering does not block the call.
+///
 /// Not covered: the `GET` server→client stream and `Last-Event-ID`
 /// resumability. [`McpTransport`] is `send`/`close` only, so a server-initiated
 /// message has nowhere to be delivered — supporting them would mean growing the
-/// trait an inbound channel.
-///
-/// The body is read to completion, so a server that holds the POST stream open
-/// after answering will block rather than return.
+/// trait an inbound channel. Notifications that arrive on the POST stream
+/// *before* the response are read and skipped; any that trail it are not, since
+/// the call has already returned by then.
 pub struct HttpTransport {
     client: reqwest::Client,
     base_url: String,
@@ -187,64 +191,127 @@ impl HttpTransport {
         Some(response)
     }
 
-    /// Extract this request's response from a body that may be raw JSON or SSE.
+    /// Join an SSE event's `data:` lines into its payload, per the SSE spec.
     ///
-    /// Tries the whole body as JSON first so a plain JSON-RPC body never enters
-    /// the SSE walk. Note this is `text()`-then-parse rather than the previous
-    /// `resp.json()`: the body is now charset-decoded, which sniffs a BOM and
-    /// replaces invalid UTF-8 rather than erroring.
+    /// Returns `None` for events that carry no data — comments, bare `event:`
+    /// or `id:` lines, keep-alives.
+    fn event_payload(event: &str) -> Option<String> {
+        let data: Vec<&str> = event
+            .lines()
+            .filter_map(|line| {
+                line.strip_prefix("data:")
+                    .map(|d| d.trim_start_matches(' '))
+            })
+            .collect();
+        if data.is_empty() {
+            return None;
+        }
+        let payload = data.join("\n");
+        let payload = payload.trim().to_string();
+        (!payload.is_empty()).then_some(payload)
+    }
+
+    /// Note a frame that was valid JSON-RPC but not our answer, so a call that
+    /// never finds its response can say what it saw instead.
+    fn note_skipped(payload: &str, method: &str, skipped: &mut Vec<String>) {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
+            let what = match value.get("method").and_then(|m| m.as_str()) {
+                Some(m) => m.to_string(),
+                None => match value.get("id").and_then(|i| i.as_u64()) {
+                    Some(id) => format!("response for id {id}"),
+                    None => "unrecognized JSON-RPC frame".to_string(),
+                },
+            };
+            debug!("skipping SSE frame that is not the response to '{method}': {what}");
+            skipped.push(what);
+        }
+    }
+
+    /// Read the response body, returning as soon as this request's answer
+    /// arrives rather than draining to EOF.
     ///
-    /// Otherwise walks SSE events, joining each event's `data:` lines with
-    /// newlines as the SSE spec requires, and skipping comments, `event:`, and
-    /// `id:` lines.
-    fn parse_body(
-        body: &str,
+    /// The early return is the point: Streamable HTTP permits a server to keep
+    /// the POST stream open after answering (to deliver further notifications),
+    /// so buffering the whole body would block until the server gave up. It
+    /// also means a long `tools/call` that streams progress frames returns the
+    /// moment the result lands, instead of waiting out the trailing traffic.
+    ///
+    /// A plain JSON-RPC body has no event boundaries, so it falls through to
+    /// the whole-body parse at EOF — the same result as before, and the shape
+    /// that made `resp.json()` sufficient until now.
+    async fn read_response(
+        resp: reqwest::Response,
         request_id: u64,
         method: &str,
         status: reqwest::StatusCode,
     ) -> Result<JsonRpcResponse, McpError> {
-        // Normalize CRLF so event splitting works on `\r\n\r\n` too.
-        let body = body.replace("\r\n", "\n");
+        // Scanning happens on bytes, not text: a chunk boundary can split a
+        // multi-byte character, and decoding each chunk independently would
+        // corrupt it. Whole events decode cleanly.
+        let mut buf: Vec<u8> = Vec::new();
+        let mut scanned = 0usize;
+        let mut skipped: Vec<String> = Vec::new();
+        let mut stream = resp.bytes_stream();
 
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                McpError::Transport(format!("Response read error on '{method}': {e}"))
+            })?;
+            // Drop CR so event boundaries are plain `\n\n` whichever framing the
+            // server uses. A raw CR is illegal inside a JSON string, so this
+            // cannot corrupt a payload.
+            buf.extend(chunk.iter().copied().filter(|b| *b != b'\r'));
+
+            while let Some(pos) = buf[scanned..].windows(2).position(|w| w == b"\n\n") {
+                let event = String::from_utf8_lossy(&buf[scanned..scanned + pos]).into_owned();
+                scanned += pos + 2;
+
+                let Some(payload) = Self::event_payload(&event) else {
+                    continue;
+                };
+                if let Some(response) = Self::response_for(&payload, request_id) {
+                    return Ok(response);
+                }
+                Self::note_skipped(&payload, method, &mut skipped);
+            }
+        }
+
+        let body = String::from_utf8_lossy(&buf).into_owned();
+
+        if body.trim().is_empty() {
+            // 202/204 with no body is how Streamable HTTP acknowledges a
+            // notification — there is no JSON-RPC response to return, so
+            // synthesize an empty success. Any other empty 2xx is a real
+            // failure (a proxy answering instead of the MCP server, a drained
+            // upstream) and must not be dressed up as one.
+            if status == reqwest::StatusCode::ACCEPTED || status == reqwest::StatusCode::NO_CONTENT
+            {
+                return Ok(JsonRpcResponse {
+                    jsonrpc: "2.0".into(),
+                    id: Some(request_id),
+                    result: None,
+                    error: None,
+                });
+            }
+            return Err(McpError::Transport(format!(
+                "HTTP {status} with an empty body on '{method}' (expected a JSON-RPC response; \
+                 an empty 2xx usually means a proxy or gateway answered instead of the MCP server)"
+            )));
+        }
+
+        // Plain JSON-RPC: no event boundaries, so nothing matched above.
         if let Some(response) = Self::response_for(&body, request_id) {
             return Ok(response);
         }
 
-        // Frames that were valid JSON-RPC but not our answer, kept for the
-        // error message — a stalled call is otherwise undiagnosable.
-        let mut skipped: Vec<String> = Vec::new();
-
-        for event in body.split("\n\n") {
-            let data: Vec<&str> = event
-                .lines()
-                .filter_map(|line| {
-                    line.strip_prefix("data:")
-                        .map(|d| d.trim_start_matches(' '))
-                })
-                .collect();
-            if data.is_empty() {
-                continue;
-            }
-            let payload = data.join("\n");
-            let payload = payload.trim();
-            if payload.is_empty() {
-                continue;
-            }
-
-            if let Some(response) = Self::response_for(payload, request_id) {
-                return Ok(response);
-            }
-
-            if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
-                let what = match value.get("method").and_then(|m| m.as_str()) {
-                    Some(m) => m.to_string(),
-                    None => match value.get("id").and_then(|i| i.as_u64()) {
-                        Some(id) => format!("response for id {id}"),
-                        None => "unrecognized JSON-RPC frame".to_string(),
-                    },
-                };
-                debug!("skipping SSE frame that is not the response to '{method}': {what}");
-                skipped.push(what);
+        // A final event the server never terminated with a blank line.
+        if scanned < buf.len() {
+            let tail = String::from_utf8_lossy(&buf[scanned..]).into_owned();
+            if let Some(payload) = Self::event_payload(&tail) {
+                if let Some(response) = Self::response_for(&payload, request_id) {
+                    return Ok(response);
+                }
+                Self::note_skipped(&payload, method, &mut skipped);
             }
         }
 
@@ -328,33 +395,7 @@ impl McpTransport for HttpTransport {
             None => {}
         }
 
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| McpError::Transport(format!("Response read error on '{method}': {e}")))?;
-
-        if body.trim().is_empty() {
-            // 202/204 with no body is how Streamable HTTP acknowledges a
-            // notification — there is no JSON-RPC response to return, so
-            // synthesize an empty success. Any other empty 2xx is a real
-            // failure (a proxy answering instead of the MCP server, a drained
-            // upstream) and must not be dressed up as one.
-            if status == reqwest::StatusCode::ACCEPTED || status == reqwest::StatusCode::NO_CONTENT
-            {
-                return Ok(JsonRpcResponse {
-                    jsonrpc: "2.0".into(),
-                    id: Some(request_id),
-                    result: None,
-                    error: None,
-                });
-            }
-            return Err(McpError::Transport(format!(
-                "HTTP {status} with an empty body on '{method}' (expected a JSON-RPC response; \
-                 an empty 2xx usually means a proxy or gateway answered instead of the MCP server)"
-            )));
-        }
-
-        Self::parse_body(&body, request_id, &method, status)
+        Self::read_response(resp, request_id, &method, status).await
     }
 
     async fn close(&self) -> Result<(), McpError> {

--- a/tests/mcp_http_chunking_test.rs
+++ b/tests/mcp_http_chunking_test.rs
@@ -1,0 +1,237 @@
+//! Incremental assembly tests for `HttpTransport`.
+//!
+//! The wiremock suite delivers each body as a single stream item, so it cannot
+//! see anything that depends on where chunk boundaries fall. These drive a raw
+//! TCP server that writes each piece as its own HTTP chunk, which is what makes
+//! the seams observable.
+//!
+//! Separation comes from HTTP chunk framing, not from timing — no sleeps, and a
+//! slower runner makes the pieces *more* separated, not less. Every timeout here
+//! is a failure deadline, never a synchronisation point.
+
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use yoagent::mcp::transport::McpTransport;
+use yoagent::mcp::types::JsonRpcRequest;
+use yoagent::mcp::HttpTransport;
+
+/// Writes each piece as its own HTTP chunk. `terminate` controls whether the
+/// body ever ends; when it does not, only an early return can complete the call.
+///
+/// Write errors are ignored on purpose: the transport hangs up as soon as the
+/// answer lands, so later writes legitimately hit BrokenPipe. Unwrapping there
+/// would panic inside a detached task and print noise that fails nothing.
+async fn serve_pieces(pieces: Vec<Vec<u8>>, terminate: bool) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = format!("http://{}", listener.local_addr().unwrap());
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 4096];
+        let _ = socket.read(&mut buf).await;
+
+        let head = "HTTP/1.1 200 OK\r\n\
+             Content-Type: text/event-stream\r\n\
+             Transfer-Encoding: chunked\r\n\
+             \r\n";
+        let _ = socket.write_all(head.as_bytes()).await;
+        let _ = socket.flush().await;
+
+        for piece in pieces {
+            let _ = socket
+                .write_all(format!("{:x}\r\n", piece.len()).as_bytes())
+                .await;
+            let _ = socket.write_all(&piece).await;
+            let _ = socket.write_all(b"\r\n").await;
+            let _ = socket.flush().await;
+        }
+        if terminate {
+            let _ = socket.write_all(b"0\r\n\r\n").await;
+            let _ = socket.flush().await;
+        }
+        tokio::time::sleep(Duration::from_secs(300)).await;
+    });
+
+    addr
+}
+
+fn split_at(bytes: &[u8], at: usize) -> Vec<Vec<u8>> {
+    vec![bytes[..at].to_vec(), bytes[at..].to_vec()]
+}
+
+/// The classic incremental-parser bug: scanning only the newly arrived bytes
+/// misses a boundary whose two newlines straddle a chunk seam. Since the server
+/// never closes the body here, that bug surfaces as the exact hang this
+/// transport exists to avoid.
+#[tokio::test]
+async fn event_boundary_split_across_chunks_is_still_found() {
+    let request = JsonRpcRequest::new("tools/list", None);
+    let frames = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"tools\":[]}}}}\n\n",
+        request.id
+    );
+    let at = frames.len() - 1;
+    assert_eq!(
+        &frames.as_bytes()[at - 1..at + 1],
+        b"\n\n",
+        "split the boundary"
+    );
+    let addr = serve_pieces(split_at(frames.as_bytes(), at), false).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("a boundary spanning a chunk seam must still be found")
+        .expect("the response must parse");
+
+    assert!(response.result.unwrap()["tools"].is_array());
+}
+
+/// The stated reason scanning happens on bytes rather than text. Decoding each
+/// chunk independently substitutes U+FFFD for the split character — which is
+/// still valid JSON string content, so the frame parses and the corruption is
+/// returned as a success. Only an exact string comparison catches it.
+#[tokio::test]
+async fn multibyte_character_split_across_chunks_is_not_corrupted() {
+    let request = JsonRpcRequest::new("tools/call", None);
+    let text = "café 日本語 🎉";
+    let frames = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"text\":\"{}\"}}}}\n\n",
+        request.id, text
+    );
+    let at = frames.find('日').unwrap() + 1;
+    assert!(
+        !frames.is_char_boundary(at),
+        "split inside a multi-byte char"
+    );
+    let addr = serve_pieces(split_at(frames.as_bytes(), at), false).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("must not hang")
+        .expect("the response must parse");
+
+    assert_eq!(
+        response.result.unwrap()["text"].as_str().unwrap(),
+        text,
+        "a character split across chunks must survive intact"
+    );
+}
+
+/// CRLF framing split mid-sequence: the `\r` ends one chunk and the `\n` begins
+/// the next. Normalizing CR to LF has to carry that state across the seam, or
+/// the boundary is mangled into `\n\n\n` and the event mis-split.
+#[tokio::test]
+async fn crlf_boundary_split_mid_sequence_is_normalized() {
+    let request = JsonRpcRequest::new("tools/list", None);
+    let frames = format!(
+        "event: message\r\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"ok\":true}}}}\r\n\r\n",
+        request.id
+    );
+    // Split between the final \r and its \n.
+    let at = frames.len() - 1;
+    assert_eq!(&frames.as_bytes()[at - 1..at + 1], b"\r\n");
+    let addr = serve_pieces(split_at(frames.as_bytes(), at), false).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("CRLF split across a seam must still frame")
+        .expect("the response must parse");
+
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// SSE permits a bare CR as a line terminator. Deleting CR outright — rather
+/// than normalizing it — collapses such a stream into one unsplittable line and
+/// the response is never found.
+#[tokio::test]
+async fn bare_cr_framing_is_supported() {
+    let request = JsonRpcRequest::new("tools/list", None);
+    let frames = format!(
+        "event: message\rdata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"ok\":true}}}}\r\r",
+        request.id
+    );
+    let addr = serve_pieces(vec![frames.into_bytes()], true).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("must not hang")
+        .expect("bare-CR framing must parse");
+
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// Real servers close without a trailing blank line. The recovery path for that
+/// runs only at EOF, so nothing else exercises it. The leading notification
+/// matters: it advances `scanned`, where an off-by-one in the tail slice shows.
+#[tokio::test]
+async fn unterminated_final_event_after_a_notification_is_parsed() {
+    let request = JsonRpcRequest::new("tools/call", None);
+    let frames = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"ok\":true}}}}\n"
+        ),
+        request.id
+    );
+    let addr = serve_pieces(vec![frames.into_bytes()], true).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("must not hang")
+        .expect("an unterminated final event must be parsed at EOF");
+
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// A connection that dies *after* delivering the answer is a success. This is a
+/// load-bearing property of the early return: any refactor that drains before
+/// returning turns an intermittent server-side disconnect into a tool failure.
+#[tokio::test]
+async fn truncation_after_the_answer_still_succeeds() {
+    let request = JsonRpcRequest::new("tools/list", None);
+    let frames = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"ok\":true}}}}\n\n",
+        request.id
+    );
+    // A bogus chunk header after the answer: the body dies mid-stream.
+    let pieces = vec![frames.into_bytes(), b"garbage-not-a-chunk".to_vec()];
+    let addr = serve_pieces(pieces, false).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("must not hang")
+        .expect("a body that dies after the answer must not fail the call");
+
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// One byte per chunk splits every boundary and every multi-byte character at
+/// once — a backstop for seam handling generally. Less diagnostic than the
+/// targeted tests above when it fails, so it complements them rather than
+/// replacing them.
+#[tokio::test]
+async fn byte_at_a_time_delivery_assembles_correctly() {
+    let request = JsonRpcRequest::new("tools/call", None);
+    let text = "日本語";
+    let frames = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"text\":\"{}\"}}}}\n\n",
+        request.id, text
+    );
+    let pieces: Vec<Vec<u8>> = frames.as_bytes().iter().map(|b| vec![*b]).collect();
+    let addr = serve_pieces(pieces, false).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(20), transport.send(request))
+        .await
+        .expect("must not hang")
+        .expect("the response must parse");
+
+    assert_eq!(response.result.unwrap()["text"].as_str().unwrap(), text);
+}

--- a/tests/mcp_http_streaming_test.rs
+++ b/tests/mcp_http_streaming_test.rs
@@ -1,0 +1,97 @@
+//! Proves `HttpTransport` returns as soon as this request's response frame
+//! arrives, rather than draining the body to EOF.
+//!
+//! Streamable HTTP permits a server to keep the POST stream open after
+//! answering. Reading to completion would block until the server gave up — so
+//! this uses a raw TCP server that writes the response and then deliberately
+//! never terminates the chunked body. `wiremock` cannot express that: it always
+//! writes a complete body and closes.
+
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use yoagent::mcp::transport::McpTransport;
+use yoagent::mcp::types::JsonRpcRequest;
+use yoagent::mcp::HttpTransport;
+
+/// Serves one request: headers, then a chunk carrying `frames`, then holds the
+/// connection open without the terminating zero-length chunk.
+///
+/// Returns the bound address. The task is detached; it parks until the test
+/// process ends.
+async fn serve_then_hold_open(frames: String) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = format!("http://{}", listener.local_addr().unwrap());
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+
+        // Drain the request head so the client's write completes.
+        let mut buf = [0u8; 4096];
+        let _ = socket.read(&mut buf).await;
+
+        let head = "HTTP/1.1 200 OK\r\n\
+             Content-Type: text/event-stream\r\n\
+             Transfer-Encoding: chunked\r\n\
+             \r\n";
+        socket.write_all(head.as_bytes()).await.unwrap();
+        socket
+            .write_all(format!("{:x}\r\n{}\r\n", frames.len(), frames).as_bytes())
+            .await
+            .unwrap();
+        socket.flush().await.unwrap();
+
+        // No terminating "0\r\n\r\n": the body stays open, exactly like a server
+        // holding the stream for further notifications.
+        tokio::time::sleep(Duration::from_secs(300)).await;
+    });
+
+    addr
+}
+
+/// The response arrives in the first chunk; the server never closes the body.
+/// Draining to EOF would hang here.
+#[tokio::test]
+async fn returns_without_waiting_for_the_server_to_close_the_stream() {
+    let request = JsonRpcRequest::new("tools/list", None);
+    let frames = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"tools\":[]}}}}\n\n",
+        request.id
+    );
+    let addr = serve_then_hold_open(frames).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("send must return once the response frame arrives, not at EOF")
+        .expect("the response must parse");
+
+    assert!(response.result.unwrap()["tools"].is_array());
+}
+
+/// The same, with progress notifications ahead of the result: the transport
+/// must skip them, take the result, and still not wait for EOF.
+#[tokio::test]
+async fn returns_at_the_result_frame_despite_leading_notifications() {
+    let request = JsonRpcRequest::new("tools/call", None);
+    let frames = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{{\"progress\":1}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{{\"level\":\"info\"}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"content\":[{{\"type\":\"text\"}}]}}}}\n\n"
+        ),
+        request.id
+    );
+    let addr = serve_then_hold_open(frames).await;
+
+    let transport = HttpTransport::new(&addr).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(10), transport.send(request))
+        .await
+        .expect("send must return at the result frame")
+        .expect("the response must parse");
+
+    assert!(
+        response.result.is_some(),
+        "the result must be selected over the notifications"
+    );
+}

--- a/tests/mcp_http_transport_test.rs
+++ b/tests/mcp_http_transport_test.rs
@@ -99,6 +99,80 @@ async fn sse_framed_response_parses() {
     assert!(response.result.unwrap()["tools"].is_array());
 }
 
+/// A UTF-8 BOM is legal at the head of a JSON document and .NET/JVM servers
+/// emit one. `Response::text()` sniffed it away; reading the body as bytes does
+/// not, and `trim()` will not remove it either — U+FEFF stopped being
+/// White_Space in Unicode 4.0 — so it breaks the parse and the error names a
+/// body that visibly contains the response.
+#[tokio::test]
+async fn bom_prefixed_plain_json_body_still_parses() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("ping", None);
+    mount_body(
+        &server,
+        format!(
+            "\u{feff}{{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"ok\":true}}}}",
+            request.id
+        ),
+        "application/json",
+    )
+    .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport
+        .send(request)
+        .await
+        .expect("a BOM must not hide the response");
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// A declared non-UTF-8 charset must fail loudly. Reading the body as bytes
+/// gives up the transcoding `Response::text()` did, and decoding such a body as
+/// UTF-8 anyway would return silently mangled tool output as a success.
+#[tokio::test]
+async fn non_utf8_charset_is_refused_rather_than_mangled() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("ping", None);
+    mount_body(
+        &server,
+        format!(r#"{{"jsonrpc":"2.0","id":{},"result":{{}}}}"#, request.id),
+        "application/json; charset=iso-8859-1",
+    )
+    .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let err = transport
+        .send(request)
+        .await
+        .expect_err("a non-UTF-8 charset must not be silently decoded as UTF-8");
+    assert!(err.to_string().contains("charset"), "got: {err}");
+}
+
+/// The one shape only the `method` check rejects: a malformed frame carrying
+/// both a `method` and a `result`. Without this, that check is unkillable by
+/// the suite and a maintainer doing dead-code cleanup would delete it green.
+#[tokio::test]
+async fn frame_with_both_method_and_result_is_not_the_response() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    let body = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"notifications/progress\",\"result\":{{\"bogus\":true}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{{\"real\":true}}}}\n\n"
+        ),
+        id = request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    assert_eq!(
+        response.result.expect("the well-formed response must win")["real"],
+        true
+    );
+}
+
 /// Frames that aren't JSON-RPC at all — comments, `event:`/`id:` lines, foreign
 /// payloads — must be skipped.
 #[tokio::test]

--- a/tests/mcp_http_transport_test.rs
+++ b/tests/mcp_http_transport_test.rs
@@ -1,0 +1,280 @@
+//! Tests for `HttpTransport` — the request/response subset of MCP Streamable
+//! HTTP (issue #82), plus the plain JSON-RPC behavior it must not regress.
+
+use wiremock::matchers::{body_string_contains, header, method};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+use yoagent::mcp::transport::McpTransport;
+use yoagent::mcp::types::JsonRpcRequest;
+use yoagent::mcp::HttpTransport;
+
+/// Matcher: the request must NOT carry the given header.
+struct HeaderAbsent(&'static str);
+
+impl wiremock::Match for HeaderAbsent {
+    fn matches(&self, request: &Request) -> bool {
+        !request.headers.contains_key(self.0)
+    }
+}
+
+/// Matcher: the named header's value contains the given substring.
+///
+/// `wiremock::matchers::header` splits comma-separated values and compares each
+/// one, so it can never match a multi-value header like
+/// `Accept: application/json, text/event-stream` as a whole string.
+struct HeaderContains(&'static str, &'static str);
+
+impl wiremock::Match for HeaderContains {
+    fn matches(&self, request: &Request) -> bool {
+        request
+            .headers
+            .get(self.0)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains(self.1))
+    }
+}
+
+fn sse(payload: &str) -> String {
+    format!("event: message\ndata: {payload}\n\n")
+}
+
+/// Backward compatibility: a plain JSON-RPC body keeps working. This was the
+/// only shape supported before #82.
+#[tokio::test]
+async fn plain_json_response_still_parses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport
+        .send(JsonRpcRequest::new("ping", None))
+        .await
+        .expect("plain JSON must still parse");
+
+    assert_eq!(response.result.unwrap()["ok"], true);
+}
+
+/// The reported failure: servers returning `text/event-stream` used to hit
+/// `Response parse error` because the body was parsed as a single JSON object.
+#[tokio::test]
+async fn sse_framed_response_parses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse(r#"{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}"#),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect("SSE-framed response must parse");
+
+    assert!(response.result.unwrap()["tools"].is_array());
+}
+
+/// Real SSE streams carry comments, `event:` and `id:` lines, and may deliver
+/// the payload in a later frame — the parser must walk to it.
+#[tokio::test]
+async fn sse_with_noise_frames_finds_the_payload() {
+    let server = MockServer::start().await;
+    let body = concat!(
+        ": keep-alive comment\n\n",
+        "event: ping\ndata: {\"unrelated\":true}\n\n",
+        "id: 42\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"found\":true}}\n\n"
+    );
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect("payload in a later frame must be found");
+
+    assert_eq!(response.result.unwrap()["found"], true);
+}
+
+/// Streamable HTTP assigns a session on `initialize` and expects it echoed on
+/// every subsequent request.
+#[tokio::test]
+async fn session_id_is_captured_then_replayed() {
+    let server = MockServer::start().await;
+
+    // First call: no session header yet; server assigns one.
+    Mock::given(method("POST"))
+        .and(HeaderAbsent("mcp-session-id"))
+        .and(body_string_contains("initialize"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Mcp-Session-Id", "sess-abc123")
+                .set_body_raw(
+                    sse(r#"{"jsonrpc":"2.0","id":1,"result":{"initialized":true}}"#),
+                    "text/event-stream",
+                ),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Second call: must carry the assigned session.
+    Mock::given(method("POST"))
+        .and(header("mcp-session-id", "sess-abc123"))
+        .and(body_string_contains("tools/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse(r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#),
+            "text/event-stream",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport
+        .send(JsonRpcRequest::new("initialize", None))
+        .await
+        .expect("initialize");
+    transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect("follow-up must reuse the session");
+    // Mock `expect(1)` assertions verify the headers when the server drops.
+}
+
+/// Notifications get `202 Accepted` with no body. `send()` must still return a
+/// response rather than failing a call that succeeded.
+#[tokio::test]
+async fn accepted_with_empty_body_is_not_an_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(202))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let request = JsonRpcRequest::new("notifications/initialized", None);
+    let request_id = request.id;
+
+    let response = transport
+        .send(request)
+        .await
+        .expect("202 with no body must not be an error");
+
+    assert_eq!(response.id, Some(request_id));
+    assert!(response.result.is_none() && response.error.is_none());
+}
+
+/// Every request advertises both framings so a Streamable HTTP server can pick.
+#[tokio::test]
+async fn accept_header_advertises_both_framings() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(HeaderContains("accept", "application/json"))
+        .and(HeaderContains("accept", "text/event-stream"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+            "application/json",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport
+        .send(JsonRpcRequest::new("ping", None))
+        .await
+        .expect("send");
+}
+
+/// `close()` releases the session server-side. Without a session it must stay a
+/// no-op — the pre-#82 behavior.
+#[tokio::test]
+async fn close_deletes_the_session_when_one_exists() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Mcp-Session-Id", "sess-xyz")
+                .set_body_raw(
+                    r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+                    "application/json",
+                ),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(header("mcp-session-id", "sess-xyz"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport
+        .send(JsonRpcRequest::new("initialize", None))
+        .await
+        .expect("initialize");
+    transport.close().await.expect("close");
+}
+
+/// A server that rejects DELETE must not turn a successful run into an error.
+#[tokio::test]
+async fn close_ignores_a_server_that_rejects_delete() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Mcp-Session-Id", "sess-xyz")
+                .set_body_raw(
+                    r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+                    "application/json",
+                ),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport
+        .send(JsonRpcRequest::new("initialize", None))
+        .await
+        .expect("initialize");
+    transport
+        .close()
+        .await
+        .expect("a 405 on DELETE must not fail close()");
+}
+
+/// An unparseable body must still be a loud error, with a snippet to debug from.
+#[tokio::test]
+async fn unparseable_body_is_an_error_with_context() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("<html>gateway</html>", "text/html"))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let err = transport
+        .send(JsonRpcRequest::new("ping", None))
+        .await
+        .expect_err("an unparseable body must be an error");
+
+    assert!(
+        err.to_string().contains("gateway"),
+        "error should quote the body to debug from, got: {err}"
+    );
+}

--- a/tests/mcp_http_transport_test.rs
+++ b/tests/mcp_http_transport_test.rs
@@ -1,11 +1,18 @@
 //! Tests for `HttpTransport` — the request/response subset of MCP Streamable
 //! HTTP (issue #82), plus the plain JSON-RPC behavior it must not regress.
+//!
+//! Response bodies interpolate the *real* request id. Ids come from a
+//! process-global counter (`types::next_request_id`), so a hardcoded `"id":1`
+//! would never match, and a suite full of them would quietly encode "we don't
+//! correlate responses to requests" — which is the bug these tests exist to
+//! prevent. Each test therefore builds its request first and mounts the mock
+//! with that id.
 
 use wiremock::matchers::{body_string_contains, header, method};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 use yoagent::mcp::transport::McpTransport;
 use yoagent::mcp::types::JsonRpcRequest;
-use yoagent::mcp::HttpTransport;
+use yoagent::mcp::{HttpTransport, McpClient};
 
 /// Matcher: the request must NOT carry the given header.
 struct HeaderAbsent(&'static str);
@@ -18,9 +25,10 @@ impl wiremock::Match for HeaderAbsent {
 
 /// Matcher: the named header's value contains the given substring.
 ///
-/// `wiremock::matchers::header` splits comma-separated values and compares each
-/// one, so it can never match a multi-value header like
-/// `Accept: application/json, text/event-stream` as a whole string.
+/// `wiremock::matchers::header` splits the *request's* value on commas and
+/// compares the whole resulting list against the expected value wrapped in a
+/// one-element list, so it can never match a multi-value header like
+/// `Accept: application/json, text/event-stream`.
 struct HeaderContains(&'static str, &'static str);
 
 impl wiremock::Match for HeaderContains {
@@ -37,24 +45,34 @@ fn sse(payload: &str) -> String {
     format!("event: message\ndata: {payload}\n\n")
 }
 
+async fn mount_body(server: &MockServer, body: String, content_type: &str) {
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, content_type))
+        .mount(server)
+        .await;
+}
+
 /// Backward compatibility: a plain JSON-RPC body keeps working. This was the
 /// only shape supported before #82.
 #[tokio::test]
 async fn plain_json_response_still_parses() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(
-            r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#,
-            "application/json",
-        ))
-        .mount(&server)
-        .await;
+    let request = JsonRpcRequest::new("ping", None);
+    mount_body(
+        &server,
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{},"result":{{"ok":true}}}}"#,
+            request.id
+        ),
+        "application/json",
+    )
+    .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
     let response = transport
-        .send(JsonRpcRequest::new("ping", None))
+        .send(request)
         .await
-        .expect("plain JSON must still parse");
+        .expect("plain JSON must parse");
 
     assert_eq!(response.result.unwrap()["ok"], true);
 }
@@ -64,45 +82,194 @@ async fn plain_json_response_still_parses() {
 #[tokio::test]
 async fn sse_framed_response_parses() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(
-            sse(r#"{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}"#),
-            "text/event-stream",
-        ))
-        .mount(&server)
-        .await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    mount_body(
+        &server,
+        sse(&format!(
+            r#"{{"jsonrpc":"2.0","id":{},"result":{{"tools":[]}}}}"#,
+            request.id
+        )),
+        "text/event-stream",
+    )
+    .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
-    let response = transport
-        .send(JsonRpcRequest::new("tools/list", None))
-        .await
-        .expect("SSE-framed response must parse");
+    let response = transport.send(request).await.expect("SSE must parse");
 
     assert!(response.result.unwrap()["tools"].is_array());
 }
 
-/// Real SSE streams carry comments, `event:` and `id:` lines, and may deliver
-/// the payload in a later frame — the parser must walk to it.
+/// Frames that aren't JSON-RPC at all — comments, `event:`/`id:` lines, foreign
+/// payloads — must be skipped.
 #[tokio::test]
-async fn sse_with_noise_frames_finds_the_payload() {
+async fn sse_skips_frames_that_are_not_json_rpc() {
     let server = MockServer::start().await;
-    let body = concat!(
-        ": keep-alive comment\n\n",
-        "event: ping\ndata: {\"unrelated\":true}\n\n",
-        "id: 42\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"found\":true}}\n\n"
+    let request = JsonRpcRequest::new("tools/list", None);
+    let body = format!(
+        concat!(
+            ": keep-alive comment\n\n",
+            "event: ping\ndata: {{\"unrelated\":true}}\n\n",
+            "id: 42\nevent: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"found\":true}}}}\n\n"
+        ),
+        request.id
     );
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
-        .mount(&server)
-        .await;
+    mount_body(&server, body, "text/event-stream").await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
     let response = transport
-        .send(JsonRpcRequest::new("tools/list", None))
+        .send(request)
         .await
-        .expect("payload in a later frame must be found");
+        .expect("payload must be found");
 
     assert_eq!(response.result.unwrap()["found"], true);
+}
+
+/// The bug this suite previously missed. A Streamable HTTP server may emit
+/// `notifications/progress` and `notifications/message` on the POST response
+/// stream *before* the result — that is how it reports progress and logs during
+/// a `tools/call`.
+///
+/// Those frames deserialize into `JsonRpcResponse` (every field but `jsonrpc`
+/// is optional, and unknown keys are ignored), so a parser that accepts the
+/// first thing that *parses* returns the notification and silently discards the
+/// answer. Selection must be structural: no `method`, and a `result` or `error`.
+#[tokio::test]
+async fn notification_frames_do_not_shadow_the_response() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    let body = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{{\"level\":\"info\",\"data\":\"searching\"}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{{\"progress\":1}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"tools\":[{{\"name\":\"web_search\"}}]}}}}\n\n"
+        ),
+        request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    let result = response
+        .result
+        .expect("the result must win over preceding notification frames");
+    assert_eq!(result["tools"][0]["name"], "web_search");
+}
+
+/// A server→client *request* (e.g. `sampling/createMessage`) also carries a
+/// `method` and an id that is not ours. It must not be mistaken for the answer.
+#[tokio::test]
+async fn server_initiated_request_does_not_shadow_the_response() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/call", None);
+    let body = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":77,\"method\":\"sampling/createMessage\",\"params\":{{}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"content\":[]}}}}\n\n"
+        ),
+        request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    assert!(
+        response.result.is_some(),
+        "the real result must be selected"
+    );
+}
+
+/// A bare ack frame carries our id but neither a result nor an error. It has no
+/// `method`, so only the result-or-error check rejects it — without that, it
+/// would be returned as the answer and the real result discarded.
+#[tokio::test]
+async fn bare_ack_frame_does_not_shadow_the_response() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    let body = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{id}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{{\"real\":true}}}}\n\n"
+        ),
+        id = request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    assert_eq!(
+        response
+            .result
+            .expect("the real result must win over a bare ack")["real"],
+        true
+    );
+}
+
+/// Guards the *natural wrong fix* for the shadowing bug. Filtering on
+/// `result.is_some()` alone would convert every server-side JSON-RPC error into
+/// an opaque transport failure, hiding the reason a tool call was rejected.
+#[tokio::test]
+async fn json_rpc_error_over_sse_reaches_the_caller() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/call", None);
+    let body = format!(
+        concat!(
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{{}}}}\n\n",
+            "event: message\ndata: {{\"jsonrpc\":\"2.0\",\"id\":{},\"error\":{{\"code\":-32602,\"message\":\"path must be absolute\"}}}}\n\n"
+        ),
+        request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    let error = response.error.expect("the server's error must survive");
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains("absolute"));
+}
+
+/// A response for a different request must not be accepted as ours.
+#[tokio::test]
+async fn mismatched_response_id_is_rejected() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    mount_body(
+        &server,
+        sse(r#"{"jsonrpc":"2.0","id":999999,"result":{"stale":true}}"#),
+        "text/event-stream",
+    )
+    .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let err = transport
+        .send(request)
+        .await
+        .expect_err("a response for another id must not be returned as ours");
+    assert!(
+        err.to_string().contains("no JSON-RPC response"),
+        "got: {err}"
+    );
+}
+
+/// SSE joins an event's multiple `data:` lines with newlines. A server that
+/// pretty-prints its JSON across lines is spec-legal.
+#[tokio::test]
+async fn multi_line_data_frames_are_joined() {
+    let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("tools/list", None);
+    let body = format!(
+        "event: message\ndata: {{\"jsonrpc\":\"2.0\",\ndata: \"id\":{},\ndata: \"result\":{{\"joined\":true}}}}\n\n",
+        request.id
+    );
+    mount_body(&server, body, "text/event-stream").await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let response = transport.send(request).await.expect("send");
+
+    assert_eq!(response.result.unwrap()["joined"], true);
 }
 
 /// Streamable HTTP assigns a session on `initialize` and expects it echoed on
@@ -110,16 +277,20 @@ async fn sse_with_noise_frames_finds_the_payload() {
 #[tokio::test]
 async fn session_id_is_captured_then_replayed() {
     let server = MockServer::start().await;
+    let first = JsonRpcRequest::new("initialize", None);
+    let second = JsonRpcRequest::new("tools/list", None);
 
-    // First call: no session header yet; server assigns one.
     Mock::given(method("POST"))
         .and(HeaderAbsent("mcp-session-id"))
-        .and(body_string_contains("initialize"))
+        .and(body_string_contains("\"method\":\"initialize\""))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("Mcp-Session-Id", "sess-abc123")
                 .set_body_raw(
-                    sse(r#"{"jsonrpc":"2.0","id":1,"result":{"initialized":true}}"#),
+                    sse(&format!(
+                        r#"{{"jsonrpc":"2.0","id":{},"result":{{"initialized":true}}}}"#,
+                        first.id
+                    )),
                     "text/event-stream",
                 ),
         )
@@ -127,12 +298,14 @@ async fn session_id_is_captured_then_replayed() {
         .mount(&server)
         .await;
 
-    // Second call: must carry the assigned session.
     Mock::given(method("POST"))
         .and(header("mcp-session-id", "sess-abc123"))
         .and(body_string_contains("tools/list"))
         .respond_with(ResponseTemplate::new(200).set_body_raw(
-            sse(r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#),
+            sse(&format!(
+                r#"{{"jsonrpc":"2.0","id":{},"result":{{"tools":[]}}}}"#,
+                second.id
+            )),
             "text/event-stream",
         ))
         .expect(1)
@@ -140,15 +313,70 @@ async fn session_id_is_captured_then_replayed() {
         .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport.send(first).await.expect("initialize");
     transport
-        .send(JsonRpcRequest::new("initialize", None))
-        .await
-        .expect("initialize");
-    transport
-        .send(JsonRpcRequest::new("tools/list", None))
+        .send(second)
         .await
         .expect("follow-up must reuse the session");
-    // Mock `expect(1)` assertions verify the headers when the server drops.
+}
+
+/// A 404 on a session-bearing request means the server dropped the session.
+/// Keeping the dead id would make every later call fail identically with an
+/// error that reads like a bad URL.
+#[tokio::test]
+async fn expired_session_is_cleared_and_named() {
+    let server = MockServer::start().await;
+    let first = JsonRpcRequest::new("initialize", None);
+
+    Mock::given(method("POST"))
+        .and(HeaderAbsent("mcp-session-id"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Mcp-Session-Id", "sess-dead")
+                .set_body_raw(
+                    format!(r#"{{"jsonrpc":"2.0","id":{},"result":{{}}}}"#, first.id),
+                    "application/json",
+                ),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(header("mcp-session-id", "sess-dead"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport.send(first).await.expect("initialize");
+
+    let err = transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect_err("404 must surface");
+    assert!(
+        err.to_string().contains("session expired"),
+        "the error must name the cause, got: {err}"
+    );
+
+    // The dead session is gone: the next request goes out without one, so a
+    // caller that rebuilds the handshake can recover. (Asserted on the wire
+    // rather than on the response, because a fresh request carries a fresh id
+    // that this test's canned body cannot know.)
+    let _ = transport
+        .send(JsonRpcRequest::new("initialize", None))
+        .await;
+
+    let last = server
+        .received_requests()
+        .await
+        .unwrap()
+        .pop()
+        .expect("a third request was sent");
+    assert!(
+        !last.headers.contains_key("mcp-session-id"),
+        "the expired session must not be replayed"
+    );
 }
 
 /// Notifications get `202 Accepted` with no body. `send()` must still return a
@@ -174,15 +402,35 @@ async fn accepted_with_empty_body_is_not_an_error() {
     assert!(response.result.is_none() && response.error.is_none());
 }
 
+/// But an empty body on a *non-ack* status is a real failure — a proxy
+/// answering instead of the MCP server, or a drained upstream. Synthesizing a
+/// success there would hide it.
+#[tokio::test]
+async fn empty_body_on_plain_200_is_an_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let err = transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect_err("an empty 200 must not be dressed up as success");
+    assert!(err.to_string().contains("empty body"), "got: {err}");
+}
+
 /// Every request advertises both framings so a Streamable HTTP server can pick.
 #[tokio::test]
 async fn accept_header_advertises_both_framings() {
     let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("ping", None);
     Mock::given(method("POST"))
         .and(HeaderContains("accept", "application/json"))
         .and(HeaderContains("accept", "text/event-stream"))
         .respond_with(ResponseTemplate::new(200).set_body_raw(
-            r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+            format!(r#"{{"jsonrpc":"2.0","id":{},"result":{{}}}}"#, request.id),
             "application/json",
         ))
         .expect(1)
@@ -190,23 +438,44 @@ async fn accept_header_advertises_both_framings() {
         .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
-    transport
-        .send(JsonRpcRequest::new("ping", None))
-        .await
-        .expect("send");
+    transport.send(request).await.expect("send");
 }
 
-/// `close()` releases the session server-side. Without a session it must stay a
-/// no-op — the pre-#82 behavior.
+/// A non-2xx body carries the server's explanation. Dropping it leaves the user
+/// a bare status code to guess from.
+#[tokio::test]
+async fn non_2xx_preserves_the_server_explanation() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(400).set_body_raw(
+            r#"{"error":{"message":"Mcp-Session-Id header required"}}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    let err = transport
+        .send(JsonRpcRequest::new("tools/list", None))
+        .await
+        .expect_err("400 must surface");
+    assert!(
+        err.to_string().contains("Mcp-Session-Id header required"),
+        "the server's explanation must survive, got: {err}"
+    );
+}
+
+/// `close()` releases the session server-side.
 #[tokio::test]
 async fn close_deletes_the_session_when_one_exists() {
     let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("initialize", None);
     Mock::given(method("POST"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("Mcp-Session-Id", "sess-xyz")
                 .set_body_raw(
-                    r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+                    format!(r#"{{"jsonrpc":"2.0","id":{},"result":{{}}}}"#, request.id),
                     "application/json",
                 ),
         )
@@ -220,23 +489,36 @@ async fn close_deletes_the_session_when_one_exists() {
         .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
-    transport
-        .send(JsonRpcRequest::new("initialize", None))
-        .await
-        .expect("initialize");
+    transport.send(request).await.expect("initialize");
     transport.close().await.expect("close");
+}
+
+/// Without a session there is nothing to release — `close()` must stay the
+/// pre-#82 no-op and send nothing at all.
+#[tokio::test]
+async fn close_without_a_session_sends_nothing() {
+    let server = MockServer::start().await;
+
+    let transport = HttpTransport::new(&server.uri()).unwrap();
+    transport.close().await.expect("close must be a no-op");
+
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "close() without a session must not touch the network"
+    );
 }
 
 /// A server that rejects DELETE must not turn a successful run into an error.
 #[tokio::test]
 async fn close_ignores_a_server_that_rejects_delete() {
     let server = MockServer::start().await;
+    let request = JsonRpcRequest::new("initialize", None);
     Mock::given(method("POST"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("Mcp-Session-Id", "sess-xyz")
                 .set_body_raw(
-                    r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+                    format!(r#"{{"jsonrpc":"2.0","id":{},"result":{{}}}}"#, request.id),
                     "application/json",
                 ),
         )
@@ -248,10 +530,7 @@ async fn close_ignores_a_server_that_rejects_delete() {
         .await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
-    transport
-        .send(JsonRpcRequest::new("initialize", None))
-        .await
-        .expect("initialize");
+    transport.send(request).await.expect("initialize");
     transport
         .close()
         .await
@@ -262,10 +541,7 @@ async fn close_ignores_a_server_that_rejects_delete() {
 #[tokio::test]
 async fn unparseable_body_is_an_error_with_context() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw("<html>gateway</html>", "text/html"))
-        .mount(&server)
-        .await;
+    mount_body(&server, "<html>gateway</html>".into(), "text/html").await;
 
     let transport = HttpTransport::new(&server.uri()).unwrap();
     let err = transport
@@ -275,6 +551,61 @@ async fn unparseable_body_is_an_error_with_context() {
 
     assert!(
         err.to_string().contains("gateway"),
-        "error should quote the body to debug from, got: {err}"
+        "error should quote the body, got: {err}"
     );
+}
+
+/// End to end through the public entry point: `McpClient::connect_http` runs the
+/// real handshake (initialize → notifications/initialized → tools/list) against
+/// a Streamable HTTP server that SSE-frames its responses, assigns a session,
+/// and emits a log notification ahead of the result.
+///
+/// This is the path issue #82 is actually about, and it had no coverage — the
+/// nine transport tests all construct `HttpTransport` by hand, and the
+/// `tool_adapter` tests use `from_transport`, which skips `initialize` entirely.
+#[tokio::test]
+async fn e2e_handshake_over_streamable_http() {
+    let server = MockServer::start().await;
+
+    // `body_string_contains("initialize")` would also match
+    // `notifications/initialized`, so match the method field exactly.
+    Mock::given(method("POST"))
+        .and(body_string_contains("\"method\":\"initialize\""))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Mcp-Session-Id", "sess-e2e")
+                .set_body_raw(
+                    sse(r#"{"jsonrpc":"2.0","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"probe","version":"1.0"}}}"#),
+                    "text/event-stream",
+                ),
+        )
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_string_contains("notifications/initialized"))
+        .respond_with(ResponseTemplate::new(202))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_string_contains("tools/list"))
+        .and(header("mcp-session-id", "sess-e2e"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            concat!(
+                "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"}}\n\n",
+                "event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[{\"name\":\"web_search\",\"inputSchema\":{}}]}}\n\n"
+            ),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    let client = McpClient::connect_http(&server.uri())
+        .await
+        .expect("handshake over SSE must succeed");
+    assert_eq!(client.server_info().unwrap().name, "probe");
+
+    let tools = client.list_tools().await.expect("tools/list over SSE");
+    assert_eq!(tools[0].name, "web_search");
 }


### PR DESCRIPTION
Closes #82. Reported by @markokocic.

## Problem

`HttpTransport::send()` parsed the response body as a single JSON object:

```rust
let response: JsonRpcResponse = resp.json().await...;
```

Servers following Streamable HTTP return `event: message\ndata: {...}\n\n` instead, so every call failed with `Response parse error`. Consumers (like [rab](https://github.com/markokocic/rab)) had to write their own transport wrapper.

## What this adds

The **request/response subset** of Streamable HTTP:

| | |
|---|---|
| SSE-framed bodies | JSON-RPC payload parsed out of the frames, walking past comments, `event:`/`id:` lines, and unrelated frames |
| `Accept` header | `application/json, text/event-stream`, so the server picks the framing |
| `Mcp-Session-Id` | captured from the `initialize` response, replayed on every later request |
| Session teardown | best-effort `DELETE` on `close()` — a server rejecting it must not fail a successful run |
| `202 Accepted`, empty body | success (how notifications are acknowledged), not a parse failure |

Plain JSON-RPC bodies take the same path they always did — that's asserted by a test.

## No API changes

This was the main design constraint, and it shaped the scope:

- **`McpTransport` is untouched.** `send(&self)` / `close(&self)` already take `&self`, so the session lives behind a `Mutex` — the same interior-mutability pattern `StdioTransport` already uses. Changing the trait would break every downstream implementor.
- **`HttpTransport`'s fields were already private**, so adding `session_id` isn't breaking.
- **`McpClient::connect_http` is unchanged** — session capture happens inside `send()` during the existing `initialize()` call, so nothing needed threading through.

Sends are already serialized (`McpClient` holds the transport as `Arc<Mutex<Box<dyn McpTransport>>>`), so there's no race on the session write.

## Deliberately out of scope

The `GET` server→client stream and `Last-Event-ID` resumability. `McpTransport` is strictly request/response, so a server-initiated message has nowhere to be delivered — supporting them needs a different trait, and *that* is what would have made this a breaking change. Documented as a subset rather than claiming spec compliance.

Also unchanged: `initialize()` still negotiates `protocolVersion: "2024-11-05"`. Transport-level framing works regardless, and bumping it affects stdio servers too — a separate decision with separate testing.

## One correction to the issue

Point 4 (accept HTTP 202) was **already satisfied** — `resp.status().is_success()` covers all 2xx. The real gap was the empty *body*, which is handled here.

## Testing

Adds the crate's **first MCP tests** (9, wiremock-based): plain JSON backward compat, SSE framing, SSE with noise frames, session capture + replay, `Accept` advertisement, 202 empty body, `DELETE` on close, `DELETE` rejected by server, and unparseable body still erroring with a body snippet to debug from.

Each was verified to fail against the specific mutation it targets (SSE parsing removed, session replay removed, empty-body synthesis removed, `DELETE` removed).

`cargo fmt --check`, `cargo clippy --all-targets` under `-Dwarnings`, and all 20 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)