### PR TITLE
fix: make the GASP crash-recovery test wait for the run node, not the log line

### DIFF
--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -60,6 +60,23 @@ fn tool_then_text_provider() -> MockProvider {
     ])
 }
 
+/// Like `event_kinds`, but tolerant of a file that is still being written:
+/// missing file, or a torn final line, yield what is readable so far. Used by
+/// barriers that poll while the recorder appends.
+fn event_kinds_lenient(repo: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(repo.join("state/events.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .ok()?
+                .get("kind")?
+                .as_str()
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
 fn event_kinds(repo: &std::path::Path) -> Vec<String> {
     std::fs::read_to_string(repo.join("state/events.jsonl"))
         .expect("events.jsonl exists")
@@ -362,12 +379,31 @@ async fn reopen_after_crash_closes_stale_run_and_records_again() {
     // it — a faithful crash simulation.
     let (tx, handle) = recorder.recording_sender("doomed", None);
     tx.send(AgentEvent::AgentStart).unwrap();
-    while !std::fs::read_to_string(dir.path().join("state/events.jsonl"))
-        .unwrap_or_default()
-        .contains("run.started")
-    {
+
+    // Wait for the run to be *fully* open, not just logged. `record_run_started`
+    // writes the `run.started` event, opens the run marker, and only then
+    // applies the ops that create the run node — a window its own source
+    // comments call out. Aborting on `run.started` alone can land inside it,
+    // leaving a run whose node was never written; the reopen below then fails
+    // with "node not found" instead of exercising the stale-run recovery this
+    // test is about. The node-creating ops arrive as the `state.ops_applied`
+    // event that follows, so that is the barrier.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let kinds = event_kinds_lenient(dir.path());
+        if let Some(started) = kinds.iter().position(|k| k == "run.started") {
+            if kinds[started..].iter().any(|k| k == "state.ops_applied") {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "run never opened fully; saw events: {:?}",
+            event_kinds_lenient(dir.path())
+        );
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
+
     handle.abort();
     let _ = handle.await;
     drop(tx);


### PR DESCRIPTION
`reopen_after_crash_closes_stale_run_and_records_again` has failed **6 CI runs**, always on ubuntu, always with:

```
found an open run and could not close it (node not found: run_e97c6bc6a7fb4352a5b8b5c2ebdb7357)
```

Three of those were in the last two days, and one required a manual re-run to get #91 green. Test-only change; no library code touched.

## Root cause

`yoagent_state::record_run_started` does three things in order:

1. writes the `run.started` event to `events.jsonl`
2. sets the open-run marker
3. applies the ops that create the run **node**

Its own source comments call out the window between 2 and 3. The test aborted the consumer as soon as `run.started` appeared in `events.jsonl` — step 1 — which is inside it.

## It was not a narrow race

I measured it: **the old barrier fired before the node existed in 40 of 40 trials.** The test passed anyway because `handle.abort()` only takes effect at the task's next await point, so the node write usually completed regardless. On a loaded runner it sometimes didn't — and then the reopen failed on a run whose node was never written, never reaching the stale-run recovery the test exists to cover.

So the test was *always* racing; only the abort's latency was hiding it. That also explains why it reproduced on ubuntu and never locally.

## Fix

Wait for the `state.ops_applied` event that follows `run.started` — that is the one carrying the node-creating ops — with a 10s deadline so a genuine hang fails loudly instead of spinning. Reads go through a lenient helper, since the file is being appended concurrently and its final line can be torn.

25 consecutive local runs pass; the full `--all-features` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)