### PR TITLE
release: 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.14.0
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Version bump for the MCP Streamable HTTP transport (#82, merged in #91).

- `Cargo.toml`: `0.13.3` → `0.14.0`
- `CHANGELOG.md`: `## Unreleased` → `## 0.14.0`

**Minor, not patch.** This adds a capability *and* changes observable behavior: every MCP POST now carries an `Accept` header (plus `Mcp-Session-Id` once assigned), `close()` went from a pure no-op to a network round-trip, and an SSE response forgoes connection reuse unless the server had already closed the body. A `0.13.x` consumer running `cargo update` should see a version that signals the change.

Closes out all five issues reported by @markokocic (#81, #82, #83, #84 — plus #85 from you, shipped in 0.13.2).

Merging this triggers the tag + GitHub Release, which fires `publish.yml` to publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)