### PR TITLE
fix: surface malformed tool-call JSON instead of discarding it (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,33 +8,53 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Malformed tool-call JSON is surfaced instead of silently discarded**
-  (#89, Anthropic provider). When a tool call's streamed `input_json_delta`
-  did not assemble into valid JSON, the provider replaced the arguments with an
-  empty object and carried on — so the tool executed with default arguments,
-  and neither the caller nor the model learned that the model's actual input had
-  been dropped. This is on the happy path for yoagent's own configuration, which
-  sends the `fine-grained-tool-streaming` beta that Anthropic documents as able
-  to emit incomplete tool JSON when a response hits `max_tokens`.
+- **Tool calls with unusable arguments are surfaced instead of executed**
+  (#89, Anthropic provider). `content_block_stop` is what turns a tool call's
+  streamed `input_json_delta` accumulator into real arguments. When it did not
+  — the accumulated text was not valid JSON — the provider substituted an empty
+  object and carried on, so the tool executed with default arguments while
+  neither the caller nor the model learned the model's actual input had been
+  dropped. `list_files` asked for `/etc` would list the process's working
+  directory instead.
 
-  The turn now fails with an `error_message` naming the tool and quoting the
-  unparseable input. The agent loop returns on `StopReason::Error` before it
-  extracts tool calls, so nothing executes. The unusable `tool_use` block is
-  replaced with text rather than left in place: a `tool_use` with no matching
-  `tool_result` is rejected by the API on the *next* request, so leaving it would
-  break the conversation rather than just the turn.
+  A single check after the stream now fails the turn if *any* tool call still
+  carries the accumulator, whichever route left it there: unparseable JSON, a
+  `content_block_stop` whose body is not JSON, or one with no `index` (which no
+  longer silently closes block 0 — a block the event was never about). The error
+  names each tool and quotes its input, truncated, since the accumulator can be
+  a whole `max_tokens` worth of JSON and it reaches logs, session files, and —
+  through `SubAgentTool` — the parent model's context.
 
-  Two adjacent silent paths in the same event went with it. A
-  `content_block_stop` whose body is not JSON is now logged instead of skipped
-  in silence (it leaves a tool call unfinalized *and* emits no `ToolCallEnd`, so
-  a UI tracking the call's lifecycle hangs it open). And one with a missing or
-  non-numeric `index` no longer defaults to block 0 — closing a block the event
-  was never about, which could parse a half-written accumulator and fail an
-  otherwise healthy turn.
-- **An unrecognized Anthropic `stop_reason` is logged** rather than quietly
-  treated as a normal finish, so a stop reason added later surfaces as a visible
-  change. It still maps to `Stop`. A `message_delta` carrying no `stop_reason`
-  also no longer overwrites one an earlier delta had set.
+  `agent_loop` returns on `StopReason::Error` before extracting tool calls, so
+  nothing runs. *Every* tool call in the message is replaced with text, not just
+  the unusable one: the turn executes none of them, so any left behind would
+  return to the API as a `tool_use` with no `tool_result` and be rejected on the
+  next request — breaking the conversation rather than just the turn. Replacing
+  in place keeps `content.len()` aligned with the provider's block indices.
+
+  A refusal reported in the same response keeps its `Refusal` stop reason and
+  its explanation; the tool-argument note is appended rather than substituted,
+  so an in-stream context overflow still matches `Message::is_context_overflow()`
+  and its compaction-retry hook.
+
+### Fixed
+
+- **`end_turn` and `stop_sequence` are recognized stop reasons** (Anthropic).
+  They previously fell through to the catch-all. Harmless until the catch-all
+  gained a warning — at which point every healthy turn logged one.
+- **`pause_turn` is reported as incomplete rather than finished** (Anthropic).
+  It means the model stopped mid-turn and expects the conversation to be re-sent
+  to continue; mapping it to a normal stop handed back a truncated answer as
+  though it were complete. This transport cannot resume, so it now says so.
+- **A trailing `message_delta` no longer zeroes the output token count**
+  (Anthropic). `usage` is optional on the wire, and a defaulted struct made an
+  absent block indistinguishable from a reported zero, wiping cost accounting
+  and `ContextTracker` calibration for the turn. Such a delta already no longer
+  overwrites a stop reason an earlier one established.
+- **Structured-output responses keep their error message** (`agent_loop`). The
+  rebuild that unwraps a forced tool call preserved the stop reason but dropped
+  the explanation, so a failed structured call surfaced as
+  `"provider error (no detail)"`.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- **Malformed tool-call JSON is surfaced instead of silently discarded**
+  (#89, Anthropic provider). When a tool call's streamed `input_json_delta`
+  did not assemble into valid JSON, the provider replaced the arguments with an
+  empty object and carried on — so the tool executed with default arguments,
+  and neither the caller nor the model learned that the model's actual input had
+  been dropped. This is on the happy path for yoagent's own configuration, which
+  sends the `fine-grained-tool-streaming` beta that Anthropic documents as able
+  to emit incomplete tool JSON when a response hits `max_tokens`.
+
+  The turn now fails with an `error_message` naming the tool and quoting the
+  unparseable input. The agent loop returns on `StopReason::Error` before it
+  extracts tool calls, so nothing executes. The unusable `tool_use` block is
+  replaced with text rather than left in place: a `tool_use` with no matching
+  `tool_result` is rejected by the API on the *next* request, so leaving it would
+  break the conversation rather than just the turn.
+
+  Two adjacent silent paths in the same event went with it. A
+  `content_block_stop` whose body is not JSON is now logged instead of skipped
+  in silence (it leaves a tool call unfinalized *and* emits no `ToolCallEnd`, so
+  a UI tracking the call's lifecycle hangs it open). And one with a missing or
+  non-numeric `index` no longer defaults to block 0 — closing a block the event
+  was never about, which could parse a half-written accumulator and fail an
+  otherwise healthy turn.
+- **An unrecognized Anthropic `stop_reason` is logged** rather than quietly
+  treated as a normal finish, so a stop reason added later surfaces as a visible
+  change. It still maps to `Stop`. A `message_delta` carrying no `stop_reason`
+  also no longer overwrites one an earlier delta had set.
+
 ## 0.14.0
 
 ### Added

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -800,6 +800,7 @@ fn unwrap_structured_tool_call(
         provider,
         usage,
         stop_reason,
+        error_message,
         ..
     } = &message
     else {
@@ -834,13 +835,21 @@ fn unwrap_structured_tool_call(
     } else {
         stop_reason.clone()
     };
-    Message::assistant(
+    let rebuilt = Message::assistant(
         new_content,
         new_stop,
         model.clone(),
         provider.clone(),
         usage.clone(),
-    )
+    );
+    // `Message::assistant` nulls `error_message`, so carry it across explicitly.
+    // The stop reason is preserved a few lines up for the same reason; dropping
+    // the explanation with it leaves the caller a bare `Error` and
+    // `StructuredPromptError::Provider { message: "provider error (no detail)" }`.
+    match error_message {
+        Some(msg) => rebuilt.with_error_message(msg.clone()),
+        None => rebuilt,
+    }
 }
 
 async fn execute_tool_calls(

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -113,6 +113,10 @@ impl StreamProvider for AnthropicProvider {
         // delta without a stop_reason: that proves nothing about completeness.
         let mut saw_stop_reason = false;
         let mut error_message: Option<String> = None;
+        // A tool call whose arguments could not be parsed. Tracked separately
+        // because `message_delta` arrives *after* `content_block_stop` and would
+        // otherwise overwrite the error with its own `tool_use` stop reason.
+        let mut dropped_malformed_tool_call = false;
 
         let _ = tx.send(StreamEvent::Start);
 
@@ -215,27 +219,81 @@ impl StreamProvider for AnthropicProvider {
                                         }
                                     }
                                 }
-                                "content_block_stop" => {
-                                    if let Ok(data) = serde_json::from_str::<serde_json::Value>(&msg.data) {
-                                        let idx = data["index"].as_u64().unwrap_or(0) as usize;
-                                        // Parse accumulated JSON for tool calls
-                                        if let Some(Content::ToolCall { ref mut arguments, .. }) = content.get_mut(idx) {
-                                            if let Some(partial) = arguments.as_object()
-                                                .and_then(|o| o.get("__partial_json"))
-                                                .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string())
-                                            {
-                                                if let Ok(parsed) = serde_json::from_str(&partial) {
-                                                    *arguments = parsed;
-                                                } else {
-                                                    warn!("Failed to parse tool call JSON: {}", partial);
-                                                    *arguments = serde_json::Value::Object(Default::default());
+                                "content_block_stop" => match serde_json::from_str::<serde_json::Value>(&msg.data) {
+                                    // Skipping this silently would leave a tool
+                                    // call's accumulator unparsed *and* never emit
+                                    // ToolCallEnd, so a UI tracking the call's
+                                    // lifecycle hangs it open forever.
+                                    Err(e) => warn!(
+                                        "content_block_stop body is not JSON ({e}); \
+                                         any tool call it closes is left unfinalized: {}",
+                                        msg.data
+                                    ),
+                                    Ok(data) => match data["index"].as_u64() {
+                                        // Defaulting to 0 would close the wrong
+                                        // block: block 0 gets block N's arguments
+                                        // and block N keeps its raw accumulator.
+                                        None => warn!(
+                                            "content_block_stop without a numeric index; \
+                                             refusing to guess which block it closes: {}",
+                                            msg.data
+                                        ),
+                                        Some(idx) => {
+                                            let idx = idx as usize;
+                                            // Deferred so the mutable borrow of
+                                            // `content` ends before we replace the
+                                            // block below.
+                                            let mut malformed: Option<(String, String)> = None;
+                                            if let Some(Content::ToolCall { name, arguments, .. }) = content.get_mut(idx) {
+                                                if let Some(partial) = arguments.as_object()
+                                                    .and_then(|o| o.get("__partial_json"))
+                                                    .and_then(|v| v.as_str())
+                                                    .map(|s| s.to_string())
+                                                {
+                                                    match serde_json::from_str(&partial) {
+                                                        Ok(parsed) => *arguments = parsed,
+                                                        Err(e) => {
+                                                            warn!(
+                                                                "tool call `{}` has malformed JSON arguments ({e}): {partial}",
+                                                                name
+                                                            );
+                                                            malformed = Some((name.clone(), partial));
+                                                        }
+                                                    }
                                                 }
                                             }
+                                            if let Some((tool, partial)) = malformed {
+                                                // Substituting `{}` here (the old
+                                                // behavior) let the tool run with
+                                                // default arguments while neither
+                                                // the caller nor the model learned
+                                                // the model's actual input was
+                                                // dropped — silently wrong action.
+                                                // Failing the turn stops the loop
+                                                // before it executes anything.
+                                                error_message = Some(format!(
+                                                    "Tool call `{tool}` (block {idx}) had malformed JSON \
+                                                     arguments and was not executed: {partial}"
+                                                ));
+                                                stop_reason = StopReason::Error;
+                                                dropped_malformed_tool_call = true;
+                                                // And replace the block: a tool_use
+                                                // with no matching tool_result is
+                                                // rejected by the API on the next
+                                                // request, so leaving it would break
+                                                // the conversation rather than just
+                                                // this turn. Text keeps the index
+                                                // stable for later blocks.
+                                                content[idx] = Content::Text {
+                                                    text: format!(
+                                                        "[tool call `{tool}` dropped: malformed JSON arguments]"
+                                                    ),
+                                                };
+                                            }
+                                            let _ = tx.send(StreamEvent::ToolCallEnd { content_index: idx });
                                         }
-                                        let _ = tx.send(StreamEvent::ToolCallEnd { content_index: idx });
-                                    }
-                                }
+                                    },
+                                },
                                 "message_delta" => {
                                     if let Ok(data) = serde_json::from_str::<AnthropicMessageDelta>(&msg.data) {
                                         // Only a delta that actually carried a
@@ -243,11 +301,16 @@ impl StreamProvider for AnthropicProvider {
                                         // is finished. An intermediate delta (usage
                                         // update, empty `delta`) parses fine and
                                         // must NOT arm the clean-EOF guard.
-                                        saw_stop_reason |= data.delta.stop_reason.is_some();
-                                        stop_reason = match data.delta.stop_reason.as_deref() {
-                                            Some("tool_use") => StopReason::ToolUse,
-                                            Some("max_tokens") => StopReason::Length,
-                                            Some("model_context_window_exceeded") => {
+                                        // A delta with no stop_reason leaves the
+                                        // current one alone — overwriting it would
+                                        // clobber a terminal reason an earlier
+                                        // delta already set.
+                                        if let Some(reason) = data.delta.stop_reason.as_deref() {
+                                        saw_stop_reason = true;
+                                        stop_reason = match reason {
+                                            "tool_use" => StopReason::ToolUse,
+                                            "max_tokens" => StopReason::Length,
+                                            "model_context_window_exceeded" => {
                                                 // In-stream overflow (HTTP 200). Map to the same
                                                 // Error + overflow-phrase shape as an HTTP 400
                                                 // overflow so Message::is_context_overflow() and
@@ -257,7 +320,7 @@ impl StreamProvider for AnthropicProvider {
                                                     Some("model_context_window_exceeded".into());
                                                 StopReason::Error
                                             }
-                                            Some("refusal") => {
+                                            "refusal" => {
                                                 warn!(
                                                     "Anthropic declined the request (stop_reason=refusal)"
                                                 );
@@ -268,8 +331,21 @@ impl StreamProvider for AnthropicProvider {
                                                 );
                                                 StopReason::Refusal
                                             }
-                                            _ => StopReason::Stop,
+                                            // A stop reason we do not know yet is
+                                            // reported rather than quietly treated
+                                            // as a normal finish, so a new one
+                                            // (a future `pause_turn`, say) surfaces
+                                            // as a visible change instead of a
+                                            // silent behavior shift.
+                                            other => {
+                                                warn!(
+                                                    "unknown Anthropic stop_reason '{other}'; \
+                                                     treating it as a normal stop"
+                                                );
+                                                StopReason::Stop
+                                            }
                                         };
+                                        }
                                         usage.output = data.usage.output_tokens;
                                     }
                                 }
@@ -327,6 +403,13 @@ impl StreamProvider for AnthropicProvider {
         let has_tool_calls = content
             .iter()
             .any(|c| matches!(c, Content::ToolCall { .. }));
+        // A content-level failure outranks whatever terminal reason the stream
+        // reported: the `message_delta` carrying `tool_use` arrives after the
+        // `content_block_stop` that found the malformed arguments.
+        if dropped_malformed_tool_call {
+            stop_reason = StopReason::Error;
+        }
+
         // Never let the tool-call fallback mask a refusal or an error signal.
         if has_tool_calls && !matches!(stop_reason, StopReason::Refusal | StopReason::Error) {
             stop_reason = StopReason::ToolUse;

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -12,6 +12,69 @@ use tracing::{debug, warn};
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
 const API_VERSION: &str = "2023-06-01";
 
+/// Trim a model-supplied string for inclusion in an error or log line.
+///
+/// The accumulator can be a whole `max_tokens` worth of JSON — a truncated file
+/// write or a base64 blob. That string reaches `on_error`, the assistant
+/// message, session JSONL, and (via `SubAgentTool`) the parent model's context,
+/// so quoting it whole floods every one of them.
+fn truncate_for_error(s: &str) -> String {
+    const MAX: usize = 200;
+    if s.chars().count() <= MAX {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(MAX).collect();
+    format!("{head}\u{2026} ({} bytes total)", s.len())
+}
+
+/// Map an Anthropic `stop_reason` onto [`StopReason`], recording a diagnosis for
+/// the terminal ones that carry one.
+///
+/// Every documented value is listed explicitly. A catch-all that silently means
+/// "finished normally" is how `end_turn` — the ordinary completion — would land
+/// in the unknown arm and warn on every healthy turn, and how a resumable state
+/// would be handed back as a finished answer.
+fn map_stop_reason(reason: &str, error_message: &mut Option<String>) -> StopReason {
+    match reason {
+        "end_turn" | "stop_sequence" => StopReason::Stop,
+        "tool_use" => StopReason::ToolUse,
+        "max_tokens" => StopReason::Length,
+        "model_context_window_exceeded" => {
+            // In-stream overflow (HTTP 200). Map to the same Error +
+            // overflow-phrase shape as an HTTP 400 overflow so
+            // `Message::is_context_overflow()` and compaction-retry hooks keep
+            // working.
+            warn!("Anthropic context window exceeded mid-stream");
+            *error_message = Some("model_context_window_exceeded".into());
+            StopReason::Error
+        }
+        "refusal" => {
+            warn!("Anthropic declined the request (stop_reason=refusal)");
+            *error_message =
+                Some("Request declined by the model's safety system (stop_reason: refusal)".into());
+            StopReason::Refusal
+        }
+        "pause_turn" => {
+            // The model paused mid-turn and expects the conversation to be
+            // re-sent to continue — emitted when a server-side tool loop hits
+            // its iteration limit. There is no resume path here, so reporting
+            // it as a normal stop would hand back a truncated answer as though
+            // it were complete.
+            warn!("Anthropic paused the turn (stop_reason=pause_turn); response is incomplete");
+            *error_message = Some(
+                "Anthropic paused the turn (stop_reason: pause_turn); the response is \
+                 incomplete and must be resumed by re-sending the conversation"
+                    .into(),
+            );
+            StopReason::Error
+        }
+        other => {
+            warn!("unrecognized Anthropic stop_reason '{other}'; treating it as a normal stop");
+            StopReason::Stop
+        }
+    }
+}
+
 /// Resolve the request URL: `{base_url}/messages` when a `ModelConfig` is set
 /// (e.g. a gateway like OpenCode Zen), the official endpoint otherwise.
 fn request_url(config: &StreamConfig) -> String {
@@ -113,10 +176,6 @@ impl StreamProvider for AnthropicProvider {
         // delta without a stop_reason: that proves nothing about completeness.
         let mut saw_stop_reason = false;
         let mut error_message: Option<String> = None;
-        // A tool call whose arguments could not be parsed. Tracked separately
-        // because `message_delta` arrives *after* `content_block_stop` and would
-        // otherwise overwrite the error with its own `tool_use` stop reason.
-        let mut dropped_malformed_tool_call = false;
 
         let _ = tx.send(StreamEvent::Start);
 
@@ -240,10 +299,13 @@ impl StreamProvider for AnthropicProvider {
                                         ),
                                         Some(idx) => {
                                             let idx = idx as usize;
-                                            // Deferred so the mutable borrow of
-                                            // `content` ends before we replace the
-                                            // block below.
-                                            let mut malformed: Option<(String, String)> = None;
+                                            // A block whose accumulator does not
+                                            // parse is left carrying it. The sweep
+                                            // after the loop is what fails the
+                                            // turn — doing it here would miss the
+                                            // blocks this arm never reaches (a
+                                            // non-JSON stop event, or one with no
+                                            // index), which leak the same way.
                                             if let Some(Content::ToolCall { name, arguments, .. }) = content.get_mut(idx) {
                                                 if let Some(partial) = arguments.as_object()
                                                     .and_then(|o| o.get("__partial_json"))
@@ -252,43 +314,13 @@ impl StreamProvider for AnthropicProvider {
                                                 {
                                                     match serde_json::from_str(&partial) {
                                                         Ok(parsed) => *arguments = parsed,
-                                                        Err(e) => {
-                                                            warn!(
-                                                                "tool call `{}` has malformed JSON arguments ({e}): {partial}",
-                                                                name
-                                                            );
-                                                            malformed = Some((name.clone(), partial));
-                                                        }
+                                                        Err(e) => warn!(
+                                                            "tool call `{}` has malformed JSON arguments ({e}): {}",
+                                                            name,
+                                                            truncate_for_error(&partial)
+                                                        ),
                                                     }
                                                 }
-                                            }
-                                            if let Some((tool, partial)) = malformed {
-                                                // Substituting `{}` here (the old
-                                                // behavior) let the tool run with
-                                                // default arguments while neither
-                                                // the caller nor the model learned
-                                                // the model's actual input was
-                                                // dropped — silently wrong action.
-                                                // Failing the turn stops the loop
-                                                // before it executes anything.
-                                                error_message = Some(format!(
-                                                    "Tool call `{tool}` (block {idx}) had malformed JSON \
-                                                     arguments and was not executed: {partial}"
-                                                ));
-                                                stop_reason = StopReason::Error;
-                                                dropped_malformed_tool_call = true;
-                                                // And replace the block: a tool_use
-                                                // with no matching tool_result is
-                                                // rejected by the API on the next
-                                                // request, so leaving it would break
-                                                // the conversation rather than just
-                                                // this turn. Text keeps the index
-                                                // stable for later blocks.
-                                                content[idx] = Content::Text {
-                                                    text: format!(
-                                                        "[tool call `{tool}` dropped: malformed JSON arguments]"
-                                                    ),
-                                                };
                                             }
                                             let _ = tx.send(StreamEvent::ToolCallEnd { content_index: idx });
                                         }
@@ -304,49 +336,22 @@ impl StreamProvider for AnthropicProvider {
                                         // A delta with no stop_reason leaves the
                                         // current one alone — overwriting it would
                                         // clobber a terminal reason an earlier
-                                        // delta already set.
+                                        // delta already set. Only a delta that
+                                        // actually carried one proves the response
+                                        // is finished, so only that arms the
+                                        // clean-EOF guard.
                                         if let Some(reason) = data.delta.stop_reason.as_deref() {
-                                        saw_stop_reason = true;
-                                        stop_reason = match reason {
-                                            "tool_use" => StopReason::ToolUse,
-                                            "max_tokens" => StopReason::Length,
-                                            "model_context_window_exceeded" => {
-                                                // In-stream overflow (HTTP 200). Map to the same
-                                                // Error + overflow-phrase shape as an HTTP 400
-                                                // overflow so Message::is_context_overflow() and
-                                                // compaction-retry hooks keep working.
-                                                warn!("Anthropic context window exceeded mid-stream");
-                                                error_message =
-                                                    Some("model_context_window_exceeded".into());
-                                                StopReason::Error
-                                            }
-                                            "refusal" => {
-                                                warn!(
-                                                    "Anthropic declined the request (stop_reason=refusal)"
-                                                );
-                                                error_message = Some(
-                                                    "Request declined by the model's safety system \
-                                                     (stop_reason: refusal)"
-                                                        .into(),
-                                                );
-                                                StopReason::Refusal
-                                            }
-                                            // A stop reason we do not know yet is
-                                            // reported rather than quietly treated
-                                            // as a normal finish, so a new one
-                                            // (a future `pause_turn`, say) surfaces
-                                            // as a visible change instead of a
-                                            // silent behavior shift.
-                                            other => {
-                                                warn!(
-                                                    "unknown Anthropic stop_reason '{other}'; \
-                                                     treating it as a normal stop"
-                                                );
-                                                StopReason::Stop
-                                            }
-                                        };
+                                            saw_stop_reason = true;
+                                            stop_reason =
+                                                map_stop_reason(reason, &mut error_message);
                                         }
-                                        usage.output = data.usage.output_tokens;
+                                        // A usage-less delta must not zero a real
+                                        // count: `AnthropicUsage` defaults every
+                                        // field, so an absent block would otherwise
+                                        // overwrite the output tokens with 0.
+                                        if let Some(delta_usage) = data.usage {
+                                            usage.output = delta_usage.output_tokens;
+                                        }
                                     }
                                 }
                                 "message_stop" => break,
@@ -403,11 +408,61 @@ impl StreamProvider for AnthropicProvider {
         let has_tool_calls = content
             .iter()
             .any(|c| matches!(c, Content::ToolCall { .. }));
-        // A content-level failure outranks whatever terminal reason the stream
-        // reported: the `message_delta` carrying `tool_use` arrives after the
-        // `content_block_stop` that found the malformed arguments.
-        if dropped_malformed_tool_call {
-            stop_reason = StopReason::Error;
+        // Invariant: no tool call leaves this provider still carrying the
+        // streaming accumulator. `content_block_stop` is what turns
+        // `__partial_json` into real arguments; if it never arrived, or arrived
+        // unusable (not JSON, no index, or holding JSON that does not parse),
+        // the sentinel is still there — and a tool handed
+        // `{"__partial_json": ...}` runs on its defaults instead of what the
+        // model asked for. One sweep covers every route to that state.
+        let unusable: Vec<(String, String)> = content
+            .iter()
+            .filter_map(|c| match c {
+                Content::ToolCall {
+                    name, arguments, ..
+                } => arguments
+                    .get("__partial_json")
+                    .and_then(|v| v.as_str())
+                    .map(|partial| (name.clone(), partial.to_string())),
+                _ => None,
+            })
+            .collect();
+
+        if !unusable.is_empty() {
+            let detail = unusable
+                .iter()
+                .map(|(name, partial)| format!("`{name}` ({})", truncate_for_error(partial)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let note = format!("tool call(s) with unusable arguments, not executed: {detail}");
+            // Append rather than replace: a refusal or an overflow reported by
+            // `message_delta` carries its own diagnosis, and the overflow phrase
+            // is what `Message::is_context_overflow()` matches on.
+            error_message = Some(match error_message.take() {
+                Some(existing) => format!("{existing}; {note}"),
+                None => note,
+            });
+            // A refusal is the more specific verdict and nothing can execute
+            // once the calls are gone, so leave it standing.
+            if stop_reason != StopReason::Refusal {
+                stop_reason = StopReason::Error;
+            }
+            // Every tool call goes, not just the unusable one. The turn executes
+            // none of them, so any that survived would return to the API as a
+            // `tool_use` with no `tool_result` and be rejected on the *next*
+            // request — breaking the conversation rather than just this turn.
+            // Replacing in place keeps `content.len()` aligned with the
+            // provider's block indices.
+            for block in content.iter_mut() {
+                if let Content::ToolCall { name, .. } = block {
+                    let name = name.clone();
+                    *block = Content::Text {
+                        text: format!(
+                            "[tool call `{name}` not executed: the turn failed on unusable tool arguments]"
+                        ),
+                    };
+                }
+            }
         }
 
         // Never let the tool-call fallback mask a refusal or an error signal.
@@ -794,8 +849,11 @@ struct AnthropicMessageDelta {
     // Gateways relaying this protocol sometimes omit `usage` on message_delta.
     // Without the default the whole event fails to parse, silently dropping the
     // stop_reason it carried (downgrading tool_use/max_tokens/refusal to Stop).
+    // `Option` rather than a defaulted struct so an absent block is
+    // distinguishable from a reported zero — otherwise a trailing usage-less
+    // delta overwrites a real output count with 0.
     #[serde(default)]
-    usage: AnthropicUsage,
+    usage: Option<AnthropicUsage>,
 }
 
 #[derive(Deserialize)]

--- a/tests/anthropic_stream_test.rs
+++ b/tests/anthropic_stream_test.rs
@@ -486,6 +486,29 @@ async fn malformed_tool_arguments_fail_the_turn_instead_of_defaulting() {
         !format!("{content:?}").contains("__partial_json"),
         "the accumulator sentinel must not escape: {content:?}"
     );
+
+    // Replaced, not removed. Removing would shift `content.len()` out of step
+    // with the provider's block indices, so a later `content_block_start` pads
+    // with duplicate placeholders; it would also erase the turn from the
+    // transcript, since an assistant message with no blocks is dropped whole
+    // from the next request.
+    let Some(Content::Text { text }) = content.first() else {
+        panic!("the dropped tool call must leave a text block behind: {content:?}");
+    };
+    assert!(
+        text.contains("bash"),
+        "the replacement must record which tool was dropped, got: {text}"
+    );
+    assert_eq!(content.len(), 1, "no other blocks expected: {content:?}");
+
+    // The quoted input is what makes the error actionable in a log.
+    assert!(
+        error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("{not valid json"),
+        "the error must quote the unparseable input, got: {error_message:?}"
+    );
 }
 
 /// Issue #89: `content_block_stop` used to default a missing index to 0, closing
@@ -550,12 +573,39 @@ async fn content_block_stop_without_an_index_does_not_close_block_zero() {
     );
 }
 
-/// Issue #89: an unrecognized `stop_reason` used to be silently reported as a
-/// normal finish. It still maps to `Stop` — that is the safe default — but is
-/// now logged, so a stop reason added by Anthropic later surfaces as a visible
-/// change rather than a silent behavior shift.
+/// Issue #89 follow-up: `end_turn` is what an ordinary completion carries. It
+/// must be matched explicitly — folding it into the unknown-reason arm makes the
+/// "we hit a stop reason we don't handle" warning fire on every healthy turn,
+/// which buries the signal it exists to give.
 #[tokio::test]
-async fn unknown_stop_reason_still_completes_as_a_normal_stop() {
+async fn end_turn_and_stop_sequence_are_recognized_stop_reasons() {
+    for reason in ["end_turn", "stop_sequence"] {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(sse_empty_with_stop(reason), "text/event-stream"),
+            )
+            .mount(&server)
+            .await;
+
+        let message = run_stream(stream_config(&server.uri(), None))
+            .await
+            .unwrap_or_else(|e| panic!("[{reason}] stream should succeed: {e}"));
+        let Message::Assistant { stop_reason, .. } = &message else {
+            panic!("[{reason}] expected assistant message");
+        };
+        assert_eq!(*stop_reason, StopReason::Stop, "[{reason}]");
+    }
+}
+
+/// `pause_turn` means the model stopped mid-turn and expects the conversation
+/// to be re-sent to continue — it is a shipped Anthropic stop reason, not a
+/// hypothetical. Reporting it as a normal stop hands back a truncated answer as
+/// though it were complete; this transport cannot resume, so it must say so.
+#[tokio::test]
+async fn pause_turn_is_reported_as_incomplete_rather_than_finished() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/messages"))
@@ -568,10 +618,200 @@ async fn unknown_stop_reason_still_completes_as_a_normal_stop() {
 
     let message = run_stream(stream_config(&server.uri(), None))
         .await
-        .expect("an unknown stop reason must not fail the stream");
+        .expect("stream should succeed");
+    let Message::Assistant {
+        stop_reason,
+        error_message,
+        ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(
+        *stop_reason,
+        StopReason::Error,
+        "a paused turn is not a finished one"
+    );
+    assert!(
+        error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("pause_turn"),
+        "the error must name the cause, got: {error_message:?}"
+    );
+}
 
+/// A stop reason we genuinely do not recognize still maps to `Stop` — the safe
+/// default — and is logged. Uses a string Anthropic does not define, so this
+/// keeps testing the fallback rather than a value that later gains meaning.
+#[tokio::test]
+async fn unrecognized_stop_reason_falls_back_to_a_normal_stop() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse_empty_with_stop("reason_that_does_not_exist"),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("an unrecognized stop reason must not fail the stream");
     let Message::Assistant { stop_reason, .. } = &message else {
         panic!("expected assistant message");
     };
     assert_eq!(*stop_reason, StopReason::Stop);
+}
+
+/// Issue #89 follow-up: a `content_block_stop` that is unusable — not JSON, or
+/// carrying no index — leaves the block holding the streaming accumulator. If
+/// that reaches the caller, the loop executes the tool with
+/// `{"__partial_json": ...}` as its input, and the tool falls back to its
+/// defaults: `list_files` asked for `/etc` lists the process's cwd instead.
+/// That is the wrong-arguments execution this whole fix exists to stop.
+#[tokio::test]
+async fn an_unfinalized_tool_call_never_reaches_the_caller() {
+    for (label, stop_line) in [
+        ("index-less", r#"data: {"type":"content_block_stop"}"#),
+        ("non-JSON body", "data: not-json-at-all"),
+    ] {
+        let server = MockServer::start().await;
+        let body = format!(
+            "event: message_start\n\
+             data: {{\"type\":\"message_start\",\"message\":{{\"usage\":{{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}}}}\n\n\
+             event: content_block_start\n\
+             data: {{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"bash\",\"input\":{{}}}}}}\n\n\
+             event: content_block_delta\n\
+             data: {{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{{\"type\":\"input_json_delta\",\"partial_json\":\"{{\\\"cmd\\\":\\\"ls\\\"}}\"}}}}\n\n\
+             event: content_block_stop\n\
+             {stop_line}\n\n\
+             event: message_delta\n\
+             data: {{\"type\":\"message_delta\",\"delta\":{{\"stop_reason\":\"tool_use\"}},\"usage\":{{\"output_tokens\":9}}}}\n\n\
+             event: message_stop\n\
+             data: {{\"type\":\"message_stop\"}}\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let message = run_stream(stream_config(&server.uri(), None))
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] stream should not error: {e}"));
+        let Message::Assistant {
+            content,
+            stop_reason,
+            ..
+        } = &message
+        else {
+            panic!("[{label}] expected assistant message");
+        };
+        assert!(
+            !format!("{content:?}").contains("__partial_json"),
+            "[{label}] the accumulator escaped as tool arguments: {content:?}"
+        );
+        assert_ne!(
+            *stop_reason,
+            StopReason::ToolUse,
+            "[{label}] an unfinalized tool call must not be presented as runnable"
+        );
+    }
+}
+
+/// Issue #89 follow-up: the malformed block is replaced precisely because a
+/// `tool_use` with no matching `tool_result` is rejected on the next request.
+/// The turn executes nothing, so a *healthy* sibling would never get a
+/// `tool_result` either — leaving it would move the same 400 one turn later.
+#[tokio::test]
+async fn a_healthy_sibling_tool_call_does_not_dangle() {
+    let server = MockServer::start().await;
+    let body = "event: message_start\n\
+         data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n\n\
+         event: content_block_start\n\
+         data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_0\",\"name\":\"read\",\"input\":{}}}\n\n\
+         event: content_block_delta\n\
+         data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"p\\\":\\\"a\\\"}\"}}\n\n\
+         event: content_block_stop\n\
+         data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+         event: content_block_start\n\
+         data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"bash\",\"input\":{}}}\n\n\
+         event: content_block_delta\n\
+         data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{not valid\"}}\n\n\
+         event: content_block_stop\n\
+         data: {\"type\":\"content_block_stop\",\"index\":1}\n\n\
+         event: message_delta\n\
+         data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n\
+         event: message_stop\n\
+         data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+    let Message::Assistant {
+        content,
+        stop_reason,
+        error_message,
+        ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(*stop_reason, StopReason::Error);
+    assert!(error_message.as_deref().unwrap_or("").contains("bash"));
+    assert!(
+        !content
+            .iter()
+            .any(|c| matches!(c, Content::ToolCall { .. })),
+        "no tool_use may survive an errored turn unanswered: {content:?}"
+    );
+}
+
+/// A trailing `message_delta` carrying neither a stop reason nor usage must not
+/// downgrade what an earlier one established. Gateways relaying this protocol
+/// emit such deltas.
+#[tokio::test]
+async fn a_trailing_empty_delta_preserves_stop_reason_and_usage() {
+    let server = MockServer::start().await;
+    let body = "event: message_start\n\
+         data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n\n\
+         event: message_delta\n\
+         data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"refusal\"},\"usage\":{\"output_tokens\":42}}\n\n\
+         event: message_delta\n\
+         data: {\"type\":\"message_delta\",\"delta\":{}}\n\n\
+         event: message_stop\n\
+         data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+    let Message::Assistant {
+        stop_reason, usage, ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(
+        *stop_reason,
+        StopReason::Refusal,
+        "a trailing delta must not downgrade a terminal stop reason"
+    );
+    assert_eq!(
+        usage.output, 42,
+        "a usage-less trailing delta must not zero the count"
+    );
 }

--- a/tests/anthropic_stream_test.rs
+++ b/tests/anthropic_stream_test.rs
@@ -413,3 +413,165 @@ async fn message_delta_without_usage_still_yields_its_stop_reason() {
         "stop_reason must survive a message_delta with no usage field"
     );
 }
+
+/// Issue #89: malformed tool-call JSON used to be replaced with an empty
+/// object, so the tool ran with default arguments and neither the caller nor
+/// the model learned the model's actual input had been dropped — silently wrong
+/// action. It must fail the turn instead.
+///
+/// This is on the happy path for this crate's own configuration: we send the
+/// `fine-grained-tool-streaming` beta, which Anthropic documents as able to
+/// emit incomplete tool JSON when a response hits `max_tokens`.
+#[tokio::test]
+async fn malformed_tool_arguments_fail_the_turn_instead_of_defaulting() {
+    let server = MockServer::start().await;
+    // `input_json_delta` never completes into valid JSON, but the block and the
+    // message are both properly terminated — so this is not truncation, it is a
+    // well-formed stream carrying an unparseable tool input.
+    let body = "event: message_start\n\
+         data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n\n\
+         event: content_block_start\n\
+         data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"bash\",\"input\":{}}}\n\n\
+         event: content_block_delta\n\
+         data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{not valid json\"}}\n\n\
+         event: content_block_stop\n\
+         data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+         event: message_delta\n\
+         data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n\
+         event: message_stop\n\
+         data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("the stream itself is well-formed");
+
+    let Message::Assistant {
+        stop_reason,
+        error_message,
+        content,
+        ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+
+    // The agent loop returns on Error *before* extracting tool calls, so this
+    // is what stops the tool from running with fabricated arguments.
+    assert_eq!(
+        *stop_reason,
+        StopReason::Error,
+        "a tool call we cannot parse must not be presented as a usable turn"
+    );
+    assert!(
+        error_message.as_deref().unwrap_or("").contains("bash"),
+        "the error must name the tool, got: {error_message:?}"
+    );
+
+    // No tool_use may survive: it would go back to the API with no matching
+    // tool_result and be rejected on the next request.
+    assert!(
+        !content
+            .iter()
+            .any(|c| matches!(c, Content::ToolCall { .. })),
+        "the unusable tool call must not remain in the message"
+    );
+    // And the internal accumulator must never leak into the message.
+    assert!(
+        !format!("{content:?}").contains("__partial_json"),
+        "the accumulator sentinel must not escape: {content:?}"
+    );
+}
+
+/// Issue #89: `content_block_stop` used to default a missing index to 0, closing
+/// a block the event was never about.
+///
+/// The damage is concrete: block 0 is still accumulating here, so closing it
+/// early parses a half-written `{"cmd":` and — correctly, per the fix above —
+/// fails the whole turn. Ignoring the index-less event lets block 0 finish and
+/// the turn succeed.
+#[tokio::test]
+async fn content_block_stop_without_an_index_does_not_close_block_zero() {
+    let server = MockServer::start().await;
+    let body = "event: message_start\n\
+         data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n\n\
+         event: content_block_start\n\
+         data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"bash\",\"input\":{}}}\n\n\
+         event: content_block_delta\n\
+         data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\":\"}}\n\n\
+         event: content_block_stop\n\
+         data: {\"type\":\"content_block_stop\"}\n\n\
+         event: content_block_delta\n\
+         data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"ls\\\"}\"}}\n\n\
+         event: content_block_stop\n\
+         data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+         event: message_delta\n\
+         data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n\
+         event: message_stop\n\
+         data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("stream should succeed");
+
+    let Message::Assistant {
+        content,
+        stop_reason,
+        ..
+    } = &message
+    else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(
+        *stop_reason,
+        StopReason::ToolUse,
+        "an index-less stop must not close block 0 mid-accumulation and fail the turn"
+    );
+    let Some(Content::ToolCall { arguments, .. }) = content
+        .iter()
+        .find(|c| matches!(c, Content::ToolCall { .. }))
+    else {
+        panic!("the tool call must survive: {content:?}");
+    };
+    assert_eq!(
+        arguments["cmd"], "ls",
+        "arguments must assemble fully: {arguments:?}"
+    );
+}
+
+/// Issue #89: an unrecognized `stop_reason` used to be silently reported as a
+/// normal finish. It still maps to `Stop` — that is the safe default — but is
+/// now logged, so a stop reason added by Anthropic later surfaces as a visible
+/// change rather than a silent behavior shift.
+#[tokio::test]
+async fn unknown_stop_reason_still_completes_as_a_normal_stop() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop("pause_turn"), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let message = run_stream(stream_config(&server.uri(), None))
+        .await
+        .expect("an unknown stop reason must not fail the stream");
+
+    let Message::Assistant { stop_reason, .. } = &message else {
+        panic!("expected assistant message");
+    };
+    assert_eq!(*stop_reason, StopReason::Stop);
+}

--- a/tests/anthropic_stream_test.rs
+++ b/tests/anthropic_stream_test.rs
@@ -573,6 +573,100 @@ async fn content_block_stop_without_an_index_does_not_close_block_zero() {
     );
 }
 
+/// Captures `tracing` events on this thread so a test can assert on what was
+/// *not* logged.
+///
+/// This is the crate's only log-asserting harness, and it earns its place: the
+/// regression it guards — a `warn!` firing on every healthy turn — is invisible
+/// to every behavioral assertion, because the stop reason is `Stop` either way.
+/// It shipped once for exactly that reason. `set_default` is thread-local and
+/// `#[tokio::test]` keeps the task on one thread, so parallel tests do not
+/// interfere.
+#[derive(Clone, Default)]
+struct CapturedLogs(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+impl CapturedLogs {
+    fn contains(&self, needle: &str) -> bool {
+        self.0.lock().unwrap().iter().any(|l| l.contains(needle))
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedLogs {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        struct Msg(String);
+        impl tracing::field::Visit for Msg {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{value:?}");
+                }
+            }
+        }
+        let mut msg = Msg(String::new());
+        event.record(&mut msg);
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("{}: {}", event.metadata().level(), msg.0));
+    }
+}
+
+/// Run a canned stream with `tracing` captured.
+async fn run_stream_capturing_logs(stop_reason: &str) -> CapturedLogs {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let logs = CapturedLogs::default();
+    let _guard =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(logs.clone()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_empty_with_stop(stop_reason), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    run_stream(stream_config(&server.uri(), None))
+        .await
+        .unwrap_or_else(|e| panic!("[{stop_reason}] stream should succeed: {e}"));
+
+    logs
+}
+
+/// The regression that motivated listing every stop reason explicitly: with
+/// `end_turn` folded into the catch-all, the "unrecognized stop reason" warning
+/// fired on every successful turn, burying the signal it exists to give. No
+/// behavioral assertion can see this — `end_turn` maps to `Stop` either way.
+#[tokio::test]
+async fn a_healthy_turn_logs_no_stop_reason_warning() {
+    for reason in ["end_turn", "stop_sequence"] {
+        let logs = run_stream_capturing_logs(reason).await;
+        assert!(
+            !logs.contains("unrecognized Anthropic stop_reason"),
+            "[{reason}] a recognized stop reason must not warn; captured: {:?}",
+            logs.0.lock().unwrap()
+        );
+    }
+}
+
+/// The other half: a genuinely unrecognized reason must still be reported, or
+/// the arm is silent again.
+#[tokio::test]
+async fn an_unrecognized_stop_reason_is_logged() {
+    let logs = run_stream_capturing_logs("reason_that_does_not_exist").await;
+    assert!(
+        logs.contains("unrecognized Anthropic stop_reason"),
+        "an unrecognized stop reason must be logged; captured: {:?}",
+        logs.0.lock().unwrap()
+    );
+}
+
 /// Issue #89 follow-up: `end_turn` is what an ordinary completion carries. It
 /// must be matched explicitly — folding it into the unknown-reason arm makes the
 /// "we hit a stop reason we don't handle" warning fire on every healthy turn,


### PR DESCRIPTION
Closes #89.

## The bug

When a tool call's streamed `input_json_delta` did not assemble into valid JSON:

```rust
warn!("Failed to parse tool call JSON: {}", partial);
*arguments = serde_json::Value::Object(Default::default());
```

The tool then **executed with default arguments** while neither the caller nor the model learned the model's actual input had been dropped. Silently wrong action — and it contradicts the project convention that tools surface failures so the LLM can self-correct.

Not a corner case here: yoagent sends the `fine-grained-tool-streaming` beta, which Anthropic documents as able to emit incomplete tool JSON when a response hits `max_tokens`.

## The fix

The turn fails with an `error_message` naming the tool and quoting the unparseable input. `agent_loop` returns on `StopReason::Error` **before** it extracts tool calls (`agent_loop.rs:470`), so nothing executes.

Two details that shaped it:

- **The unusable `tool_use` block is replaced with text, not left in place.** A `tool_use` with no matching `tool_result` is rejected by the API on the *next* request, so leaving it would break the conversation rather than just the turn. Replacing in place keeps later block indices stable.
- **The stop reason had to be re-asserted after the stream loop.** `message_delta` arrives *after* `content_block_stop`, so its `tool_use` was overwriting the error. A content-level failure now outranks the stream's reported reason, ahead of the existing tool-call override.

## Also from #89

- `content_block_stop` with a **non-JSON body** was skipped in silence — leaving a tool call unfinalized *and* emitting no `ToolCallEnd`, so a UI tracking the call's lifecycle hung it open forever. Now logged.
- `content_block_stop` with a **missing or non-numeric index** defaulted to block 0, closing a block the event was never about. With the fix above that could parse a half-written accumulator and fail an otherwise healthy turn. Now ignored with a warning.
- An **unrecognized `stop_reason`** was silently reported as a normal finish. It still maps to `Stop`, but is logged, so one added later surfaces as a visible change. A `message_delta` carrying no `stop_reason` also no longer overwrites one an earlier delta set.

## Testing

Three tests, each verified against the mutation it targets.

The index test needed a second attempt worth mentioning: the obvious version — an index-less `content_block_stop` followed by a proper one — **passed with the old default-to-0 behavior**, because closing block 0 twice is harmless. It now leaves block 0 mid-accumulation, where defaulting parses incomplete JSON and fails the turn, so the two behaviors are actually distinguishable.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` under `-Dwarnings`, `cargo doc`, and all 22 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)