### PR TITLE
release: 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.14.1
 
 ### Fixed
 
@@ -36,8 +36,6 @@ adheres to [Semantic Versioning](https://semver.org/).
   its explanation; the tool-argument note is appended rather than substituted,
   so an in-stream context overflow still matches `Message::is_context_overflow()`
   and its compaction-retry hook.
-
-### Fixed
 
 - **`end_turn` and `stop_sequence` are recognized stop reasons** (Anthropic).
   They previously fell through to the catch-all. Harmless until the catch-all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = "0.12"
+yoagent = "0.14"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/concepts/gasp.md
+++ b/docs/concepts/gasp.md
@@ -13,7 +13,7 @@ runtime). The bridge is a consumer of the [`AgentEvent`] stream — **zero
 agent-loop changes**:
 
 ```toml
-yoagent = { version = "0.12", features = ["gasp"] }
+yoagent = { version = "0.14", features = ["gasp"] }
 ```
 
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-yoagent = "0.12"
+yoagent = "0.14"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -40,5 +40,5 @@ Enable in `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = { version = "0.12", features = ["openapi"] }
+yoagent = { version = "0.14", features = ["openapi"] }
 ```

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -51,12 +51,44 @@ needed.
 
 Thinking content is streamed as `Content::Thinking` with a cryptographic `signature` for verification.
 
-### Refusals
+### Stop Reasons
 
-Models with safety classifiers (e.g. Claude Fable 5) can decline a request
-with `stop_reason: "refusal"`. The provider maps this to `StopReason::Refusal`;
-the agent loop stops the turn like a normal `Stop`, and callers can match on
-the variant to retry on a fallback model.
+Every documented Anthropic `stop_reason` maps explicitly:
+
+| Wire value | `StopReason` | Notes |
+|---|---|---|
+| `end_turn`, `stop_sequence` | `Stop` | |
+| `tool_use` | `ToolUse` | |
+| `max_tokens` | `Length` | |
+| `refusal` | `Refusal` | Sets `error_message`; see below |
+| `model_context_window_exceeded` | `Error` | In-stream overflow; keeps the phrase `Message::is_context_overflow()` matches, so compaction-retry hooks still fire |
+| `pause_turn` | `Error` | The model stopped mid-turn expecting the conversation to be re-sent. This transport cannot resume, so reporting it as a normal stop would return a truncated answer as though it were complete |
+
+Anything unrecognized maps to `Stop` and is logged at `warn`, so a stop reason
+added by Anthropic later is visible rather than silently treated as a finish.
+
+**Refusals.** Models with safety classifiers (e.g. Claude Fable 5) can decline a
+request with `stop_reason: "refusal"`. The agent loop stops the turn like a
+normal `Stop`, and callers can match on the variant to retry on a fallback model.
+
+### Tool Calls With Unusable Arguments
+
+A tool call's arguments arrive as `input_json_delta` fragments and are assembled
+at `content_block_stop`. When that assembly cannot happen — the accumulated text
+is not valid JSON, or the `content_block_stop` event itself is unusable — the
+turn fails with `StopReason::Error` and an `error_message` naming each affected
+tool and quoting its input.
+
+This matters because the alternative is silent: a tool executed with empty
+arguments falls back to its defaults, so `list_files` asked for `/etc` would
+list the working directory instead, with nothing in the response indicating the
+model's actual input was dropped.
+
+`agent_loop` returns on `StopReason::Error` before extracting tool calls, so
+nothing executes. Every tool call in the message is replaced with a text block —
+not just the unusable one — because the turn runs none of them, and a `tool_use`
+block with no matching `tool_result` is rejected by the API on the *next*
+request.
 
 ### Cache Control
 


### PR DESCRIPTION
Version bump for the Anthropic tool-call and stop-reason fixes (#89, merged in #94).

- `Cargo.toml`: `0.14.0` → `0.14.1`
- `CHANGELOG.md`: `## Unreleased` → `## 0.14.1`, and collapses a duplicated `### Fixed` heading introduced while editing the entry

**Patch, not minor.** No API surface changed — these are correctness fixes.

Two are worth knowing about before upgrading, both documented in the entry:

- A turn carrying a tool call whose streamed arguments never assembled into valid JSON now **fails** instead of executing the tool with defaults. That is the point of the fix, but a stream that previously returned a usable-looking turn will now return `StopReason::Error`.
- `pause_turn` now maps to `Error` rather than `Stop`. It means the model stopped mid-turn expecting the conversation to be re-sent; reporting it as a normal stop handed back a truncated answer as though it were complete.

Merging triggers the tag + GitHub Release, which fires `publish.yml` to publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)