### PR TITLE
docs: rewrite README for adoption, fix docs.rs rendering an incomplete crate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something in yoagent behaves incorrectly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Most yoagent bugs turn out to be provider-specific, so the
+        protocol and model id below usually save a round-trip.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >-
+        Ideally a minimal snippet. A `MockProvider` repro is the fastest path to a fix, but a
+        description of the failing request works too.
+      render: rust
+    validations:
+      required: false
+
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: API protocol
+      description: Which wire protocol was in use?
+      options:
+        - Anthropic Messages
+        - OpenAI Completions (incl. Groq, xAI, DeepSeek, Ollama, local, ...)
+        - OpenAI Responses
+        - Azure OpenAI
+        - Google Generative AI (Gemini)
+        - Google Vertex
+        - Bedrock ConverseStream
+        - Not provider-related / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: provider-model
+    attributes:
+      label: Provider and model id
+      description: e.g. `anthropic` / `claude-sonnet-5`, or `ollama` / `llama3.1:8b`
+      placeholder: provider / model-id
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: yoagent version
+      placeholder: "0.14.1"
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version` (MSRV is 1.86)
+      placeholder: "rustc 1.86.0"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: features
+    attributes:
+      label: Cargo features enabled
+      options:
+        - label: "`openapi`"
+        - label: "`gasp`"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: >-
+        Any relevant `tracing` output or error text. Please redact API keys — yoagent never logs
+        them, but pasted request dumps sometimes contain them.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest a capability or an improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        yoagent is deliberately narrow — the loop, tool execution, and what's needed to run it in
+        production. Retrieval, vector stores, and task-graph orchestration are intentionally out of
+        scope. That doesn't mean don't ask; it just helps to say how the idea fits the loop.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that yoagent makes hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you'd like
+      description: A sketch of the API or behaviour you have in mind.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - The agent loop
+        - A provider / protocol
+        - Tools (built-in or the AgentTool trait)
+        - MCP
+        - OpenAPI
+        - Sub-agents / shared state
+        - Context management / sessions
+        - Telemetry / cost tracking
+        - GASP recording
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you've tried
+      description: >-
+        Including "none" is fine. If you solved it outside yoagent, knowing how helps judge whether
+        this belongs in the crate.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Title convention: feat: / fix: / docs: / chore: / release:
+-->
+
+## What this changes
+
+<!-- One or two sentences. Link the issue if there is one: "Closes #123". -->
+
+## Why
+
+<!-- What was broken or missing. For provider fixes, name the provider and protocol. -->
+
+## How it was verified
+
+<!--
+Say what you actually ran, not what should pass. If a test is new, say what it would catch —
+ideally confirm it fails without the fix.
+-->
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --all-targets --all-features` (CI runs with `-Dwarnings`)
+- [ ] `cargo test --all-features`
+
+## Checklist
+
+- [ ] Tests cover the change
+- [ ] `CHANGELOG.md` updated under `## Unreleased`
+- [ ] Docs updated ([`docs/`](../docs/) and/or rustdoc) if user-facing
+- [ ] No new public API without a doc comment
+
+<!--
+Breaking change? Say so explicitly here and describe the migration.
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 .DS_Store
+# mdbook build output (`mdbook build`); the site is published by CI
+/book

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- **docs.rs was rendering an incomplete crate.** Without
+  `[package.metadata.docs.rs]`, docs.rs built with default features, so the
+  `openapi` and `gasp` modules — both advertised in the README — were missing
+  from the published API reference. The build now enables all features and
+  passes `--cfg docsrs`, and both feature-gated modules carry `doc(cfg(..))`
+  availability badges.
+
+### Changed
+
+- **README rewritten for first-time readers.** It now leads with the one
+  command that runs a real coding agent against a local model with no API key,
+  a Quick Start that actually calls a tool (every snippet compile-checked), a
+  diagram of the loop, and a section stating plainly what yoagent does *not* do
+  and which crates to use instead. Capabilities moved from a ~40-bullet wall
+  into six collapsible groups.
+- Surfaced what the README previously omitted: `SharedState`, `InputFilter`,
+  `MockProvider`, cost tracking, `set_model`, the OpenCode gateways, all ten
+  examples (nine were unreferenced), and the testing story — 456 of 463 tests
+  run with no network and no API keys.
+- Corrected stale claims: the CLI example is 370 lines, not ~250; the
+  OpenAI-compatible implementation covers 12 compat profiles, not "15+"; and
+  the module map now covers all of `src/`, including `mcp/`, `openapi/`,
+  `session`, `skills`, `shared_state`, `retry`, and `gasp` — roughly 4,000
+  lines the old architecture tree left out.
+- `docs/introduction.md`, the landing page the `homepage` field points at, was
+  a 27-line subset that never mentioned sub-agents, tool middleware, structured
+  outputs, skills, session trees, GASP, MCP, or OpenAPI. Rewritten to match the
+  README and link the pages that cover each area.
+- Crate metadata: filled the three unused crates.io category slots and swapped
+  two low-traffic keywords for `anthropic` and `openai`.
+
+### Added
+
+- `CONTRIBUTING.md`, `SECURITY.md`, issue templates (the bug report asks for
+  the protocol and model id up front, since most reports are provider-specific)
+  and a pull request template — the repository previously had none.
+- Loop and sub-agent/shared-state diagrams in `docs/images/`, with light and
+  dark variants.
+
 ## 0.14.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ adheres to [Semantic Versioning](https://semver.org/).
   and a pull request template — the repository previously had none.
 - Loop and sub-agent/shared-state diagrams in `docs/images/`, with light and
   dark variants.
+- A **Built with yoagent** section listing the projects that depend on the
+  crate, headed by [yoyo-evolve](https://github.com/yologdev/yoyo-evolve), plus
+  an invitation to add your own.
 
 ## 0.14.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to yoagent
+
+Thanks for taking the time. Bug reports, provider quirks, and small focused PRs are all welcome.
+
+## Getting set up
+
+```bash
+git clone https://github.com/yologdev/yoagent && cd yoagent
+cargo build --all-features
+cargo test --all-features
+```
+
+You need **Rust 1.86 or newer** — that's the MSRV, and CI checks it on every PR.
+
+No API keys are required to develop on yoagent. Of the 463 tests, 456 run with no network and no
+credentials; the 7 that need a live key are `#[ignore]`d by default and live in
+`tests/integration_*.rs`.
+
+## Before you open a PR
+
+CI runs with `RUSTFLAGS="-Dwarnings"`, so **any** clippy warning fails the build. Run the same
+checks locally first:
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-targets --all-features
+cargo test --all-features
+```
+
+CI additionally runs a Windows compile check, an MSRV (1.86) check, and a GASP conformance job
+that emits an agent repo and validates it against the protocol's checker.
+
+## Conventions
+
+**Branches** — `feat/<feature-name>` off `main`.
+
+**Commits and PR titles** — prefix with `feat:`, `fix:`, `docs:`, `chore:`, or `release:`.
+
+**Tests** — new behaviour needs a test. Unit tests live beside the code in `src/`; integration
+tests go in `tests/`. Use `MockProvider` (`src/provider/mock.rs`) to script LLM responses rather
+than hitting a real API:
+
+```rust
+let provider = MockProvider::new(vec![
+    MockResponse::ToolCalls(vec![/* ... */]),
+    MockResponse::Text("done".into()),
+]);
+let agent = Agent::from_provider(provider, ModelConfig::mock());
+```
+
+A test that only passes because of a timing assumption isn't a test. If you're unsure a new test
+actually covers the change, break the change deliberately and confirm the test fails.
+
+**Docs** — user-facing changes belong in the [mdBook](docs/) as well as in rustdoc. Build the site
+locally with `mdbook build` and open `book/index.html`.
+
+**Changelog** — add an entry under `## Unreleased` in [CHANGELOG.md](CHANGELOG.md).
+
+## Adding a provider
+
+Most new providers are OpenAI-compatible and need no new code — just a `ModelConfig` with the right
+`base_url` and an `OpenAiCompat` flag set for any quirks (auth style, reasoning format,
+`max_tokens` field name). See `src/provider/model.rs` for the existing presets.
+
+A genuinely new wire protocol means implementing `StreamProvider` (`src/provider/traits.rs`), adding
+an `ApiProtocol` variant, wiring it into `ProviderRegistry`, and adding a `wiremock`-based SSE test
+alongside the existing ones in `tests/*_stream_test.rs`.
+
+If a provider reports context overflow with a new error string, add it to `OVERFLOW_PHRASES` in
+`src/provider/traits.rs` — that list is the single place overflow is detected.
+
+## Reporting bugs
+
+Provider-specific issues are the most common kind, so please include the protocol and provider
+along with the model id. The [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml) asks for
+these. A minimal reproduction using `MockProvider` is the fastest path to a fix, but a description
+of the failing request is fine too.
+
+## Security
+
+Please don't open a public issue for a vulnerability — see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,13 @@ alongside the existing ones in `tests/*_stream_test.rs`.
 If a provider reports context overflow with a new error string, add it to `OVERFLOW_PHRASES` in
 `src/provider/traits.rs` — that list is the single place overflow is detected.
 
+## Adding your project to the README
+
+If you've built something on yoagent, open a PR adding a row to the **Built with yoagent** table in
+[README.md](README.md) — project link and one line on what it is. It doesn't need to be big or
+finished. Seeing what people build with the loop is genuinely useful for deciding what to work on
+next.
+
 ## Reporting bugs
 
 Provider-specific issues are the most common kind, so please include the protocol and provider

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,23 @@ repository = "https://github.com/yologdev/yoagent"
 homepage = "https://yologdev.github.io/yoagent/"
 documentation = "https://docs.rs/yoagent"
 readme = "README.md"
-keywords = ["agent", "llm", "ai", "tools", "streaming"]
-categories = ["api-bindings", "asynchronous"]
+keywords = ["agent", "llm", "ai", "anthropic", "openai"]
+categories = [
+    "api-bindings",
+    "asynchronous",
+    "development-tools",
+    "web-programming::http-client",
+    "network-programming",
+]
 authors = ["Yuanhao <yuanhao@yolog.dev>"]
 rust-version = "1.86"
 exclude = ["docs/images/*", "docs/theme/*", ".github/*", "scripts/*"]
+
+# docs.rs builds with default features unless told otherwise, which would hide
+# the `openapi` and `gasp` modules that the README advertises.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "sync", "fs", "macros", "process", "time", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ What that focus bought:
 
 ---
 
+## Built with yoagent
+
+**[yoyo-evolve](https://github.com/yologdev/yoyo-evolve)** [![][yoyo-stars]][yoyo-link] — a coding
+agent that evolves its own source in public. It began as 200 lines of Rust; every commit since has
+been agent-written and gated on tests. It runs on this loop with the `openapi` feature enabled.
+
+Also built on yoagent:
+
+| Project | What it is |
+|---|---|
+| [`rab`](https://github.com/markokocic/rab) | A lightweight, extensible Rust coding agent |
+| [`greatsage`](https://github.com/rick68/greatsage) | "Rimuru's Unique Skill, you know the one" |
+| [`yoclaw`](https://github.com/yologdev/yoclaw) | OpenClaw reborn in Rust — a single-binary agent that remembers you |
+
+Built something on yoagent? [Open a PR](CONTRIBUTING.md) and add it here — we'd like to see it.
+
+---
+
 ## What's in the box
 
 <details open>
@@ -369,3 +387,5 @@ Inspired by [pi-agent-core](https://github.com/badlogic/pi-mono/tree/main/packag
 [msrv-link]: https://github.com/yologdev/yoagent/blob/main/Cargo.toml
 [license-shield]: https://img.shields.io/badge/license-MIT-white?labelColor=black&style=flat-square
 [license-link]: https://github.com/yologdev/yoagent/blob/main/LICENSE
+[yoyo-stars]: https://img.shields.io/github/stars/yologdev/yoyo-evolve?labelColor=black&style=flat-square&color=c4f042
+[yoyo-link]: https://github.com/yologdev/yoyo-evolve

--- a/README.md
+++ b/README.md
@@ -4,168 +4,42 @@
   <img alt="yoagent" src="docs/images/banner.png" width="100%" height="auto">
 </picture>
 
-<a href="https://crates.io/crates/yoagent">crates.io</a> · <a href="https://yologdev.github.io/yoagent/">Docs</a> · <a href="https://github.com/yologdev/yoagent">GitHub</a> · <a href="https://deepwiki.com/yologdev/yoagent">DeepWiki</a> · <a href="https://github.com/yologdev/yoagent/issues">Issues</a> · <a href="https://github.com/yologdev/yoagent/releases">Releases</a>
+<a href="https://crates.io/crates/yoagent">crates.io</a> · <a href="https://yologdev.github.io/yoagent/">Docs</a> · <a href="https://docs.rs/yoagent">API</a> · <a href="https://github.com/yologdev/yoagent">GitHub</a> · <a href="https://deepwiki.com/yologdev/yoagent">DeepWiki</a> · <a href="CHANGELOG.md">Changelog</a>
 
 [![][crates-shield]][crates-link]
+[![][docsrs-shield]][docsrs-link]
 [![][ci-shield]][ci-link]
+[![][msrv-shield]][msrv-link]
 [![][license-shield]][license-link]
-[![][docs-shield]][docs-link]
-[![][last-commit-shield]][last-commit-link]
+
+**The agent loop for Rust.** Stream from any of 7 LLM protocols, run tools, loop until done.
 
 </div>
 
----
-
-## Overview
-
-yoagent is a simple, effective agent loop with tool execution and event streaming in Rust. Inspired by [pi-agent-core](https://github.com/badlogic/pi-mono/tree/main/packages/agent).
-
-The loop is the product. No over-engineered planning/reflection/RAG layers — just:
-
-```
-Prompt → LLM Stream → Tool Execution → Loop if tool calls → Done
-```
-
-Everything is observable via events. Supports 7 API protocols covering 20+ LLM providers out of the box.
-
-## Features
-
-**Agent Loop**
-- Stateful agent with steering (interrupt mid-run) and follow-up (queue work after completion)
-- Full event stream: `AgentStart` → `TurnStart` → `MessageUpdate` (deltas) → `ToolExecution` → `TurnEnd` → `AgentEnd`
-- Parallel tool execution by default — sequential and batched strategies also available
-- Sub-agents via `SubAgentTool` — delegate tasks to child agent loops with their own tools and system prompts
-- Tool middleware — async approve/deny/modify hooks gating every tool call (`with_tool_middleware`), the mechanism for permission prompts and policy engines
-- Structured outputs — `prompt_structured::<T>()` returns typed, schema-validated replies, enforced natively where supported (Anthropic tool-forcing, OpenAI `json_schema`, Gemini `responseSchema`; other protocols log a warning)
-- Real-time event streaming — `prompt()` spawns the loop concurrently and returns events immediately; `prompt_with_sender()` accepts a caller-provided channel for custom consumption
-- Streaming tool output — tools emit real-time progress via `on_update` callback
-- Multimodal support — `Content::Image` flows through tool results across all providers
-- Automatic retry with exponential backoff and jitter for rate limits and network errors
-- Custom message types via `AgentMessage::Extension` — app-specific messages that don't pollute LLM context
-- State persistence — `save_messages()` / `restore_messages()` for pause/resume workflows
-- Session trees — branching history with fork, checkpoints, and JSONL persistence (`Session`); edit an earlier turn and re-run without losing the original branch
-- Lifecycle callbacks — `before_turn`, `after_turn`, `on_error` for observability and control
-- Telemetry — `tracing` spans for the loop, each LLM stream (tokens + cost fields), and each tool execution; bridge to OpenTelemetry via `tracing-opentelemetry`, negligible overhead when no subscriber is installed
-- Full serde support — all core types implement `Serialize`/`Deserialize`/`PartialEq`
-- [AgentSkills](https://agentskills.io)-compatible skills — load skill directories, inject into system prompt, agent activates on demand
-
-**Multi-Provider**
-- 7 API protocols, 20+ providers behind one `StreamProvider` trait
-- One OpenAI-compatible implementation covers OpenAI, xAI, Groq, Cerebras, OpenRouter, Mistral, and more
-- Per-provider quirk flags (`OpenAiCompat`, `AnthropicCompat`) handle auth, reasoning format, and tool handling differences
-- Capability notes: thinking/reasoning controls are wired for **all 7 protocols** — Anthropic (adaptive/budget), OpenAI-compatible where the `ModelConfig` opts in (the `openai()`/`deepseek()`/`meta()` presets do; other compat presets silently drop `thinking_level`), OpenAI Responses & Azure (reasoning effort), Gemini & Vertex (`thinkingConfig` with thought summaries streamed back), Bedrock (Anthropic-style budgets, reasoning deltas streamed back). Client-side prompt-cache breakpoints are Anthropic-specific; most other providers cache server-side automatically, but Bedrock has no automatic caching
-
-**Built-in Tools**
-- `bash` — Shell execution with timeout, output truncation, command deny patterns
-- `read_file` / `write_file` — File I/O with line numbers, path restrictions, auto-mkdir
-- `edit_file` — Surgical search/replace with fuzzy match error hints
-- `list_files` — Directory exploration via `find`
-- `search` — Pattern search via ripgrep/grep with context lines
-
-**Integrations**
-- OpenAPI tool adapter — auto-generate tools from any OpenAPI 3.0 spec (`features = ["openapi"]`)
-- MCP (Model Context Protocol) — connect to MCP tool servers via stdio or HTTP
-- GASP (`features = ["gasp"]`) — record runs into a [GASP](https://github.com/yologdev/gasp) agent repo (append-only semantic event log; restore = clone + replay); yoagent is a **tested** GASP-conformant runtime — the protocol's 7-check conformance suite runs in CI
-
-**Context Management**
-- Context overflow detection across all major providers (Anthropic, OpenAI, Google, Bedrock, xAI, Groq, OpenRouter, llama.cpp, and more)
-- `ContextTracker` — hybrid real-usage + estimation for accurate token tracking
-- Tiered compaction: truncate tool outputs → summarize old turns → drop middle
-- Execution limits (max turns, max tokens, timeout)
-- Building blocks for LLM-based summarization (`replace_messages()`, `compact_messages()`)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/loop.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/images/loop-light.svg">
+  <img alt="The yoagent loop: prompt, LLM stream, tool execution, loop" src="docs/images/loop.svg" width="100%">
+</picture>
 
 ---
 
-## Quick Start
-
-### Install
+## Try it in one command — no API key
 
 ```bash
-cargo add yoagent tokio --features tokio/full
+git clone https://github.com/yologdev/yoagent && cd yoagent
+ollama serve &                                    # any local model works
+cargo run --example cli -- --provider ollama
 ```
 
-Or add to `Cargo.toml`:
-
-```toml
-[dependencies]
-yoagent = "0.14"
-tokio = { version = "1", features = ["full"] }
-```
-
-### Basic Usage
-
-```rust
-use yoagent::agent::Agent;
-use yoagent::provider::ModelConfig;
-use yoagent::types::*;
-
-#[tokio::main]
-async fn main() {
-    // Provider is selected from the config's protocol; the key is read from
-    // ANTHROPIC_API_KEY. Call `.with_api_key(key)` to pass one explicitly.
-    let mut agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
-        .with_system_prompt("You are a helpful assistant.");
-
-    let mut rx = agent.prompt("What is Rust's ownership model?").await;
-
-    while let Some(event) = rx.recv().await {
-        match event {
-            AgentEvent::MessageUpdate {
-                delta: StreamDelta::Text { delta }, ..
-            } => print!("{}", delta),
-            AgentEvent::AgentEnd { .. } => break,
-            _ => {}
-        }
-    }
-}
-```
-
-### Skills ([AgentSkills](https://agentskills.io) compatible)
-
-Skills extend the agent with domain expertise. A skill is a directory with a `SKILL.md`:
-
-```
-skills/
-└── git/
-    ├── SKILL.md       # YAML frontmatter + instructions
-    └── scripts/       # Optional resources
-```
-
-```rust
-use yoagent::SkillSet;
-
-let skills = SkillSet::load(&["./skills"])?;
-
-let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Sonnet 5"))
-    .with_system_prompt("You are a coding assistant.")
-    .with_skills(skills)   // Injects skill index into system prompt
-    .with_tools(tools);
-```
-
-The agent sees a compact index of available skills. When a task matches, it reads the full SKILL.md using the `read_file` tool — no special infrastructure needed. Skills are cross-compatible with Claude Code, Codex CLI, Gemini CLI, Cursor, and other AgentSkills-compatible agents.
-
-See [docs/concepts/skills.md](docs/concepts/skills.md) for the full guide.
-
-### Interactive CLI (mini coding agent)
-
-```bash
-ANTHROPIC_API_KEY=sk-... cargo run --example cli
-# With skills:
-ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --skills ./skills
-# With Ollama:
-cargo run --example cli -- --provider ollama --model llama3.1:8b
-# With another local server (LM Studio, llama.cpp, vLLM):
-cargo run --example cli -- --api-url http://localhost:1234/v1 --model my-model
-```
-
-A ~250-line interactive coding agent with all built-in tools, skills support, streaming output, and colored tool feedback. Like a baby Claude Code.
+That's a working coding agent in your terminal — file read/write/edit, shell, ripgrep search,
+streaming output, skills. No signup, no key, nothing to configure.
 
 ```
   yoagent cli — mini coding agent
   Type /quit to exit, /clear to reset
 
-  model: claude-sonnet-5
-  skills: 3 loaded
+  model: llama3.1:8b
   cwd:   /home/user/my-project
 
 > find all TODO comments in src/
@@ -180,96 +54,318 @@ Found 3 TODOs:
   tokens: 1250 in / 89 out
 ```
 
-<details>
-<summary>OpenAI-compatible provider example</summary>
+Point it at a hosted model instead by swapping the flag:
 
-```rust
-use yoagent::{Agent, provider::ModelConfig};
-
-// Pick a first-class preset — the provider is inferred from it, and the API
-// key is read from that provider's conventional env var (GROQ_API_KEY here).
-let mut agent = Agent::from_config(ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B"));
-
-// Or Qwen / DashScope (DASHSCOPE_API_KEY):
-let mut agent = Agent::from_config(ModelConfig::qwen("qwen3.6-plus", "Qwen 3.6 Plus"));
-
-// Or Google Gemini (GEMINI_API_KEY):
-let mut agent = Agent::from_config(ModelConfig::google("gemini-2.5-pro", "Gemini 2.5 Pro"));
+```bash
+ANTHROPIC_API_KEY=sk-... cargo run --example cli
+GROQ_API_KEY=...        cargo run --example cli -- --provider groq --model llama-3.3-70b-versatile
+cargo run --example cli -- --api-url http://localhost:1234/v1 --model my-model   # LM Studio, llama.cpp, vLLM
 ```
-
-</details>
 
 ---
 
-## Providers
+## Install
+
+```toml
+[dependencies]
+yoagent = "0.14"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Quick start
+
+An agent that actually uses a tool — the thing the crate exists for:
+
+```rust
+use yoagent::provider::ModelConfig;
+use yoagent::{tools, Agent, AgentEvent, StreamDelta};
+
+#[tokio::main]
+async fn main() {
+    // The provider is selected from the config's protocol and the key is read
+    // from ANTHROPIC_API_KEY. Call `.with_api_key(k)` to pass one explicitly.
+    let mut agent = Agent::from_config(ModelConfig::claude_sonnet_5())
+        .with_system_prompt("You are a coding assistant.")
+        .with_tools(tools::default_tools());
+
+    let mut events = agent.prompt("Find every TODO in src/ and summarise them").await;
+
+    while let Some(event) = events.recv().await {
+        match event {
+            AgentEvent::MessageUpdate { delta: StreamDelta::Text { delta }, .. } => print!("{delta}"),
+            AgentEvent::ToolExecutionStart { tool_name, .. } => println!("\n▶ {tool_name}"),
+            AgentEvent::AgentEnd { .. } => break,
+            _ => {}
+        }
+    }
+    agent.finish().await;
+}
+```
+
+Swap the model by swapping the config — the provider follows, and the key is read from that
+provider's conventional env var:
+
+```rust
+Agent::from_config(ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B")); // GROQ_API_KEY
+Agent::from_config(ModelConfig::google("gemini-2.5-pro", "Gemini 2.5 Pro"));       // GEMINI_API_KEY
+Agent::from_config(ModelConfig::ollama("http://localhost:11434", "llama3.1:8b"));  // no key
+```
+
+---
+
+## How yoagent differs
+
+yoagent is deliberately narrow. It is the loop, tool execution, and the machinery you need to
+run that loop in production. It ships **no** vector stores, embedding pipelines, or task-graph
+layer — if your problem is retrieval or orchestration, one of these is the better fit:
+
+| If you need | Look at |
+|---|---|
+| RAG pipelines, vector stores, embeddings, transcription and image generation | [`rig`](https://github.com/0xPlaygrounds/rig) — *"Build modular and scalable LLM Applications in Rust"* |
+| Typed task graphs and streaming RAG indexing alongside agents | [`swiftide`](https://github.com/bosun-ai/swiftide) — *"Composable LLM agents and harness, typed task graphs, and streaming RAG pipelines in Rust"* |
+| A tool-calling loop you host, gate, steer, branch, and record | yoagent |
+
+What that focus bought:
+
+- **The loop is a free function.** [`agent_loop()`](src/agent_loop.rs) is stateless and takes
+  everything it needs as arguments. `Agent` is an *optional* wrapper that adds history and queues.
+  You can drive the loop yourself without adopting our state model.
+- **7 native wire protocols**, not one OpenAI-compat shim with adapters bolted on. Anthropic
+  Messages, OpenAI Completions, OpenAI Responses, Azure, Gemini, Vertex, and Bedrock each have a
+  real implementation, so provider-specific features (thinking budgets, prompt-cache breakpoints,
+  reasoning deltas) survive instead of being flattened away.
+- **Every tool call passes one gate.** `ToolMiddleware` can allow, **modify**, or deny each call
+  at a single choke point shared by all execution strategies — the mechanism behind approval
+  prompts and policy engines.
+- **Steer a run that's already going.** Inject guidance mid-flight; it's picked up between tool
+  batches without restarting the turn.
+- **History is a tree, not a list.** [`Session`](src/session.rs) forks, checkpoints, and seeks.
+  Edit an earlier turn and re-run it without destroying the original branch.
+- **Runs are recordable.** With `features = ["gasp"]`, a run becomes an append-only semantic
+  event log in a git repo — restore is clone + replay. Conformance-checked in CI.
+- **The whole loop is testable offline.** `MockProvider` scripts multi-turn tool-calling
+  conversations and honours cancellation, so abort and steering paths are testable with no
+  network. 456 of our 463 tests need no key.
+
+---
+
+## What's in the box
+
+<details open>
+<summary><b>The loop &amp; control</b></summary>
+
+- Full event stream: `AgentStart` → `TurnStart` → `MessageUpdate` (deltas) → `ToolExecution*` → `TurnEnd` → `AgentEnd`
+- Parallel tool execution by default; `Sequential` and `Batched { size }` strategies available
+- **Steering** — interrupt mid-run; **follow-ups** — queue work after completion; both queues are inspectable and editable
+- **`ToolMiddleware`** — async `Allow` / `Modify(args)` / `Deny(reason)` hooks gating every call. A denial becomes an error tool result the model sees, so the loop keeps going
+- **`InputFilter`** — rewrite or reject user input before it reaches the model (PII redaction, prompt-injection guards)
+- Execution limits (max turns, max tokens, wall-clock timeout), `abort()`, and lifecycle callbacks (`before_turn`, `after_turn`, `on_error`)
+- Automatic retry with exponential backoff and ±20% jitter, for rate-limit and network errors only
+
+</details>
+
+<details>
+<summary><b>Providers</b> — 7 protocols, 20+ providers</summary>
 
 | Protocol | Providers |
 |----------|-----------|
 | Anthropic Messages | Anthropic (Claude) |
-| OpenAI Completions | OpenAI, xAI, Groq, Mistral, DeepSeek, MiniMax, Z.ai, Qwen, Meta (Muse Spark), Ollama, local servers, and custom compatible APIs |
-| OpenAI Responses | OpenAI (newer API) |
+| OpenAI Completions | OpenAI, xAI, Groq, Cerebras, OpenRouter, Mistral, DeepSeek, MiniMax, Z.ai, Qwen, Meta (Muse Spark), Ollama, local servers, custom compatible APIs |
+| OpenAI Responses | OpenAI (Responses API) |
 | Azure OpenAI | Azure OpenAI |
 | Google Generative AI | Google Gemini |
 | Google Vertex | Google Vertex AI |
 | Bedrock ConverseStream | Amazon Bedrock |
 
-OpenAI-compatible providers share one implementation with per-provider quirk flags for differences in auth, reasoning format, tool handling, and more. Adding a new compatible provider is just a `ModelConfig` with the right `base_url`.
+`ModelConfig` presets cover the common providers; `ModelConfig::openai_compat(..)` handles anything
+else with a `base_url`. Per-provider quirks (auth style, reasoning format, `max_tokens` field name)
+live in `OpenAiCompat` / `AnthropicCompat` flags — 12 compat profiles ship in the box.
+
+The `opencode_zen(..)` / `opencode_go(..)` gateways pick the wire protocol from the model id
+automatically, so one config reaches models across several vendors.
+
+Thinking/reasoning controls are wired for all 7 protocols. Client-side prompt-cache breakpoints are
+Anthropic-specific; most other providers cache server-side, and Bedrock does not cache automatically.
+Context-overflow detection is centralised across 15+ provider-specific error strings.
+
+</details>
+
+<details>
+<summary><b>Tools</b> — built-in, custom, MCP, OpenAPI</summary>
+
+Built in: `bash` (timeout, deny patterns), `read_file` / `write_file` (line numbers, path
+restrictions), `edit_file` (fuzzy-match hints on failure), `list_files`, `search` (ripgrep).
+Tools return stdout *and* stderr even on failure, so the model can self-correct.
+
+Custom tools implement one trait:
+
+```rust
+#[async_trait::async_trait]
+impl AgentTool for GreetTool {
+    fn name(&self) -> &str { "greet" }
+    fn label(&self) -> &str { "Greet" }
+    fn description(&self) -> &str { "Greets someone" }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": { "name": { "type": "string" } } })
+    }
+    async fn execute(&self, params: serde_json::Value, _ctx: ToolContext)
+        -> Result<ToolResult, ToolError>
+    {
+        let name = params["name"].as_str().unwrap_or("stranger");
+        Ok(ToolResult {
+            content: vec![Content::Text { text: format!("Hello, {name}!") }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+```
+
+**MCP** — `with_mcp_server_stdio()` / `with_mcp_server_http()` connect to Model Context Protocol
+servers over stdio or Streamable HTTP (session ids, SSE framing, incremental parsing) and register
+their tools transparently.
+
+**OpenAPI** (`features = ["openapi"]`) — point `with_openapi_url()` at a spec and every operation
+becomes a tool, filtered by `OperationFilter`.
+
+</details>
+
+<details>
+<summary><b>Sub-agents &amp; shared state</b></summary>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/subagents.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/images/subagents-light.svg">
+  <img alt="Sub-agents sharing artifacts by reference through SharedState" src="docs/images/subagents.svg" width="100%">
+</picture>
+
+`SubAgentTool` delegates to a child loop with its own model, system prompt, tools, skills,
+middleware, retry policy, and turn limits — a fully independent configuration, not a thin shim.
+Run a cheap model for triage and an expensive one for the hard step in the same session.
+
+`SharedState` is a pluggable key-value store (`MemoryBackend`, `FileBackend`, or your own via the
+`SharedStateBackend` trait). A parent stores a large artifact once and sub-agents read it by key,
+so it never gets re-pasted into every context window. Opt in with `.with_shared_state(state)` —
+it injects the `shared_state` tool and a state summary into the sub-agent's system prompt.
+
+</details>
+
+<details>
+<summary><b>Context, sessions &amp; skills</b></summary>
+
+- **`ContextTracker`** — hybrid real-usage + estimation, calibrated against actual provider usage
+- **Tiered compaction** — truncate tool outputs → summarise old turns → drop middle turns
+- **`Session`** — history as an id/parent tree with `append`, `seek`, `checkpoint`, `branch_tips`, and JSONL persistence. Appending after a seek forks a branch; it never overwrites
+- **Skills** — load [AgentSkills](https://agentskills.io)-standard `SKILL.md` directories. The agent sees a compact index and reads the full skill on demand, so skills stay cross-compatible with Claude Code, Codex CLI, Cursor, and others
+- **Structured outputs** — `prompt_structured::<T>()` returns typed, schema-validated replies, enforced natively where supported (Anthropic tool-forcing, OpenAI `json_schema`, Gemini `responseSchema`)
+
+</details>
+
+<details>
+<summary><b>Production concerns</b></summary>
+
+- **Cost tracking** — `CostConfig` carries separate input/output/cache-read/cache-write rates; `session_cost_usd()` gives a running total, and `is_configured()` distinguishes "free" from "pricing unknown"
+- **Telemetry** — `tracing` spans per loop / LLM stream / tool, recording tokens and cost. OpenTelemetry is bridged app-side via `tracing-opentelemetry`; the library carries no OTel dependency by design
+- **GASP** (`features = ["gasp"]`) — record runs into a [GASP](https://github.com/yologdev/gasp) agent repo; yoagent is a tested-conformant runtime, with the 7-check suite running in CI
+- **Serde throughout** — every core type is `Serialize` / `Deserialize` / `PartialEq`, so sessions persist and replay
+- **`set_model()`** — hot-swap the model mid-session without rebuilding the agent
+
+</details>
 
 ---
 
-## Architecture
+## Examples
 
-```
-yoagent/
-├── src/
-│   ├── types.rs            # Message, AgentMessage, AgentEvent, AgentTool trait
-│   ├── agent_loop.rs       # Core loop (agent_loop + agent_loop_continue)
-│   ├── agent.rs            # Stateful Agent with steering/follow-up queues
-│   ├── context.rs          # Token estimation, smart truncation, execution limits
-│   ├── sub_agent.rs        # SubAgentTool — delegate tasks to child agent loops
-│   ├── tools/
-│   │   ├── bash.rs         # Shell execution (timeout, deny patterns, confirm_fn)
-│   │   ├── file.rs         # Read/write files (line numbers, path restrictions)
-│   │   ├── edit.rs         # Search/replace editing with fuzzy match hints
-│   │   ├── list.rs         # Directory listing via find
-│   │   └── search.rs       # Pattern search via ripgrep/grep
-│   └── provider/
-│       ├── traits.rs           # StreamProvider trait, StreamEvent, ProviderError
-│       ├── model.rs            # ModelConfig, ApiProtocol, OpenAiCompat
-│       ├── registry.rs         # ProviderRegistry — dispatch by protocol
-│       ├── anthropic.rs        # Anthropic Messages API
-│       ├── openai_compat.rs    # OpenAI Chat Completions (15+ providers)
-│       ├── openai_responses.rs # OpenAI Responses API
-│       ├── azure_openai.rs     # Azure OpenAI
-│       ├── google.rs           # Google Generative AI (Gemini)
-│       ├── google_vertex.rs    # Google Vertex AI
-│       ├── bedrock.rs          # Amazon Bedrock (ConverseStream)
-│       ├── sse.rs              # Shared SSE parsing utility
-│       └── mock.rs             # Mock provider for testing
-├── docs/                   # mdBook documentation
-├── examples/               # Usage examples
-└── tests/                  # Integration tests
-```
+Ten runnable examples in [`examples/`](examples/). Five need no API key at all.
+
+| Example | What it shows | Key needed |
+|---|---|---|
+| [`cli`](examples/cli.rs) | A 370-line coding agent — all tools, skills, streaming, colored output. Like a baby Claude Code | optional¹ |
+| [`rlm`](examples/rlm.rs) | An LLM that explores a codebase on its own by spawning sub-agents | yes |
+| [`code_review`](examples/code_review.rs) | Three sub-agents reviewing a diff in parallel, results merged | yes |
+| [`shared_state`](examples/shared_state.rs) | Passing a large artifact between sub-agents by reference | yes |
+| [`sub_agent`](examples/sub_agent.rs) | Delegation basics with a per-sub-agent model | yes |
+| [`basic`](examples/basic.rs) | The smallest possible agent | yes |
+| [`callbacks`](examples/callbacks.rs) | Lifecycle hooks and a custom tool | **no** |
+| [`persistence`](examples/persistence.rs) | Save and restore a session | **no** |
+| [`telemetry`](examples/telemetry.rs) | `tracing` spans with token and cost fields | **no** |
+| [`gasp_emit`](examples/gasp_emit.rs) | Recording a run into a GASP repo | **no** |
+
+¹ `--provider ollama` or `--api-url` needs no key; hosted providers read their conventional env var.
 
 ---
+
+## Testing & CI
+
+`MockProvider` scripts a whole multi-turn tool-calling conversation with no network:
+
+```rust
+use yoagent::provider::mock::{MockProvider, MockResponse, MockToolCall};
+
+let provider = MockProvider::new(vec![
+    MockResponse::ToolCalls(vec![MockToolCall {
+        name: "search".into(),
+        arguments: serde_json::json!({ "pattern": "TODO" }),
+        provider_metadata: None,
+    }]),
+    MockResponse::Text("Found 3 TODOs.".into()),
+]);
+let agent = Agent::from_provider(provider, ModelConfig::mock());
+```
+
+It emits real `StreamEvent`s and honours the `CancellationToken`, so abort and steering paths are
+testable too.
+
+- **463 tests**, of which **456 run with no network and no API keys** — `cargo test --all-features`
+- Provider SSE streams tested at the HTTP level with `wiremock` across 8 suites
+- `clippy --all-targets --all-features` with `-Dwarnings`, `cargo fmt --check`
+- Linux + macOS test matrix, a Windows compile check, a pinned **MSRV 1.86** job, and a GASP conformance job
+
+---
+
+## Module map
+
+| Module | What lives there |
+|---|---|
+| [`agent_loop`](src/agent_loop.rs) | The loop itself — `agent_loop`, `agent_loop_continue`, `AgentLoopConfig`, execution strategies |
+| [`agent`](src/agent.rs) | Optional stateful wrapper — history, tool registry, steering/follow-up queues |
+| [`types`](src/types.rs) | `Message`, `Content`, `AgentEvent`, `AgentTool`, `ToolMiddleware`, `InputFilter` |
+| [`provider/`](src/provider/) | `StreamProvider` trait, `ModelConfig`, registry, and the 7 protocol implementations + `MockProvider` |
+| [`tools/`](src/tools/) | `bash`, `file`, `edit`, `list`, `search`, `shared_state_tool` |
+| [`sub_agent`](src/sub_agent.rs) | `SubAgentTool` — delegation to child loops |
+| [`shared_state`](src/shared_state.rs) | `SharedState` + pluggable backends |
+| [`session`](src/session.rs) | Branching conversation trees with JSONL persistence |
+| [`context`](src/context.rs) | Token tracking, tiered compaction, execution limits |
+| [`skills`](src/skills.rs) | AgentSkills `SKILL.md` loading |
+| [`retry`](src/retry.rs) | Backoff with jitter |
+| [`mcp/`](src/mcp/) | MCP client, stdio + HTTP transports, tool adapter |
+| [`openapi/`](src/openapi/) | OpenAPI 3.0 → tools (feature `openapi`) |
+| [`gasp`](src/gasp.rs) | Run recording into a GASP repo (feature `gasp`) |
+
+---
+
+## Documentation
+
+- **[The book](https://yologdev.github.io/yoagent/)** — concepts, guides, and a page per provider ([source](docs/))
+- **[API reference](https://docs.rs/yoagent)** — built with all features enabled
+- **[CHANGELOG](CHANGELOG.md)** — every release
+- **[CONTRIBUTING](CONTRIBUTING.md)** — how to build, test, and send a PR
+
+MSRV is **1.86**, enforced in CI. Raising it is a minor-version change.
 
 ## License
 
-MIT License — see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).
 
-## Links
-
-- [Documentation](https://yologdev.github.io/yoagent/) — Full reference
-- [pi-agent-core](https://github.com/badlogic/pi-mono/tree/main/packages/agent) — Original inspiration (TypeScript)
+Inspired by [pi-agent-core](https://github.com/badlogic/pi-mono/tree/main/packages/agent) (TypeScript).
 
 <!-- Badge link definitions -->
 [crates-shield]: https://img.shields.io/crates/v/yoagent?labelColor=black&style=flat-square&logo=rust&color=orange
 [crates-link]: https://crates.io/crates/yoagent
+[docsrs-shield]: https://img.shields.io/docsrs/yoagent?labelColor=black&style=flat-square&logo=docsdotrs&label=docs.rs
+[docsrs-link]: https://docs.rs/yoagent
 [ci-shield]: https://img.shields.io/github/actions/workflow/status/yologdev/yoagent/ci.yml?labelColor=black&style=flat-square&logo=github&label=CI
 [ci-link]: https://github.com/yologdev/yoagent/actions/workflows/ci.yml
+[msrv-shield]: https://img.shields.io/badge/MSRV-1.86-blue?labelColor=black&style=flat-square&logo=rust
+[msrv-link]: https://github.com/yologdev/yoagent/blob/main/Cargo.toml
 [license-shield]: https://img.shields.io/badge/license-MIT-white?labelColor=black&style=flat-square
 [license-link]: https://github.com/yologdev/yoagent/blob/main/LICENSE
-[docs-shield]: https://img.shields.io/badge/docs-mdBook-blue?labelColor=black&style=flat-square
-[docs-link]: https://yologdev.github.io/yoagent/
-[last-commit-shield]: https://img.shields.io/github/last-commit/yologdev/yoagent?color=c4f042&labelColor=black&style=flat-square
-[last-commit-link]: https://github.com/yologdev/yoagent/commits/main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+yoagent is pre-1.0. Security fixes land on the latest published minor version; there are no
+long-term support branches. Please upgrade to the newest release before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.**
+
+Report privately through GitHub's
+[private vulnerability reporting](https://github.com/yologdev/yoagent/security/advisories/new).
+If that is unavailable, email the maintainer at `yuanhao@yolog.dev` with "yoagent security" in the
+subject.
+
+Please include the affected version, a description of the impact, and a reproduction if you have
+one. You can expect an initial response within a week.
+
+## Scope
+
+yoagent handles API credentials and executes tools, so the areas most worth scrutiny are:
+
+- **Credential handling** — API keys are resolved from environment variables and held in memory.
+  yoagent does not log them. A path that leaks a key into logs, `tracing` output, error messages,
+  or a serialized session is a vulnerability.
+- **Tool execution** — the `bash` tool runs shell commands and the file tools read and write disk.
+  These are *designed* to execute what the model asks for; that is the crate's purpose, not a flaw.
+  A bypass of a configured restriction — `ToolMiddleware` denials, `bash` deny patterns, or file
+  path restrictions — is a vulnerability.
+- **Deserialization** — `Session` JSONL, MCP responses, and provider SSE streams all parse
+  untrusted input. Panics or memory-safety issues there are in scope.
+- **MCP and OpenAPI adapters** — these connect to third-party servers and turn their descriptions
+  into tools the model can call.
+
+## Out of scope
+
+- An agent taking a destructive action the model chose and no configured policy blocked. yoagent
+  ships **no** default policy — `ToolMiddleware` is the mechanism, and installing a policy is the
+  application's responsibility.
+- Prompt injection causing an LLM to misbehave, absent a bypass of a yoagent-enforced restriction.
+- Vulnerabilities in the upstream LLM providers themselves.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Prompt Caching](concepts/prompt-caching.md)
 - [Retry with Backoff](concepts/retry.md)
 - [Skills](concepts/skills.md)
-- [Sub-Agents](concepts/sub-agents.md)
+- [Sub-Agents & Shared State](concepts/sub-agents.md)
 - [State Persistence](concepts/persistence.md)
 - [Session Trees](concepts/session-trees.md)
 - [GASP: Your Agent Is a Git Repo](concepts/gasp.md)

--- a/docs/images/loop-light.svg
+++ b/docs/images/loop-light.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 620" width="980" height="620">
+  <style>
+    text { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', 'Courier New', monospace; fill: #0f172a; }
+    .t  { font-size: 18px; font-weight: 700; }
+    .st { font-size: 12px; fill: #475569; }
+    .n  { font-size: 14px; font-weight: 700; }
+    .s  { font-size: 11px; fill: #475569; }
+    .lg { font-size: 11px; fill: #475569; }
+    .al { font-size: 11px; fill: #475569; }
+  </style>
+  <defs>
+    <linearGradient id="bg" x1="0%%" y1="0%%" x2="100%%" y2="100%%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f8fafc"/>
+    </linearGradient>
+    <marker id="a-purple" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="a-orange" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#ea580c"/>
+    </marker>
+    <marker id="a-green" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#059669"/>
+    </marker>
+    <marker id="a-blue" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="a-gold" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#ca8a04"/>
+    </marker>
+    <filter id="glow" x="-30%%" y="-30%%" width="160%%" height="160%%">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="980" height="620" fill="url(#bg)"/>
+  <text class="t" x="40" y="46">yoagent — the loop is the product</text>
+  <text class="st" x="40" y="70">agent_loop() is a free function. Agent is the optional stateful wrapper.</text>
+  <rect x="40" y="130" width="120" height="66" rx="6" ry="6" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+  <text class="n" x="100" y="168" text-anchor="middle">Prompt</text>
+  <rect x="210" y="130" width="150" height="66" rx="6" ry="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+  <text class="n" x="285" y="161" text-anchor="middle">Context</text>
+  <text class="s" x="285" y="179" text-anchor="middle">compact + track</text>
+  <rect x="410" y="130" width="170" height="66" rx="6" ry="6" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="n" x="495" y="161" text-anchor="middle">LLM Stream</text>
+  <text class="s" x="495" y="179" text-anchor="middle">7 protocols · SSE</text>
+  <rect x="630" y="130" width="140" height="66" rx="6" ry="6" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
+  <text class="n" x="700" y="168" text-anchor="middle">tool calls?</text>
+  <rect x="820" y="130" width="110" height="66" rx="6" ry="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+  <text class="n" x="875" y="168" text-anchor="middle">Done</text>
+  <rect x="610" y="320" width="180" height="70" rx="6" ry="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text class="n" x="700" y="353" text-anchor="middle">ToolMiddleware</text>
+  <text class="s" x="700" y="371" text-anchor="middle">allow · deny · modify</text>
+  <rect x="350" y="320" width="190" height="70" rx="6" ry="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text class="n" x="445" y="353" text-anchor="middle">Tool Execution</text>
+  <text class="s" x="445" y="371" text-anchor="middle">parallel by default</text>
+  <rect x="380" y="470" width="190" height="58" rx="6" ry="6" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text class="n" x="475" y="497" text-anchor="middle">Steering</text>
+  <text class="s" x="475" y="515" text-anchor="middle">inject mid-run</text>
+  <path d="M 160,163 L 202,163" fill="none" stroke="#2563eb" stroke-width="1.8" marker-end="url(#a-blue)"/>
+  <path d="M 360,163 L 402,163" fill="none" stroke="#059669" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <path d="M 580,163 L 622,163" fill="none" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 770,163 L 812,163" fill="none" stroke="#ca8a04" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="780" y="136" width="22" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="791" y="148" text-anchor="middle">no</text>
+  <path d="M 700,196 L 700,312" fill="none" stroke="#ca8a04" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="686" y="242" width="28" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="700" y="254" text-anchor="middle">yes</text>
+  <path d="M 610,355 L 548,355" fill="none" stroke="#ea580c" stroke-width="1.8" marker-end="url(#a-orange)"/>
+  <path d="M 350,355 L 285,355 L 285,204" fill="none" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <rect x="259" y="256" width="52" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="285" y="268" text-anchor="middle">results</text>
+  <path d="M 475,470 L 475,398" fill="none" stroke="#ca8a04" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="650" y="446" width="290" height="124" rx="6" ry="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="664" y="468" style="font-weight:700;fill:#0f172a">arrows</text>
+  <line x1="664" y1="484" x2="690" y2="484" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="488">loop back into the model</text>
+  <line x1="664" y1="502" x2="690" y2="502" stroke="#ea580c" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="506">tool path, gated per call</text>
+  <line x1="664" y1="520" x2="690" y2="520" stroke="#ca8a04" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="524">branch / user injection</text>
+  <line x1="664" y1="538" x2="690" y2="538" stroke="#059669" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="542">context + exit</text>
+</svg>

--- a/docs/images/loop.svg
+++ b/docs/images/loop.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 620" width="980" height="620">
+  <style>
+    text { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', 'Courier New', monospace; fill: #e2e8f0; }
+    .t  { font-size: 18px; font-weight: 700; }
+    .st { font-size: 12px; fill: #94a3b8; }
+    .n  { font-size: 14px; font-weight: 700; }
+    .s  { font-size: 11px; fill: #94a3b8; }
+    .lg { font-size: 11px; fill: #94a3b8; }
+    .al { font-size: 11px; fill: #94a3b8; }
+  </style>
+  <defs>
+    <linearGradient id="bg" x1="0%%" y1="0%%" x2="100%%" y2="100%%">
+      <stop offset="0%" stop-color="#0f0f1a"/>
+      <stop offset="100%" stop-color="#1a1a2e"/>
+    </linearGradient>
+    <marker id="a-purple" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#a855f7"/>
+    </marker>
+    <marker id="a-orange" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="a-green" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="a-blue" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#3b82f6"/>
+    </marker>
+    <marker id="a-gold" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#eab308"/>
+    </marker>
+    <filter id="glow" x="-30%%" y="-30%%" width="160%%" height="160%%">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="980" height="620" fill="url(#bg)"/>
+  <text class="t" x="40" y="46">yoagent — the loop is the product</text>
+  <text class="st" x="40" y="70">agent_loop() is a free function. Agent is the optional stateful wrapper.</text>
+  <rect x="40" y="130" width="120" height="66" rx="6" ry="6" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
+  <text class="n" x="100" y="168" text-anchor="middle">Prompt</text>
+  <rect x="210" y="130" width="150" height="66" rx="6" ry="6" fill="#052e16" stroke="#10b981" stroke-width="1.5"/>
+  <text class="n" x="285" y="161" text-anchor="middle">Context</text>
+  <text class="s" x="285" y="179" text-anchor="middle">compact + track</text>
+  <rect x="410" y="130" width="170" height="66" rx="6" ry="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="n" x="495" y="161" text-anchor="middle">LLM Stream</text>
+  <text class="s" x="495" y="179" text-anchor="middle">7 protocols · SSE</text>
+  <rect x="630" y="130" width="140" height="66" rx="6" ry="6" fill="#292524" stroke="#eab308" stroke-width="1.5"/>
+  <text class="n" x="700" y="168" text-anchor="middle">tool calls?</text>
+  <rect x="820" y="130" width="110" height="66" rx="6" ry="6" fill="#052e16" stroke="#10b981" stroke-width="1.5"/>
+  <text class="n" x="875" y="168" text-anchor="middle">Done</text>
+  <rect x="610" y="320" width="180" height="70" rx="6" ry="6" fill="#1c1917" stroke="#f97316" stroke-width="1.5"/>
+  <text class="n" x="700" y="353" text-anchor="middle">ToolMiddleware</text>
+  <text class="s" x="700" y="371" text-anchor="middle">allow · deny · modify</text>
+  <rect x="350" y="320" width="190" height="70" rx="6" ry="6" fill="#1c1917" stroke="#f97316" stroke-width="1.5"/>
+  <text class="n" x="445" y="353" text-anchor="middle">Tool Execution</text>
+  <text class="s" x="445" y="371" text-anchor="middle">parallel by default</text>
+  <rect x="380" y="470" width="190" height="58" rx="6" ry="6" fill="#292524" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text class="n" x="475" y="497" text-anchor="middle">Steering</text>
+  <text class="s" x="475" y="515" text-anchor="middle">inject mid-run</text>
+  <path d="M 160,163 L 202,163" fill="none" stroke="#3b82f6" stroke-width="1.8" marker-end="url(#a-blue)"/>
+  <path d="M 360,163 L 402,163" fill="none" stroke="#10b981" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <path d="M 580,163 L 622,163" fill="none" stroke="#a855f7" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 770,163 L 812,163" fill="none" stroke="#eab308" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="780" y="136" width="22" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="791" y="148" text-anchor="middle">no</text>
+  <path d="M 700,196 L 700,312" fill="none" stroke="#eab308" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="686" y="242" width="28" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="700" y="254" text-anchor="middle">yes</text>
+  <path d="M 610,355 L 548,355" fill="none" stroke="#f97316" stroke-width="1.8" marker-end="url(#a-orange)"/>
+  <path d="M 350,355 L 285,355 L 285,204" fill="none" stroke="#a855f7" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <rect x="259" y="256" width="52" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="285" y="268" text-anchor="middle">results</text>
+  <path d="M 475,470 L 475,398" fill="none" stroke="#eab308" stroke-width="1.8" marker-end="url(#a-gold)"/>
+  <rect x="650" y="446" width="290" height="124" rx="6" ry="6" fill="#0f172a" stroke="#334155" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="664" y="468" style="font-weight:700;fill:#e2e8f0">arrows</text>
+  <line x1="664" y1="484" x2="690" y2="484" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="488">loop back into the model</text>
+  <line x1="664" y1="502" x2="690" y2="502" stroke="#f97316" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="506">tool path, gated per call</text>
+  <line x1="664" y1="520" x2="690" y2="520" stroke="#eab308" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="524">branch / user injection</text>
+  <line x1="664" y1="538" x2="690" y2="538" stroke="#10b981" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="700" y="542">context + exit</text>
+</svg>

--- a/docs/images/subagents-light.svg
+++ b/docs/images/subagents-light.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 620" width="1040" height="620">
+  <style>
+    text { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', 'Courier New', monospace; fill: #0f172a; }
+    .t  { font-size: 18px; font-weight: 700; }
+    .st { font-size: 12px; fill: #475569; }
+    .n  { font-size: 14px; font-weight: 700; }
+    .s  { font-size: 11px; fill: #475569; }
+    .lg { font-size: 11px; fill: #475569; }
+    .al { font-size: 11px; fill: #475569; }
+  </style>
+  <defs>
+    <linearGradient id="bg" x1="0%%" y1="0%%" x2="100%%" y2="100%%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f8fafc"/>
+    </linearGradient>
+    <marker id="a-purple" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="a-orange" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#ea580c"/>
+    </marker>
+    <marker id="a-green" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#059669"/>
+    </marker>
+    <marker id="a-blue" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="a-gold" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#ca8a04"/>
+    </marker>
+    <filter id="glow" x="-30%%" y="-30%%" width="160%%" height="160%%">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1040" height="620" fill="url(#bg)"/>
+  <text class="t" x="40" y="46">Sub-agents share artifacts by reference</text>
+  <text class="st" x="40" y="70">Each sub-agent runs its own model. Large results never re-enter a prompt.</text>
+  <rect x="40" y="98" width="340" height="92" rx="6" ry="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="54" y="120" style="font-weight:700;fill:#0f172a">the problem it solves</text>
+  <text class="lg" x="54" y="140">A 40k-token artifact is stored once,</text>
+  <text class="lg" x="54" y="158">then read by key — not re-pasted into</text>
+  <text class="lg" x="54" y="176">every sub-agent's context window.</text>
+  <rect x="660" y="98" width="340" height="92" rx="6" ry="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="674" y="120" style="font-weight:700;fill:#0f172a">arrows</text>
+  <line x1="674" y1="136" x2="700" y2="136" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="710" y="140">spawn (own model + tools)</text>
+  <line x1="674" y1="154" x2="700" y2="154" stroke="#059669" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="710" y="158">read / write by key</text>
+  <rect x="420" y="110" width="200" height="70" rx="6" ry="6" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="n" x="520" y="143" text-anchor="middle">Agent</text>
+  <text class="s" x="520" y="161" text-anchor="middle">SubAgentTool</text>
+  <rect x="80" y="300" width="200" height="80" rx="6" ry="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text class="n" x="180" y="338" text-anchor="middle">reviewer</text>
+  <text class="s" x="180" y="356" text-anchor="middle">claude-opus-5</text>
+  <rect x="420" y="300" width="200" height="80" rx="6" ry="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text class="n" x="520" y="338" text-anchor="middle">tester</text>
+  <text class="s" x="520" y="356" text-anchor="middle">claude-haiku-4-5</text>
+  <rect x="760" y="300" width="200" height="80" rx="6" ry="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text class="n" x="860" y="338" text-anchor="middle">docs</text>
+  <text class="s" x="860" y="356" text-anchor="middle">ollama / local</text>
+  <rect x="420" y="470" width="200" height="90" rx="6" ry="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+  <text class="n" x="520" y="513" text-anchor="middle">SharedState</text>
+  <text class="s" x="520" y="531" text-anchor="middle">Memory | File | custom</text>
+  <path d="M 470,180 L 470,240 L 180,240 L 180,292" fill="none" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <rect x="300" y="222" width="40" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="320" y="234" text-anchor="middle">spawn</text>
+  <path d="M 520,180 L 520,292" fill="none" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 570,180 L 570,240 L 860,240 L 860,292" fill="none" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 412,510 L 180,510 L 180,388" fill="none" stroke="#059669" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="286" y="492" width="28" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="300" y="504" text-anchor="middle">get</text>
+  <path d="M 520,380 L 520,462" fill="none" stroke="#059669" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="506" y="416" width="28" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="520" y="428" text-anchor="middle">set</text>
+  <path d="M 628,510 L 860,510 L 860,388" fill="none" stroke="#059669" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="730" y="492" width="28" height="16" rx="3" fill="#ffffff" opacity="0.95"/>
+  <text class="al" x="744" y="504" text-anchor="middle">get</text>
+</svg>

--- a/docs/images/subagents.svg
+++ b/docs/images/subagents.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 620" width="1040" height="620">
+  <style>
+    text { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', 'Courier New', monospace; fill: #e2e8f0; }
+    .t  { font-size: 18px; font-weight: 700; }
+    .st { font-size: 12px; fill: #94a3b8; }
+    .n  { font-size: 14px; font-weight: 700; }
+    .s  { font-size: 11px; fill: #94a3b8; }
+    .lg { font-size: 11px; fill: #94a3b8; }
+    .al { font-size: 11px; fill: #94a3b8; }
+  </style>
+  <defs>
+    <linearGradient id="bg" x1="0%%" y1="0%%" x2="100%%" y2="100%%">
+      <stop offset="0%" stop-color="#0f0f1a"/>
+      <stop offset="100%" stop-color="#1a1a2e"/>
+    </linearGradient>
+    <marker id="a-purple" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#a855f7"/>
+    </marker>
+    <marker id="a-orange" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="a-green" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="a-blue" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#3b82f6"/>
+    </marker>
+    <marker id="a-gold" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#eab308"/>
+    </marker>
+    <filter id="glow" x="-30%%" y="-30%%" width="160%%" height="160%%">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1040" height="620" fill="url(#bg)"/>
+  <text class="t" x="40" y="46">Sub-agents share artifacts by reference</text>
+  <text class="st" x="40" y="70">Each sub-agent runs its own model. Large results never re-enter a prompt.</text>
+  <rect x="40" y="98" width="340" height="92" rx="6" ry="6" fill="#0f172a" stroke="#334155" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="54" y="120" style="font-weight:700;fill:#e2e8f0">the problem it solves</text>
+  <text class="lg" x="54" y="140">A 40k-token artifact is stored once,</text>
+  <text class="lg" x="54" y="158">then read by key — not re-pasted into</text>
+  <text class="lg" x="54" y="176">every sub-agent's context window.</text>
+  <rect x="660" y="98" width="340" height="92" rx="6" ry="6" fill="#0f172a" stroke="#334155" stroke-width="1" stroke-dasharray="4,3"/>
+  <text class="s" x="674" y="120" style="font-weight:700;fill:#e2e8f0">arrows</text>
+  <line x1="674" y1="136" x2="700" y2="136" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="710" y="140">spawn (own model + tools)</text>
+  <line x1="674" y1="154" x2="700" y2="154" stroke="#10b981" stroke-width="2.5" stroke-linecap="round"/>
+  <text class="lg" x="710" y="158">read / write by key</text>
+  <rect x="420" y="110" width="200" height="70" rx="6" ry="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="n" x="520" y="143" text-anchor="middle">Agent</text>
+  <text class="s" x="520" y="161" text-anchor="middle">SubAgentTool</text>
+  <rect x="80" y="300" width="200" height="80" rx="6" ry="6" fill="#1c1917" stroke="#f97316" stroke-width="1.5"/>
+  <text class="n" x="180" y="338" text-anchor="middle">reviewer</text>
+  <text class="s" x="180" y="356" text-anchor="middle">claude-opus-5</text>
+  <rect x="420" y="300" width="200" height="80" rx="6" ry="6" fill="#1c1917" stroke="#f97316" stroke-width="1.5"/>
+  <text class="n" x="520" y="338" text-anchor="middle">tester</text>
+  <text class="s" x="520" y="356" text-anchor="middle">claude-haiku-4-5</text>
+  <rect x="760" y="300" width="200" height="80" rx="6" ry="6" fill="#1c1917" stroke="#f97316" stroke-width="1.5"/>
+  <text class="n" x="860" y="338" text-anchor="middle">docs</text>
+  <text class="s" x="860" y="356" text-anchor="middle">ollama / local</text>
+  <rect x="420" y="470" width="200" height="90" rx="6" ry="6" fill="#052e16" stroke="#10b981" stroke-width="1.5"/>
+  <text class="n" x="520" y="513" text-anchor="middle">SharedState</text>
+  <text class="s" x="520" y="531" text-anchor="middle">Memory | File | custom</text>
+  <path d="M 470,180 L 470,240 L 180,240 L 180,292" fill="none" stroke="#a855f7" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <rect x="300" y="222" width="40" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="320" y="234" text-anchor="middle">spawn</text>
+  <path d="M 520,180 L 520,292" fill="none" stroke="#a855f7" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 570,180 L 570,240 L 860,240 L 860,292" fill="none" stroke="#a855f7" stroke-width="1.8" marker-end="url(#a-purple)"/>
+  <path d="M 412,510 L 180,510 L 180,388" fill="none" stroke="#10b981" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="286" y="492" width="28" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="300" y="504" text-anchor="middle">get</text>
+  <path d="M 520,380 L 520,462" fill="none" stroke="#10b981" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="506" y="416" width="28" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="520" y="428" text-anchor="middle">set</text>
+  <path d="M 628,510 L 860,510 L 860,388" fill="none" stroke="#10b981" stroke-width="1.8" marker-end="url(#a-green)"/>
+  <rect x="730" y="492" width="28" height="16" rx="3" fill="#0f0f1a" opacity="0.95"/>
+  <text class="al" x="744" y="504" text-anchor="middle">get</text>
+</svg>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,27 +1,70 @@
 # yoagent
 
-**Simple, effective agent loop in Rust.**
+**The agent loop for Rust.** Stream from any of 7 LLM protocols, run tools, loop until done.
 
-yoagent is a library for building LLM-powered agents that can use tools. It provides the core loop — prompt the model, execute tool calls, feed results back — and gets out of your way.
+yoagent is a library for building LLM-powered agents that use tools. It provides the core loop —
+prompt the model, execute tool calls, feed results back — and gets out of your way.
+
+![The yoagent loop](images/loop.svg)
 
 ## Philosophy
 
-**The loop is the product.** An agent is just a loop: send messages to an LLM, get back text and tool calls, execute the tools, repeat until the model stops. yoagent implements this loop with streaming, cancellation, context management, and multi-provider support — so you don't have to.
+**The loop is the product.** An agent is just a loop: send messages to an LLM, get back text and
+tool calls, execute the tools, repeat until the model stops. yoagent implements that loop with
+streaming, cancellation, context management, and multi-provider support — and stops there.
 
-## Features
+`agent_loop()` is a stateless free function that takes everything it needs as arguments. `Agent`
+is an *optional* wrapper that adds message history, a tool registry, and steering queues. You can
+drive the loop yourself without adopting our state model.
 
-- **Streaming events** — Real-time `AgentEvent` stream for UI updates (text deltas, thinking, tool execution)
-- **Multi-provider** — Anthropic, OpenAI, Google Gemini, Amazon Bedrock, Azure OpenAI, and any OpenAI-compatible API
-- **Tool system** — `AgentTool` trait with built-in coding tools (bash, file read/write/edit, search)
-- **Context management** — Automatic token estimation, tiered compaction (truncate tool outputs → summarize → drop old messages)
-- **Execution limits** — Max turns, tokens, and wall-clock time
-- **Steering & follow-ups** — Interrupt the agent mid-run or queue work for after it finishes
-- **Cancellation** — `CancellationToken`-based abort at any point
-- **Builder pattern** — Ergonomic `Agent` struct with chainable configuration
+## Try it without an API key
+
+```bash
+git clone https://github.com/yologdev/yoagent && cd yoagent
+ollama serve &
+cargo run --example cli -- --provider ollama
+```
+
+A working coding agent in your terminal — file read/write/edit, shell, ripgrep search, streaming
+output, and skills.
+
+## What's here
+
+**The loop and its control surfaces**
+
+- [The agent loop](concepts/agent-loop.md) — how a turn runs, and how steering and follow-ups interrupt it
+- [Messages and events](concepts/messages-events.md) — the full `AgentEvent` stream for text deltas, thinking, and tool execution
+- [Tool middleware](concepts/tools.md#permissions-tool-middleware) — async allow / modify / deny hooks gating every tool call
+- [Lifecycle callbacks](concepts/callbacks.md) plus execution limits (max turns, tokens, wall-clock) and `CancellationToken` abort
+- [Retry](concepts/retry.md) with exponential backoff and jitter, for rate-limit and network errors only
+
+**Models and tools**
+
+- [7 API protocols, 20+ providers](providers/overview.md) — Anthropic, OpenAI Completions and Responses, Azure, Gemini, Vertex, Bedrock, plus OpenAI-compatible gateways, each with a real implementation rather than a shared shim
+- [Built-in tools](concepts/tools.md) — bash, file read/write/edit, list, ripgrep search; add your own via the `AgentTool` trait
+- [MCP](guides/mcp.md) servers and [OpenAPI](guides/openapi.md) specs become tools transparently
+- [Structured outputs](concepts/structured-outputs.md) — typed, schema-validated replies enforced natively where the provider supports it
+- [Prompt caching](concepts/prompt-caching.md)
+
+**Scaling a session**
+
+- [Sub-agents and shared state](concepts/sub-agents.md) — delegate to child loops with their own model, tools, and limits; sub-agents read large artifacts by key instead of re-pasting them into every context window
+- [Context management](concepts/context-management.md) — token tracking and tiered compaction (truncate tool outputs → summarise old turns → drop middle)
+- [State persistence](concepts/persistence.md) — save and restore a run
+- [Session trees](concepts/session-trees.md) — branching history with fork, checkpoints, and JSONL persistence
+- [Skills](concepts/skills.md) — load AgentSkills-standard `SKILL.md` directories
+
+**Running it in production**
+
+- [Telemetry](concepts/telemetry.md) — `tracing` spans per loop, LLM stream, and tool, with token and cost fields
+- Cost tracking with separate cache-read and cache-write rates
+- [GASP](concepts/gasp.md) — record runs as an append-only semantic event log; restore is clone + replay
 
 ## Ecosystem
 
-yoagent is part of the [Yolog](https://github.com/yologdev) ecosystem. It powers the agent backend for Yolog applications.
+yoagent is part of the [Yolog](https://github.com/yologdev) ecosystem. It powers the agent backend
+for Yolog applications.
 
 - **Repository:** [github.com/yologdev/yoagent](https://github.com/yologdev/yoagent)
+- **API reference:** [docs.rs/yoagent](https://docs.rs/yoagent)
 - **License:** MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Enables the `doc_cfg` feature badges on docs.rs only; a no-op on stable.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! **yoagent** — the agent runtime for Rust.
 //!
 //! A simple, effective agent loop with tool execution and event streaming:
@@ -46,6 +49,8 @@
 //! - **Permissions** ([`ToolMiddleware`]) — async approve/deny/modify hooks
 //!   gating every tool call; the mechanism behind approval prompts and
 //!   policy engines (yoagent ships no policy — you install it).
+//! - **Input filtering** ([`InputFilter`]) — rewrite or reject user input
+//!   before it reaches the model (PII redaction, prompt-injection guards).
 //! - **Sub-agents** ([`SubAgentTool`]) — delegation with per-sub-agent models
 //!   and [`SharedState`] for passing artifacts by reference.
 //! - **GASP** (feature `gasp`) — record runs into a
@@ -60,6 +65,9 @@
 //!   [AgentSkills](https://agentskills.io) standard.
 //! - **Telemetry** — `tracing` spans per loop/LLM-stream/tool with token and
 //!   cost fields; bridge to OpenTelemetry app-side, negligible cost otherwise.
+//! - **Testing** ([`provider::mock::MockProvider`]) — script a whole multi-turn
+//!   tool-calling conversation with no network. It honours the cancellation
+//!   token, so abort and steering paths are testable too.
 //!
 //! The [book](https://yologdev.github.io/yoagent/) covers concepts and
 //! provider-specific guides.
@@ -78,9 +86,11 @@ pub mod tools;
 pub mod types;
 
 #[cfg(feature = "openapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "openapi")))]
 pub mod openapi;
 
 #[cfg(feature = "gasp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gasp")))]
 pub mod gasp;
 
 pub use agent::{Agent, AgentBuildError, StructuredPromptError};


### PR DESCRIPTION
## Why

Three things on the path from crates.io → docs.rs → repo were costing adoption:

1. **docs.rs was rendering an incomplete crate.** No `[package.metadata.docs.rs]` meant docs.rs built with default features, so `openapi` and `gasp` — both advertised in the README — were simply absent from the published API reference. Anyone clicking "Documentation" to check a README claim found the module missing.
2. **The README failed the 10-second scan.** It opened with a ~40-bullet feature wall, and its Quick Start showed a chat completion rather than an agent using a tool. Nothing answered "why this over `rig`?"
3. **~4,000 lines of shipped code were invisible.** The architecture tree omitted 17 of 38 `src/` files — all of `mcp/`, all of `openapi/`, plus `session`, `skills`, `shared_state`, `retry`, `gasp`. `SharedState` and `InputFilter` had zero README mentions, and 9 of 10 examples were unreferenced.

## What changed

**`Cargo.toml`** — `[package.metadata.docs.rs]` with `all-features` + `--cfg docsrs`; `doc(cfg(..))` badges on the feature-gated modules; filled the 3 unused category slots; swapped two low-traffic keywords for `anthropic`/`openai`.

**`README.md`** — rewritten. Leads with `cargo run --example cli -- --provider ollama`: a working coding agent, no key, no signup. Then a compile-checked Quick Start that actually calls a tool, a loop diagram, and a **"How yoagent differs"** section that says plainly what this crate does *not* do (no vector stores, no embeddings, no task graphs) and points at `rig` and `swiftide` for those. Capabilities moved from 40 flat bullets into six collapsible groups. Adds the examples table (all ten, marking the five that need no key), the testing story, and a module map covering all of `src/`.

**`docs/introduction.md`** — the landing page `homepage` points at was a 27-line subset that never mentioned sub-agents, tool middleware, structured outputs, skills, session trees, GASP, MCP, or OpenAPI. Rewritten to match.

**New:** `CONTRIBUTING.md`, `SECURITY.md`, issue templates, PR template — the repo had none. The bug template asks for protocol and model id up front, since most reports (#81–#89) are provider-specific.

**Diagrams:** `docs/images/{loop,subagents}.svg` with light/dark variants, wired via `<picture>`.

### Corrections

| Was | Now |
|---|---|
| CLI example "~250 lines" | 370 |
| `openai_compat.rs — 15+ providers` | 12 compat profiles |
| Provider table omitted Cerebras/OpenRouter while the bullet list named them | reconciled |
| Implied `ModelConfig::cerebras()` / `openrouter()` presets | they don't exist; wording fixed |

## Verification

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features` with `-Dwarnings` — clean
- `cargo test --all-features` — **456 passed, 0 failed, 7 ignored** (the 7 are live-API tests)
- Every README code snippet compiled as a real example before being committed. This caught two errors: `MockResponse`/`MockToolCall` live under `provider::mock`, not `provider`, and a struct literal used `..` without a base
- `cargo doc --all-features` renders `openapi` and `gasp`. The nightly `doc_cfg` badge itself could not be verified locally — there's no rustup/nightly in this environment, and docs.rs builds on nightly
- `mdbook build` — all 19 internal links on the rewritten landing page resolve; images copy correctly
- `cargo package --list` — the new SVGs stay out of the tarball via the existing `exclude`
- `cargo publish --dry-run` — clean; category slugs also probed against the crates.io API directly
- Every claim about `rig` and `swiftide` was taken from their current READMEs at write time, with taglines quoted verbatim — none written from memory

## Also in this PR

**Built with yoagent** — a section listing the four crates that depend on yoagent, headed by
[yoyo-evolve](https://github.com/yologdev/yoyo-evolve) (an order of magnitude more stars than
yoagent itself). Two of the four are third-party. Star counts are shown only for yoyo-evolve;
a column of 1s next to the young external projects would undercut the point the section makes.

**Book nav** — the sidebar entry is now "Sub-Agents & Shared State". The Shared State content
already existed (100 lines inside `concepts/sub-agents.md`, verified accurate against
`src/shared_state.rs`); it just wasn't findable by scanning the nav. No content moved.

## Correction

An earlier draft of this description claimed SharedState was undocumented in the book. That was
wrong — I had checked for a `concepts/shared-state.md` filename rather than for content. It is
documented, and the docs match the code.
