### PR TITLE
release: 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.14.2
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Patch release. Docs and metadata only — no API or behaviour change.

The substantive fix is **docs.rs**: without `[package.metadata.docs.rs]` it built
with default features, so `openapi` and `gasp` were absent from the published API
reference despite both being advertised in the README. That metadata lives in the
published `.crate`, not in `main`, so it takes effect only on this publish —
which is the reason for cutting the release.

Everything else shipped in #96 and is already on `main`: the README rewrite, the
`docs/introduction.md` rewrite, CONTRIBUTING/SECURITY/issue templates, and the
loop and sub-agent diagrams.

Exactly two files change, per the release convention: `Cargo.toml` and `CHANGELOG.md`.

- [x] `cargo check --all-features` clean
- [x] `Cargo.toml` version and `CHANGELOG.md` heading both read 0.14.2
- [x] `## Unreleased` renamed in place, not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)