### PR TITLE
fix: keep compaction from discarding the provider prefix cache (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,36 +40,60 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `ContextConfig::truncate_tool_output_on_append` (default `false`) applies
-  `tool_output_max_lines` when a tool result is appended rather than
-  retroactively during compaction. Retroactive truncation was the single
-  largest remaining source of cache loss: output is sent in full, cached, then
-  rewritten. Capping on the way in also slows context growth, so compaction
-  runs less often. The untruncated output is still carried by the
-  `AgentEvent` stream.
+- `ContextConfig::truncate_tool_output_on_append` (**default `true`**) applies
+  the line cap when a tool result is appended rather than retroactively during
+  compaction. Retroactive truncation was the single largest remaining source of
+  cache loss: output is sent in full, cached, then rewritten in one sweep once
+  the session goes over budget. Capping on the way in also slows context
+  growth, so compaction runs less often. The untruncated output is still
+  carried by the `AgentEvent` stream.
+- `ContextConfig::tool_output_max_lines_overrides` — per-tool line budgets. One
+  global number cannot serve every tool: head+tail is a good cut for command
+  output (first error at the top, summary at the bottom, repetition in the
+  middle) and the *wrong* cut for a file read, where the middle is the part
+  that was asked for. The default exempts `read_file`, which bounds itself by
+  paging instead. `usize::MAX` disables truncation for a tool.
+- `ReadFileTool::max_lines` / `tools::DEFAULT_READ_MAX_LINES` (500) — an
+  unqualified read used to return the whole file. Measured against a real Rust
+  codebase, the median source file is 1364 lines and 96% exceed 200, so one
+  read could spend ~15K tokens; reads are ~19% of tool calls. Paging is the
+  right bound for a file — unlike head+tail it is lossless and directed, and
+  the header now states the true total and tells the agent to use
+  `offset`/`limit`. 500 was chosen by measurement: hit rate is flat between a
+  300- and 500-line page and falls off sharply above it.
 - `context::truncate_tool_output()` — the single-message helper behind Level 1,
   now public for custom loops and compaction strategies.
-- `tests/context_cache_test.rs` replays a synthetic tool-heavy session through
-  `compact_messages` turn by turn and measures the shared prefix between
-  consecutive requests — the direct analogue of DeepSeek's
-  `cache_hit_tokens / input_tokens`. Over 300 turns on a 128K window:
+- `tests/context_cache_test.rs` replays a session through `compact_messages`
+  turn by turn and measures the shared prefix between consecutive requests —
+  the direct analogue of DeepSeek's `cache_hit_tokens / input_tokens`. The tool
+  mix (bash 41%, edit/write 36%, read 19%, search 4%) and the file-size
+  distribution are taken from 808 archived runs of a production agent built on
+  yoagent. Over 300 turns on a 128K window:
 
   | | prefix-cache hit rate | history rewrites |
   |---|---|---|
-  | 0.14.2 | 95.80% | 16 |
-  | 0.15.0 defaults | 96.85% | 15 |
-  | 0.15.0 + `truncate_tool_output_on_append` | 98.51% | 2 |
+  | 0.14.2 | 93.58% | 23 |
+  | 0.15.0, 0.14.2-equivalent settings | 94.38% | 22 |
+  | 0.15.0 defaults | **96.04%** | **8** |
 
 ### Changed
 
 - Level 3 now drops the smallest span of middle messages that reaches the
   target instead of always collapsing to `keep_first` + `keep_recent`, so
   compaction destroys only as much history as the budget requires.
-- **Breaking:** `ContextConfig` gained two public fields
-  (`compact_target_ratio`, `truncate_tool_output_on_append`). Code that
-  constructs it with an exhaustive struct literal needs `..Default::default()`;
-  code using `ContextConfig::default()`, `from_context_window()`, or functional
-  update syntax is unaffected.
+- `ContextConfig::tool_output_max_lines` default raised from 50 to 200. It now
+  applies on append rather than only under budget pressure, and 50 lines
+  (≈23 head + 24 tail) cuts the error list out of most build output.
+- **Breaking:** `ContextConfig` gained three public fields
+  (`compact_target_ratio`, `truncate_tool_output_on_append`,
+  `tool_output_max_lines_overrides`) and `ReadFileTool` gained `max_lines`.
+  Code that constructs either with an exhaustive struct literal needs
+  `..Default::default()`; code using `default()`, `new()`,
+  `from_context_window()`, or functional update syntax is unaffected.
+- **Breaking (behaviour):** tool output is now capped as it enters the context,
+  and an unqualified `read_file` returns 500 lines instead of the whole file.
+  To restore the old behaviour set `truncate_tool_output_on_append: false` and
+  `ReadFileTool { max_lines: usize::MAX, ..Default::default() }`.
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.15.0
+
+### Fixed
+
+- **Compaction rewrote history in place, discarding the provider's prefix
+  cache** ([#99](https://github.com/yologdev/yoagent/issues/99)). A cache hit
+  requires a byte-identical prefix, so every rewrite of already-sent history
+  costs full price for every token from the rewrite point on — automatically on
+  DeepSeek, and via `cache_control` on Anthropic. Four separate sources of
+  churn are gone:
+  - `truncate_text_head_tail` was not idempotent. The `[... N lines truncated
+    ...]` marker pushed the result past `tool_output_max_lines`, so the next
+    compaction pass re-truncated it and restated the count (`950 lines
+    truncated` became `3 lines truncated`) — a second full-prefix
+    invalidation, and a marker that lied about how much was dropped. The
+    marker is now charged against the line budget, so the result fits exactly
+    and re-truncating is a no-op.
+  - Compaction reduced to whatever just barely fit, so the next turn crossed
+    the budget again and rewrote history *every turn*. The new
+    `ContextConfig::compact_target_ratio` (default `0.7`) makes the lossy
+    levels reduce to a fraction of the budget while still triggering at the
+    full budget. Set it to `1.0` for the old behaviour.
+  - Level 3's marker embedded a message count and sat at a fixed position near
+    the front, so the cached prefix changed on every pass. The marker text is
+    now constant and the count goes to the debug log.
+  - Level 2's generated summaries and the Level 3 marker were stamped with
+    `now_ms()`, making compaction non-deterministic. They now inherit the
+    timestamp of the content they replace.
+- **Compaction could orphan tool calls.** Level 2's boundary
+  (`len - keep_recent`) could land mid-turn, summarizing away an assistant
+  message while its tool results stayed in the kept section; Level 3 and
+  `keep_within_budget` could cut the mirror image. Every provider rejects both.
+  Boundaries now snap to turn starts.
+
+### Added
+
+- `ContextConfig::truncate_tool_output_on_append` (default `false`) applies
+  `tool_output_max_lines` when a tool result is appended rather than
+  retroactively during compaction. Retroactive truncation was the single
+  largest remaining source of cache loss: output is sent in full, cached, then
+  rewritten. Capping on the way in also slows context growth, so compaction
+  runs less often. The untruncated output is still carried by the
+  `AgentEvent` stream.
+- `context::truncate_tool_output()` — the single-message helper behind Level 1,
+  now public for custom loops and compaction strategies.
+- `tests/context_cache_test.rs` replays a synthetic tool-heavy session through
+  `compact_messages` turn by turn and measures the shared prefix between
+  consecutive requests — the direct analogue of DeepSeek's
+  `cache_hit_tokens / input_tokens`. Over 300 turns on a 128K window:
+
+  | | prefix-cache hit rate | history rewrites |
+  |---|---|---|
+  | 0.14.2 | 95.80% | 16 |
+  | 0.15.0 defaults | 96.85% | 15 |
+  | 0.15.0 + `truncate_tool_output_on_append` | 98.51% | 2 |
+
+### Changed
+
+- Level 3 now drops the smallest span of middle messages that reaches the
+  target instead of always collapsing to `keep_first` + `keep_recent`, so
+  compaction destroys only as much history as the budget requires.
+- **Breaking:** `ContextConfig` gained two public fields
+  (`compact_target_ratio`, `truncate_tool_output_on_append`). Code that
+  constructs it with an exhaustive struct literal needs `..Default::default()`;
+  code using `ContextConfig::default()`, `from_context_window()`, or functional
+  update syntax is unaffected.
+
 ## 0.14.2
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo run --example cli -- --api-url http://localhost:1234/v1 --model my-model  
 
 ```toml
 [dependencies]
-yoagent = "0.14"
+yoagent = "0.15"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/concepts/context-management.md
+++ b/docs/concepts/context-management.md
@@ -90,11 +90,13 @@ For LLM-based summarization (asking the model to summarize old messages), implem
 
 ```rust
 pub struct ContextConfig {
-    pub max_context_tokens: usize,      // Default: 100,000
-    pub system_prompt_tokens: usize,    // Default: 4,000
-    pub keep_recent: usize,             // Default: 10
-    pub keep_first: usize,              // Default: 2
-    pub tool_output_max_lines: usize,   // Default: 50
+    pub max_context_tokens: usize,               // Default: 100,000
+    pub system_prompt_tokens: usize,             // Default: 4,000
+    pub keep_recent: usize,                      // Default: 10
+    pub keep_first: usize,                       // Default: 2
+    pub tool_output_max_lines: usize,            // Default: 50
+    pub compact_target_ratio: f32,               // Default: 0.7
+    pub truncate_tool_output_on_append: bool,    // Default: false
 }
 ```
 
@@ -128,15 +130,49 @@ let config = ContextConfig::from_context_window(1_000_000);
 
 ### Level 1: Truncate Tool Outputs
 
-Replaces long tool outputs with head + tail (keeping first N/2 and last N/2 lines). This is the cheapest — preserves conversation structure, typically saves 50-70% in coding sessions.
+Replaces long tool outputs with head + tail, fitting the result into exactly `tool_output_max_lines` lines (the `[... N lines truncated ...]` marker is charged against that budget). This is the cheapest level — it preserves conversation structure and typically saves 50-70% in coding sessions.
+
+Truncation is idempotent: re-running it on an already-truncated output returns it byte for byte, so a session that sits above the budget does not re-truncate the same outputs turn after turn.
 
 ### Level 2: Summarize Old Turns
 
-Keeps the last `keep_recent` messages in full detail. Older assistant messages are replaced with one-line summaries like `"[Summary] [Assistant used 3 tool(s)]"`, and their tool results are dropped.
+Keeps the last `keep_recent` messages in full detail. Older assistant messages are replaced with one-line summaries like `"[Summary] [Assistant used 3 tool(s)]"`, and their tool results are dropped. The boundary is pulled back to a turn start so an assistant message and its tool results are never split across it.
 
 ### Level 3: Drop Middle Messages
 
-Keeps `keep_first` messages from the start and `keep_recent` from the end, dropping everything in between. A marker message notes how many were removed.
+Drops the smallest span of middle messages that reaches the target, keeping at least `keep_first` from the start and `keep_recent` from the end. A constant marker message stands in for what was removed; the count goes to the debug log rather than into the marker, so the text does not change from pass to pass.
+
+## Prefix Cache Stability
+
+Providers cache request prefixes — automatically on DeepSeek, explicitly via `cache_control` on Anthropic. A cache hit needs the new request to share a byte-identical prefix with the last one, so **every rewrite of already-sent history costs full price for every token from the rewrite point onward**.
+
+Compaction is built around that:
+
+- Levels are idempotent where they can be, so re-running on settled history changes nothing.
+- `compact_target_ratio` gives compaction headroom. It still *triggers* at the full budget, but the lossy levels reduce to `budget × ratio` (default 70%) rather than to whatever just barely fits — otherwise the next turn crosses the budget again and history is rewritten every single turn.
+- Markers and generated summaries carry no wall-clock timestamps or drifting counts, so the same history always compacts to the same bytes.
+
+### truncate_tool_output_on_append
+
+The largest remaining source of cache loss is *retroactive* truncation: a tool output is sent in full, cached, and then rewritten by Level 1 once the session goes over budget. Setting `truncate_tool_output_on_append` applies `tool_output_max_lines` when the tool result is appended instead, so the bytes the provider cached are the bytes that stay:
+
+```rust
+let agent = Agent::from_config(ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat"))
+    .with_context_config(ContextConfig {
+        truncate_tool_output_on_append: true,
+        ..ContextConfig::from_context_window(128_000)
+    });
+```
+
+The trade-off is that a long tool output is trimmed even when the budget had room for it, which is why it is off by default. The untruncated output is always available in the `AgentEvent` stream either way.
+
+Measured over a 300-turn synthetic tool-heavy session on a 128K window (`tests/context_cache_test.rs`):
+
+| | prefix-cache hit rate | history rewrites |
+|---|---|---|
+| 0.14.2 | 95.80% | 16 |
+| 0.15.0 defaults | 96.85% | 15 |
+| 0.15.0 + `truncate_tool_output_on_append` | 98.51% | 2 |
 
 ## ExecutionLimits
 

--- a/docs/concepts/context-management.md
+++ b/docs/concepts/context-management.md
@@ -90,13 +90,14 @@ For LLM-based summarization (asking the model to summarize old messages), implem
 
 ```rust
 pub struct ContextConfig {
-    pub max_context_tokens: usize,               // Default: 100,000
-    pub system_prompt_tokens: usize,             // Default: 4,000
-    pub keep_recent: usize,                      // Default: 10
-    pub keep_first: usize,                       // Default: 2
-    pub tool_output_max_lines: usize,            // Default: 50
-    pub compact_target_ratio: f32,               // Default: 0.7
-    pub truncate_tool_output_on_append: bool,    // Default: false
+    pub max_context_tokens: usize,                            // Default: 100,000
+    pub system_prompt_tokens: usize,                          // Default: 4,000
+    pub keep_recent: usize,                                   // Default: 10
+    pub keep_first: usize,                                    // Default: 2
+    pub tool_output_max_lines: usize,                         // Default: 200
+    pub tool_output_max_lines_overrides: HashMap<String, usize>, // Default: {"read_file": MAX}
+    pub compact_target_ratio: f32,                            // Default: 0.7
+    pub truncate_tool_output_on_append: bool,                 // Default: true
 }
 ```
 
@@ -152,27 +153,35 @@ Compaction is built around that:
 - `compact_target_ratio` gives compaction headroom. It still *triggers* at the full budget, but the lossy levels reduce to `budget × ratio` (default 70%) rather than to whatever just barely fits — otherwise the next turn crosses the budget again and history is rewritten every single turn.
 - Markers and generated summaries carry no wall-clock timestamps or drifting counts, so the same history always compacts to the same bytes.
 
-### truncate_tool_output_on_append
+### Bounding tool output: two layers
 
-The largest remaining source of cache loss is *retroactive* truncation: a tool output is sent in full, cached, and then rewritten by Level 1 once the session goes over budget. Setting `truncate_tool_output_on_append` applies `tool_output_max_lines` when the tool result is appended instead, so the bytes the provider cached are the bytes that stay:
+The largest source of cache loss is *retroactive* truncation — output is sent in full, cached, then rewritten by Level 1 in one sweep once the session goes over budget. Bounding it as it arrives fixes that, but a single global cap is the wrong instrument, because tools differ in how well they survive being cut:
+
+**Command output** (`bash`, `search`) takes a head+tail cut well: the first error is at the top, the summary at the bottom, and the middle is repetition. `tool_output_max_lines` (200) is applied on append, controlled by `truncate_tool_output_on_append` (on by default).
+
+**File reads** do not. The middle of a source file is usually the part that was asked for, so head+tail removes exactly the wrong lines. `read_file` bounds itself instead, by paging: it returns `DEFAULT_READ_MAX_LINES` (500) at a time with a header stating the true total, and the agent asks for the next range with `offset`/`limit`. That bound is lossless and directed. `read_file` is therefore exempt from head+tail truncation by default, via `tool_output_max_lines_overrides`.
+
+Custom tools pick their own budget the same way:
 
 ```rust
-let agent = Agent::from_config(ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat"))
-    .with_context_config(ContextConfig {
-        truncate_tool_output_on_append: true,
-        ..ContextConfig::from_context_window(128_000)
-    });
+let mut config = ContextConfig::from_context_window(128_000);
+config.tool_output_max_lines_overrides.insert("my_paging_tool".into(), usize::MAX);
+config.tool_output_max_lines_overrides.insert("noisy_tool".into(), 40);
 ```
 
-The trade-off is that a long tool output is trimmed even when the budget had room for it, which is why it is off by default. The untruncated output is always available in the `AgentEvent` stream either way.
+To restore pre-0.15 behaviour, set `truncate_tool_output_on_append: false` and construct `ReadFileTool { max_lines: usize::MAX, ..Default::default() }`.
 
-Measured over a 300-turn synthetic tool-heavy session on a 128K window (`tests/context_cache_test.rs`):
+### Measured effect
+
+`tests/context_cache_test.rs` replays 300 turns on a 128K window. The tool mix (bash 41%, edit/write 36%, read 19%, search 4%) and file-size distribution come from 808 archived runs of a production agent built on yoagent.
 
 | | prefix-cache hit rate | history rewrites |
 |---|---|---|
-| 0.14.2 | 95.80% | 16 |
-| 0.15.0 defaults | 96.85% | 15 |
-| 0.15.0 + `truncate_tool_output_on_append` | 98.51% | 2 |
+| 0.14.2 | 93.58% | 23 |
+| 0.15.0, 0.14.2-equivalent settings | 94.38% | 22 |
+| 0.15.0 defaults | **96.04%** | **8** |
+
+Read page size is the dominant remaining lever — hit rate is flat between a 300- and 500-line page (96.2% / 96.0%) and falls to 94.2% at 1000 and 92.9% at 2000. 500 is the largest page that costs nothing extra. Lowering it to 200 buys about a further 1.2 points, at the cost of more read round-trips.
 
 ## ExecutionLimits
 

--- a/docs/concepts/gasp.md
+++ b/docs/concepts/gasp.md
@@ -13,7 +13,7 @@ runtime). The bridge is a consumer of the [`AgentEvent`] stream — **zero
 agent-loop changes**:
 
 ```toml
-yoagent = { version = "0.14", features = ["gasp"] }
+yoagent = { version = "0.15", features = ["gasp"] }
 ```
 
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-yoagent = "0.14"
+yoagent = "0.15"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -40,5 +40,5 @@ Enable in `Cargo.toml`:
 
 ```toml
 [dependencies]
-yoagent = { version = "0.14", features = ["openapi"] }
+yoagent = { version = "0.15", features = ["openapi"] }
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -56,17 +56,18 @@ Controls context window compaction:
 
 ```rust
 pub struct ContextConfig {
-    pub max_context_tokens: usize,               // Default: 100,000
-    pub system_prompt_tokens: usize,             // Default: 4,000
-    pub keep_recent: usize,                      // Default: 10
-    pub keep_first: usize,                       // Default: 2
-    pub tool_output_max_lines: usize,            // Default: 50
-    pub compact_target_ratio: f32,               // Default: 0.7
-    pub truncate_tool_output_on_append: bool,    // Default: false
+    pub max_context_tokens: usize,                            // Default: 100,000
+    pub system_prompt_tokens: usize,                          // Default: 4,000
+    pub keep_recent: usize,                                   // Default: 10
+    pub keep_first: usize,                                    // Default: 2
+    pub tool_output_max_lines: usize,                         // Default: 200
+    pub tool_output_max_lines_overrides: HashMap<String, usize>, // Default: {"read_file": MAX}
+    pub compact_target_ratio: f32,                            // Default: 0.7
+    pub truncate_tool_output_on_append: bool,                 // Default: true
 }
 ```
 
-`compact_target_ratio` is the headroom compaction leaves behind: it triggers at the full budget but reduces to `budget × ratio`, so history is not rewritten every turn once the budget is crossed. `truncate_tool_output_on_append` caps oversized tool output as it enters the context rather than retroactively. Both exist to keep the provider's prefix cache intact — see [Context Management](../concepts/context-management.md#prefix-cache-stability).
+`compact_target_ratio` is the headroom compaction leaves behind: it triggers at the full budget but reduces to `budget × ratio`, so history is not rewritten every turn once the budget is crossed. `truncate_tool_output_on_append` caps tool output as it enters the context rather than retroactively, and `tool_output_max_lines_overrides` gives per-tool budgets so a tool that head+tail would damage (a paging reader) can opt out. All three exist to keep the provider's prefix cache intact — see [Context Management](../concepts/context-management.md#prefix-cache-stability).
 
 When `context_config` is not explicitly set, it is automatically derived from `ModelConfig.context_window` (80% for context, 20% reserved for output). If neither is set, `ContextConfig::default()` (100K) is used.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -56,13 +56,17 @@ Controls context window compaction:
 
 ```rust
 pub struct ContextConfig {
-    pub max_context_tokens: usize,      // Default: 100,000
-    pub system_prompt_tokens: usize,    // Default: 4,000
-    pub keep_recent: usize,             // Default: 10
-    pub keep_first: usize,             // Default: 2
-    pub tool_output_max_lines: usize,   // Default: 50
+    pub max_context_tokens: usize,               // Default: 100,000
+    pub system_prompt_tokens: usize,             // Default: 4,000
+    pub keep_recent: usize,                      // Default: 10
+    pub keep_first: usize,                       // Default: 2
+    pub tool_output_max_lines: usize,            // Default: 50
+    pub compact_target_ratio: f32,               // Default: 0.7
+    pub truncate_tool_output_on_append: bool,    // Default: false
 }
 ```
+
+`compact_target_ratio` is the headroom compaction leaves behind: it triggers at the full budget but reduces to `budget × ratio`, so history is not rewritten every turn once the budget is crossed. `truncate_tool_output_on_append` caps oversized tool output as it enters the context rather than retroactively. Both exist to keep the provider's prefix cache intact — see [Context Management](../concepts/context-management.md#prefix-cache-stability).
 
 When `context_config` is not explicitly set, it is automatically derived from `ModelConfig.context_window` (80% for context, 20% reserved for output). If neither is set, `ContextConfig::default()` (100K) is used.
 

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -522,8 +522,21 @@ async fn run_loop(
                 tool_results = execution.tool_results;
                 steering_after_tools = execution.steering_messages;
 
+                // Cap oversized output on the way in when configured, so
+                // compaction never has to rewrite a tool result the provider
+                // has already cached. The events emitted above still carry the
+                // untruncated output — this is a context concern only.
+                let append_cap = config
+                    .context_config
+                    .as_ref()
+                    .filter(|c| c.truncate_tool_output_on_append)
+                    .map(|c| c.tool_output_max_lines);
+
                 for result in &tool_results {
-                    let am: AgentMessage = result.clone().into();
+                    let mut am: AgentMessage = result.clone().into();
+                    if let Some(max_lines) = append_cap {
+                        am = context::truncate_tool_output(am, max_lines);
+                    }
                     context.messages.push(am.clone());
                     new_messages.push(am);
                 }

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -524,18 +524,19 @@ async fn run_loop(
 
                 // Cap oversized output on the way in when configured, so
                 // compaction never has to rewrite a tool result the provider
-                // has already cached. The events emitted above still carry the
-                // untruncated output — this is a context concern only.
+                // has already cached. Per-tool budgets apply, so a tool that
+                // tolerates head+tail badly can opt out. The events emitted
+                // above still carry the untruncated output — this is a context
+                // concern only.
                 let append_cap = config
                     .context_config
                     .as_ref()
-                    .filter(|c| c.truncate_tool_output_on_append)
-                    .map(|c| c.tool_output_max_lines);
+                    .filter(|c| c.truncate_tool_output_on_append);
 
                 for result in &tool_results {
                     let mut am: AgentMessage = result.clone().into();
-                    if let Some(max_lines) = append_cap {
-                        am = context::truncate_tool_output(am, max_lines);
+                    if let Some(ctx_config) = append_cap {
+                        am = context::truncate_tool_output(am, ctx_config);
                     }
                     context.messages.push(am.clone());
                     new_messages.push(am);

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@
 
 use crate::types::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Token estimation
@@ -150,8 +151,25 @@ pub struct ContextConfig {
     pub keep_recent: usize,
     /// Minimum first messages to always keep
     pub keep_first: usize,
-    /// Max lines to keep per tool output in Level 1 compaction
+    /// Max lines to keep per tool output, for tools with no override below.
+    ///
+    /// Tuned for command output — build logs, test runs, `grep` — where
+    /// head+tail is a good cut: the first error is at the top, the summary at
+    /// the bottom, and the middle is repetition.
     pub tool_output_max_lines: usize,
+    /// Per-tool overrides for `tool_output_max_lines`, keyed by tool name.
+    ///
+    /// One global number cannot serve every tool. Head+tail truncation suits
+    /// command output but is the *wrong* cut for a file read, where the middle
+    /// is usually the part that matters — a paging read tool bounds itself far
+    /// better than a blind truncation can. The default therefore exempts the
+    /// built-in `read_file` (see [`DEFAULT_READ_MAX_LINES`]).
+    ///
+    /// `usize::MAX` disables truncation for a tool.
+    ///
+    /// [`DEFAULT_READ_MAX_LINES`]: crate::tools::DEFAULT_READ_MAX_LINES
+    #[serde(default)]
+    pub tool_output_max_lines_overrides: HashMap<String, usize>,
     /// Fraction of the budget that lossy compaction (Level 2/3) aims for.
     ///
     /// Compaction still *triggers* at the full budget, but once it has to
@@ -173,10 +191,13 @@ pub struct ContextConfig {
     /// It also slows context growth, so compaction runs less often.
     ///
     /// The cost is that a long tool output is trimmed even when the budget
-    /// had room for it. Off by default; the full output is always visible in
-    /// the [`AgentEvent`](crate::types::AgentEvent) stream either way.
+    /// had room for it — which is why tools that tolerate it badly are exempted
+    /// via `tool_output_max_lines_overrides` rather than by turning this off.
+    /// The full output is always visible in the
+    /// [`AgentEvent`](crate::types::AgentEvent) stream either way.
     ///
-    /// Only honoured by the agent loop when a `ContextConfig` is set.
+    /// On by default. Only honoured by the agent loop when a `ContextConfig`
+    /// is set.
     pub truncate_tool_output_on_append: bool,
 }
 
@@ -187,11 +208,21 @@ impl Default for ContextConfig {
             system_prompt_tokens: 4_000,
             keep_recent: 10,
             keep_first: 2,
-            tool_output_max_lines: 50,
+            tool_output_max_lines: 200,
+            tool_output_max_lines_overrides: default_tool_output_overrides(),
             compact_target_ratio: 0.7,
-            truncate_tool_output_on_append: false,
+            truncate_tool_output_on_append: true,
         }
     }
+}
+
+/// Tools whose output the default head+tail cap would damage.
+///
+/// `read_file` bounds itself by paging (`DEFAULT_READ_MAX_LINES`), which is
+/// both lossless and directed; cutting the middle out of a source file on top
+/// of that would remove exactly the part the agent asked for.
+fn default_tool_output_overrides() -> HashMap<String, usize> {
+    HashMap::from([("read_file".to_string(), usize::MAX)])
 }
 
 impl ContextConfig {
@@ -205,6 +236,14 @@ impl ContextConfig {
             max_context_tokens,
             ..Default::default()
         }
+    }
+
+    /// The line cap that applies to a given tool's output.
+    pub fn max_lines_for(&self, tool_name: &str) -> usize {
+        self.tool_output_max_lines_overrides
+            .get(tool_name)
+            .copied()
+            .unwrap_or(self.tool_output_max_lines)
     }
 
     /// The token count lossy compaction reduces to, given the trigger budget.
@@ -292,7 +331,7 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
     // Level 1: Truncate tool outputs. Checked against the full budget, not the
     // target: this level is idempotent and cheap to repeat, so there is nothing
     // to gain by escalating to the lossy levels before we have to.
-    let compacted = level1_truncate_tool_outputs(&messages, config.tool_output_max_lines);
+    let compacted = level1_truncate_tool_outputs(&messages, config);
     if total_tokens(&compacted) <= budget {
         return compacted;
     }
@@ -312,21 +351,26 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
 /// This is the cheapest compaction — preserves conversation structure,
 /// just removes verbose tool output middles. In practice this saves
 /// 50-70% of context in coding sessions.
-fn level1_truncate_tool_outputs(messages: &[AgentMessage], max_lines: usize) -> Vec<AgentMessage> {
+fn level1_truncate_tool_outputs(
+    messages: &[AgentMessage],
+    config: &ContextConfig,
+) -> Vec<AgentMessage> {
     messages
         .iter()
-        .map(|msg| truncate_tool_output(msg.clone(), max_lines))
+        .map(|msg| truncate_tool_output(msg.clone(), config))
         .collect()
 }
 
-/// Cap a single tool result's text at `max_lines`, keeping head and tail.
+/// Cap a single tool result's text at the tool's line budget, keeping head and
+/// tail.
 ///
-/// Non-tool-result messages pass through untouched, and the operation is
-/// idempotent, so applying it when the message is first appended means
-/// compaction never has to rewrite it later — which is what keeps the
-/// provider's prefix cache intact. See
+/// The budget comes from [`ContextConfig::max_lines_for`], so a tool that
+/// tolerates head+tail badly can be exempted. Non-tool-result messages pass
+/// through untouched, and the operation is idempotent, so applying it when the
+/// message is first appended means compaction never has to rewrite it later —
+/// which is what keeps the provider's prefix cache intact. See
 /// [`ContextConfig::truncate_tool_output_on_append`].
-pub fn truncate_tool_output(msg: AgentMessage, max_lines: usize) -> AgentMessage {
+pub fn truncate_tool_output(msg: AgentMessage, config: &ContextConfig) -> AgentMessage {
     match msg {
         AgentMessage::Llm(Message::ToolResult {
             tool_call_id,
@@ -335,6 +379,7 @@ pub fn truncate_tool_output(msg: AgentMessage, max_lines: usize) -> AgentMessage
             is_error,
             timestamp,
         }) => {
+            let max_lines = config.max_lines_for(&tool_name);
             let truncated_content: Vec<Content> = content
                 .into_iter()
                 .map(|c| match c {
@@ -1026,8 +1071,12 @@ mod tests {
             timestamp: 7,
         });
 
-        let once = truncate_tool_output(msg, 50);
-        let twice = truncate_tool_output(once.clone(), 50);
+        let config = ContextConfig {
+            tool_output_max_lines: 50,
+            ..Default::default()
+        };
+        let once = truncate_tool_output(msg, &config);
+        let twice = truncate_tool_output(once.clone(), &config);
         assert_eq!(once, twice, "on-append truncation must be idempotent");
 
         match &once {
@@ -1045,7 +1094,7 @@ mod tests {
 
         // Non-tool-result messages pass through untouched.
         let user = AgentMessage::Llm(Message::user("hello"));
-        assert_eq!(truncate_tool_output(user.clone(), 1), user);
+        assert_eq!(truncate_tool_output(user.clone(), &config), user);
     }
 
     #[test]
@@ -1065,7 +1114,13 @@ mod tests {
             }),
         ];
 
-        let compacted = level1_truncate_tool_outputs(&messages, 20);
+        let compacted = level1_truncate_tool_outputs(
+            &messages,
+            &ContextConfig {
+                tool_output_max_lines: 20,
+                ..Default::default()
+            },
+        );
         let tool_msg = &compacted[1];
         if let AgentMessage::Llm(Message::ToolResult { content, .. }) = tool_msg {
             if let Content::Text { text } = &content[0] {

--- a/src/context.rs
+++ b/src/context.rs
@@ -152,6 +152,32 @@ pub struct ContextConfig {
     pub keep_first: usize,
     /// Max lines to keep per tool output in Level 1 compaction
     pub tool_output_max_lines: usize,
+    /// Fraction of the budget that lossy compaction (Level 2/3) aims for.
+    ///
+    /// Compaction still *triggers* at the full budget, but once it has to
+    /// summarize or drop history it reduces to `budget * ratio` instead of to
+    /// whatever just barely fits. Without this headroom the very next turn
+    /// crosses the budget again and history is rewritten every single turn,
+    /// which discards the provider's prefix cache each time.
+    ///
+    /// Clamped to `[0.05, 1.0]` (a non-finite value falls back to `1.0`).
+    /// `1.0` restores the old compact-to-just-fit behaviour. Default: `0.7`.
+    pub compact_target_ratio: f32,
+    /// Apply `tool_output_max_lines` when a tool result is appended, rather
+    /// than only once the session is over budget.
+    ///
+    /// Retroactive truncation is the single largest source of prefix-cache
+    /// loss: a tool result that has already been sent in full is rewritten
+    /// later, invalidating the cache from that message onward. Capping on the
+    /// way in means the bytes the provider cached are the bytes that stay.
+    /// It also slows context growth, so compaction runs less often.
+    ///
+    /// The cost is that a long tool output is trimmed even when the budget
+    /// had room for it. Off by default; the full output is always visible in
+    /// the [`AgentEvent`](crate::types::AgentEvent) stream either way.
+    ///
+    /// Only honoured by the agent loop when a `ContextConfig` is set.
+    pub truncate_tool_output_on_append: bool,
 }
 
 impl Default for ContextConfig {
@@ -162,6 +188,8 @@ impl Default for ContextConfig {
             keep_recent: 10,
             keep_first: 2,
             tool_output_max_lines: 50,
+            compact_target_ratio: 0.7,
+            truncate_tool_output_on_append: false,
         }
     }
 }
@@ -177,6 +205,16 @@ impl ContextConfig {
             max_context_tokens,
             ..Default::default()
         }
+    }
+
+    /// The token count lossy compaction reduces to, given the trigger budget.
+    fn compaction_target(&self, budget: usize) -> usize {
+        let ratio = if self.compact_target_ratio.is_finite() {
+            self.compact_target_ratio.clamp(0.05, 1.0)
+        } else {
+            1.0
+        };
+        ((budget as f64) * (ratio as f64)) as usize
     }
 }
 
@@ -224,6 +262,21 @@ impl CompactionStrategy for DefaultCompaction {
 /// - Level 3: Drop old messages (keep first + recent only)
 ///
 /// Each level is tried in order. Returns as soon as messages fit.
+///
+/// # Prefix-cache behaviour
+///
+/// Every rewrite of an already-sent message discards the provider's prefix
+/// cache from that point on, so compaction is built to keep history
+/// byte-stable:
+///
+/// - Level 1 is idempotent — re-running it on settled history is a no-op, so
+///   staying above the budget does not re-truncate the same outputs.
+/// - Level 1 alone only has to reach the budget; the lossy levels aim for
+///   `compact_target_ratio` of it, so once history is rewritten it takes many
+///   turns before it must be rewritten again.
+/// - Level 3 drops the smallest span that reaches the target and its marker
+///   text is constant, so a boundary that lands in the same place twice
+///   reproduces the same bytes.
 pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> Vec<AgentMessage> {
     let budget = config
         .max_context_tokens
@@ -234,7 +287,11 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
         return messages;
     }
 
-    // Level 1: Truncate tool outputs
+    let target = config.compaction_target(budget);
+
+    // Level 1: Truncate tool outputs. Checked against the full budget, not the
+    // target: this level is idempotent and cheap to repeat, so there is nothing
+    // to gain by escalating to the lossy levels before we have to.
     let compacted = level1_truncate_tool_outputs(&messages, config.tool_output_max_lines);
     if total_tokens(&compacted) <= budget {
         return compacted;
@@ -242,12 +299,12 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
 
     // Level 2: Summarize old turns (keep recent N full, summarize the rest)
     let compacted = level2_summarize_old_turns(&compacted, config.keep_recent);
-    if total_tokens(&compacted) <= budget {
+    if total_tokens(&compacted) <= target {
         return compacted;
     }
 
-    // Level 3: Drop middle messages (keep first + recent)
-    level3_drop_middle(&compacted, config, budget)
+    // Level 3: Drop the smallest middle span that reaches the target
+    level3_drop_middle(&compacted, config, target)
 }
 
 /// Level 1: Truncate long tool outputs to head + tail.
@@ -258,46 +315,74 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
 fn level1_truncate_tool_outputs(messages: &[AgentMessage], max_lines: usize) -> Vec<AgentMessage> {
     messages
         .iter()
-        .map(|msg| match msg {
-            AgentMessage::Llm(Message::ToolResult {
-                tool_call_id,
-                tool_name,
-                content,
-                is_error,
-                timestamp,
-            }) => {
-                let truncated_content: Vec<Content> = content
-                    .iter()
-                    .map(|c| match c {
-                        Content::Text { text } => Content::Text {
-                            text: truncate_text_head_tail(text, max_lines),
-                        },
-                        other => other.clone(),
-                    })
-                    .collect();
-
-                AgentMessage::Llm(Message::ToolResult {
-                    tool_call_id: tool_call_id.clone(),
-                    tool_name: tool_name.clone(),
-                    content: truncated_content,
-                    is_error: *is_error,
-                    timestamp: *timestamp,
-                })
-            }
-            other => other.clone(),
-        })
+        .map(|msg| truncate_tool_output(msg.clone(), max_lines))
         .collect()
 }
 
-/// Truncate text keeping first N/2 and last N/2 lines.
+/// Cap a single tool result's text at `max_lines`, keeping head and tail.
+///
+/// Non-tool-result messages pass through untouched, and the operation is
+/// idempotent, so applying it when the message is first appended means
+/// compaction never has to rewrite it later — which is what keeps the
+/// provider's prefix cache intact. See
+/// [`ContextConfig::truncate_tool_output_on_append`].
+pub fn truncate_tool_output(msg: AgentMessage, max_lines: usize) -> AgentMessage {
+    match msg {
+        AgentMessage::Llm(Message::ToolResult {
+            tool_call_id,
+            tool_name,
+            content,
+            is_error,
+            timestamp,
+        }) => {
+            let truncated_content: Vec<Content> = content
+                .into_iter()
+                .map(|c| match c {
+                    Content::Text { text } => Content::Text {
+                        text: truncate_text_head_tail(&text, max_lines),
+                    },
+                    other => other,
+                })
+                .collect();
+
+            AgentMessage::Llm(Message::ToolResult {
+                tool_call_id,
+                tool_name,
+                content: truncated_content,
+                is_error,
+                timestamp,
+            })
+        }
+        other => other,
+    }
+}
+
+/// Lines the truncation marker occupies: a blank line, the marker, a blank line.
+const TRUNCATION_MARKER_LINES: usize = 3;
+
+/// Truncate text keeping the head and tail, dropping the middle.
+///
+/// The marker is charged against `max_lines`, so the result is exactly
+/// `max_lines` lines and truncating it again returns it unchanged. That
+/// idempotence matters: compaction runs before every turn once a session is
+/// over budget, and a marker that shrank on each pass (`950 lines truncated`
+/// → `3 lines truncated`) both misreported the loss and rewrote settled
+/// history, discarding the provider's prefix cache a second time.
 fn truncate_text_head_tail(text: &str, max_lines: usize) -> String {
     let lines: Vec<&str> = text.lines().collect();
     if lines.len() <= max_lines {
         return text.to_string();
     }
 
-    let head = max_lines / 2;
-    let tail = max_lines - head;
+    // Not enough room for head + marker + tail — keep the head and skip the
+    // marker rather than emitting something that re-truncates forever.
+    if max_lines <= TRUNCATION_MARKER_LINES + 1 {
+        return lines[..max_lines].join("\n");
+    }
+
+    let keep = max_lines - TRUNCATION_MARKER_LINES;
+    let head = keep / 2;
+    let tail = keep - head;
     let omitted = lines.len() - head - tail;
 
     let mut result = lines[..head].join("\n");
@@ -317,14 +402,23 @@ fn level2_summarize_old_turns(messages: &[AgentMessage], keep_recent: usize) -> 
         return messages.to_vec();
     }
 
-    let boundary = len - keep_recent;
+    // `len - keep_recent` can land in the middle of a turn, which would
+    // summarize away an assistant message while its tool results stay in the
+    // kept section — an orphan every provider rejects. Pull the boundary back
+    // onto the turn start so the whole turn is kept intact.
+    let boundary = safe_turn_start(messages, len - keep_recent);
+    if boundary == 0 {
+        return messages.to_vec();
+    }
     let mut result = Vec::new();
 
     let mut i = 0;
     while i < boundary {
         let msg = &messages[i];
         match msg {
-            AgentMessage::Llm(Message::Assistant { content, .. }) => {
+            AgentMessage::Llm(Message::Assistant {
+                content, timestamp, ..
+            }) => {
                 // Summarize: extract text content, skip tool call details
                 let text_parts: Vec<&str> = content
                     .iter()
@@ -353,11 +447,15 @@ fn level2_summarize_old_turns(messages: &[AgentMessage], keep_recent: usize) -> 
                     "[Assistant response]".into()
                 };
 
+                // Inherit the summarized turn's timestamp rather than stamping
+                // wall-clock time: compaction must be a pure function of its
+                // input, or the same history compacts to different bytes on
+                // every pass.
                 result.push(AgentMessage::Llm(Message::User {
                     content: vec![Content::Text {
                         text: format!("[Summary] {}", summary),
                     }],
-                    timestamp: now_ms(),
+                    timestamp: *timestamp,
                 }));
 
                 // Skip following tool results that belong to this turn
@@ -389,42 +487,131 @@ fn level2_summarize_old_turns(messages: &[AgentMessage], keep_recent: usize) -> 
     result
 }
 
-/// Level 3: Drop middle messages, keeping first + recent.
+/// Marker left in place of dropped history.
+///
+/// The text is constant on purpose. It sits near the front of the message list,
+/// so embedding a message count here would change the bytes of the cached
+/// prefix on every compaction pass — the count goes to the debug log instead.
+const COMPACTION_MARKER: &str =
+    "[Context compacted: earlier messages removed to fit the context window]";
+
+fn compaction_marker(timestamp: u64) -> AgentMessage {
+    AgentMessage::Llm(Message::User {
+        content: vec![Content::Text {
+            text: COMPACTION_MARKER.into(),
+        }],
+        timestamp,
+    })
+}
+
+fn message_timestamp(msg: &AgentMessage) -> u64 {
+    match msg {
+        AgentMessage::Llm(
+            Message::User { timestamp, .. }
+            | Message::Assistant { timestamp, .. }
+            | Message::ToolResult { timestamp, .. },
+        ) => *timestamp,
+        AgentMessage::Extension(_) => 0,
+    }
+}
+
+/// Does this message open tool calls that a later message must answer?
+fn opens_tool_calls(msg: &AgentMessage) -> bool {
+    matches!(
+        msg,
+        AgentMessage::Llm(Message::Assistant { content, .. })
+            if content.iter().any(|c| matches!(c, Content::ToolCall { .. }))
+    )
+}
+
+fn is_tool_result(msg: &AgentMessage) -> bool {
+    matches!(msg, AgentMessage::Llm(Message::ToolResult { .. }))
+}
+
+/// Pull a kept-head boundary back so the head never ends on an assistant
+/// message whose tool results are about to be dropped — providers reject a
+/// `tool_use` with no matching `tool_result`.
+fn safe_head_end(messages: &[AgentMessage], mut end: usize) -> usize {
+    while end > 0 && opens_tool_calls(&messages[end - 1]) {
+        end -= 1;
+    }
+    end
+}
+
+/// Push a kept-tail boundary forward so the tail never opens on a tool result
+/// whose originating tool call was dropped — the mirror-image rejection.
+fn safe_tail_start(messages: &[AgentMessage], mut start: usize) -> usize {
+    while start < messages.len() && is_tool_result(&messages[start]) {
+        start += 1;
+    }
+    start
+}
+
+/// Pull a boundary back onto the start of the turn it lands in, so the turn's
+/// assistant message and its tool results stay on the same side of the split.
+fn safe_turn_start(messages: &[AgentMessage], mut start: usize) -> usize {
+    while start > 0 && start < messages.len() && is_tool_result(&messages[start]) {
+        start -= 1;
+    }
+    start
+}
+
+/// Level 3: Drop the smallest middle span that brings the history to `target`.
+///
+/// Keeps `keep_first` messages at the front and at least `keep_recent` at the
+/// back, and removes only as much of the middle as the target requires — the
+/// old fixed `first + recent` shape discarded everything in between even when
+/// a fraction of it would have done.
 fn level3_drop_middle(
     messages: &[AgentMessage],
     config: &ContextConfig,
-    budget: usize,
+    target: usize,
 ) -> Vec<AgentMessage> {
     let len = messages.len();
-    let first_end = config.keep_first.min(len);
-    let recent_start = len.saturating_sub(config.keep_recent);
+    let head_end = safe_head_end(messages, config.keep_first.min(len));
+    // The furthest the cut may go: everything past it is the guaranteed tail.
+    let max_cut = len.saturating_sub(config.keep_recent);
 
-    if first_end >= recent_start {
+    if head_end >= max_cut {
         // Can't split — just keep as many recent as fit
-        return keep_within_budget(messages, budget);
+        return keep_within_budget(messages, target);
     }
 
-    let first_msgs = &messages[..first_end];
-    let recent_msgs = &messages[recent_start..];
-    let removed = recent_start - first_end;
+    // suffix[i] = tokens of messages[i..]
+    let mut suffix = vec![0usize; len + 1];
+    for i in (0..len).rev() {
+        suffix[i] = suffix[i + 1] + message_tokens(&messages[i]);
+    }
+    let head_tokens: usize = messages[..head_end].iter().map(message_tokens).sum();
+    let marker_tokens = message_tokens(&compaction_marker(0));
+    let fixed = head_tokens + marker_tokens;
 
-    let marker = AgentMessage::Llm(Message::User {
-        content: vec![Content::Text {
-            text: format!(
-                "[Context compacted: {} messages removed to fit context window]",
-                removed
-            ),
-        }],
-        timestamp: now_ms(),
-    });
+    // Smallest cut that reaches the target — the least history destroyed.
+    let cut = suffix[head_end..=max_cut]
+        .iter()
+        .position(|&tokens| fixed + tokens <= target)
+        .map_or(max_cut, |offset| head_end + offset);
+    // Snapping forward only drops more, so the target still holds.
+    let cut = safe_tail_start(messages, cut).max(head_end);
 
-    let mut result = first_msgs.to_vec();
-    result.push(marker);
-    result.extend_from_slice(recent_msgs);
+    let removed = cut - head_end;
+    if removed == 0 {
+        return messages.to_vec();
+    }
+    tracing::debug!(
+        "compaction level 3: dropping {} of {} messages (target {} tokens)",
+        removed,
+        len,
+        target
+    );
+
+    let mut result = messages[..head_end].to_vec();
+    result.push(compaction_marker(message_timestamp(&messages[head_end])));
+    result.extend_from_slice(&messages[cut..]);
 
     // If still too big, progressively drop from recent
-    if total_tokens(&result) > budget {
-        return keep_within_budget(&result, budget);
+    if total_tokens(&result) > target {
+        return keep_within_budget(&result, target);
     }
 
     result
@@ -432,7 +619,10 @@ fn level3_drop_middle(
 
 /// Keep as many recent messages as fit within budget.
 fn keep_within_budget(messages: &[AgentMessage], budget: usize) -> Vec<AgentMessage> {
-    let mut result = Vec::new();
+    if messages.is_empty() {
+        return Vec::new();
+    }
+    let mut kept = 0usize;
     let mut remaining = budget;
 
     for msg in messages.iter().rev() {
@@ -441,22 +631,21 @@ fn keep_within_budget(messages: &[AgentMessage], budget: usize) -> Vec<AgentMess
             break;
         }
         remaining -= tokens;
-        result.push(msg.clone());
+        kept += 1;
     }
 
-    result.reverse();
+    // Never open on a tool result whose tool call was just dropped.
+    let start = safe_tail_start(messages, messages.len() - kept);
+    let mut result = messages[start..].to_vec();
 
-    if result.len() < messages.len() {
-        let removed = messages.len() - result.len();
-        result.insert(
-            0,
-            AgentMessage::Llm(Message::User {
-                content: vec![Content::Text {
-                    text: format!("[Context compacted: {} messages removed]", removed),
-                }],
-                timestamp: now_ms(),
-            }),
+    if start > 0 {
+        tracing::debug!(
+            "compaction: keeping {} of {} messages within {} tokens",
+            result.len(),
+            messages.len(),
+            budget
         );
+        result.insert(0, compaction_marker(message_timestamp(&messages[0])));
     }
 
     result
@@ -572,11 +761,291 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         let result = truncate_text_head_tail(&text, 10);
-        assert!(result.contains("line 1"));
-        assert!(result.contains("line 5")); // head
+        assert!(result.contains("line 1")); // head
         assert!(result.contains("line 100")); // tail
         assert!(result.contains("truncated"));
         assert!(!result.contains("line 50")); // middle removed
+
+        // The marker is charged against the line budget, so the result fits
+        // exactly and a second pass leaves it alone.
+        assert_eq!(result.lines().count(), 10);
+        assert_eq!(truncate_text_head_tail(&result, 10), result);
+    }
+
+    #[test]
+    fn test_truncate_is_idempotent_and_keeps_an_honest_count() {
+        let text = (1..=1000)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let once = truncate_text_head_tail(&text, 50);
+        assert!(once.contains("[... 953 lines truncated ...]"));
+        assert_eq!(once.lines().count(), 50);
+
+        // Re-truncating must not shrink the content further or restate the
+        // omitted count — that churn rewrote settled history on every pass.
+        let twice = truncate_text_head_tail(&once, 50);
+        assert_eq!(twice, once);
+        assert_eq!(truncate_text_head_tail(&twice, 50), once);
+    }
+
+    #[test]
+    fn test_truncate_degenerate_line_budget() {
+        let text = (1..=100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Too small for head + marker + tail: keep the head, stay idempotent.
+        for max_lines in [1usize, 2, 3, 4] {
+            let result = truncate_text_head_tail(&text, max_lines);
+            assert_eq!(result.lines().count(), max_lines);
+            assert_eq!(truncate_text_head_tail(&result, max_lines), result);
+        }
+    }
+
+    // -- helpers for the compaction-shape tests ---------------------------
+
+    fn tool_turn(i: usize, output_lines: usize) -> Vec<AgentMessage> {
+        let output = (0..output_lines)
+            .map(|n| format!("turn {} line {} {}", i, n, "x".repeat(40)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        vec![
+            AgentMessage::Llm(Message::Assistant {
+                content: vec![Content::tool_call(
+                    format!("tc-{}", i),
+                    "bash",
+                    serde_json::json!({ "command": format!("ls {}", i) }),
+                )],
+                stop_reason: StopReason::ToolUse,
+                model: "test".into(),
+                provider: "test".into(),
+                usage: Usage::default(),
+                timestamp: i as u64,
+                error_message: None,
+            }),
+            AgentMessage::Llm(Message::ToolResult {
+                tool_call_id: format!("tc-{}", i),
+                tool_name: "bash".into(),
+                content: vec![Content::Text { text: output }],
+                is_error: false,
+                timestamp: i as u64,
+            }),
+        ]
+    }
+
+    fn tool_session(turns: usize, output_lines: usize) -> Vec<AgentMessage> {
+        let mut messages = vec![AgentMessage::Llm(Message::user("start"))];
+        for i in 0..turns {
+            messages.extend(tool_turn(i, output_lines));
+        }
+        messages
+    }
+
+    #[test]
+    fn test_compact_target_ratio_leaves_headroom() {
+        let messages = tool_session(40, 120);
+        let config = ContextConfig {
+            max_context_tokens: 8_000,
+            system_prompt_tokens: 0,
+            compact_target_ratio: 0.5,
+            ..Default::default()
+        };
+        assert!(total_tokens(&messages) > config.max_context_tokens);
+
+        let result = compact_messages(messages, &config);
+        // Compacting to just-fits means the next turn compacts again; the
+        // point of the ratio is that it lands well clear of the budget.
+        assert!(
+            total_tokens(&result) <= 4_000,
+            "compacted to {} tokens, expected <= 4000 (50% of budget)",
+            total_tokens(&result)
+        );
+    }
+
+    #[test]
+    fn test_ratio_of_one_restores_compact_to_just_fit() {
+        let config = ContextConfig {
+            max_context_tokens: 10_000,
+            system_prompt_tokens: 0,
+            compact_target_ratio: 1.0,
+            ..Default::default()
+        };
+        assert_eq!(config.compaction_target(10_000), 10_000);
+    }
+
+    #[test]
+    fn test_compaction_target_rejects_nonsense_ratios() {
+        let mut config = ContextConfig::default();
+        for (ratio, expected) in [
+            (0.0f32, 500usize),      // clamped up to the 0.05 floor
+            (-1.0, 500),             // ditto
+            (2.0, 10_000),           // clamped down to 1.0
+            (f32::NAN, 10_000),      // non-finite falls back to 1.0
+            (f32::INFINITY, 10_000), // ditto
+        ] {
+            config.compact_target_ratio = ratio;
+            assert_eq!(
+                config.compaction_target(10_000),
+                expected,
+                "ratio {}",
+                ratio
+            );
+        }
+    }
+
+    #[test]
+    fn test_level3_drops_only_what_the_target_requires() {
+        // Budget comfortably holds most of the session, so a correct Level 3
+        // sheds a few turns rather than collapsing to first + recent.
+        let messages = tool_session(40, 20);
+        let config = ContextConfig {
+            max_context_tokens: total_tokens(&messages) * 3 / 4,
+            system_prompt_tokens: 0,
+            compact_target_ratio: 0.9,
+            ..Default::default()
+        };
+
+        let result = compact_messages(messages.clone(), &config);
+        assert!(total_tokens(&result) <= config.max_context_tokens);
+        // The old fixed shape kept keep_first + marker + keep_recent = 13.
+        assert!(
+            result.len() > 13,
+            "kept only {} messages; Level 3 is still collapsing history it did not need to",
+            result.len()
+        );
+    }
+
+    #[test]
+    fn test_compaction_never_orphans_tool_calls() {
+        // Every provider rejects a tool_result with no matching tool_use, and
+        // a tool_use with no result. Compaction must not create either.
+        for (max_context_tokens, keep_recent, keep_first) in [
+            (400usize, 10usize, 2usize),
+            (1_000, 10, 2),
+            (4_000, 10, 2),
+            (20_000, 10, 2),
+            // Sweep the Level 2 / Level 3 boundaries across turn parities: a
+            // boundary landing mid-turn is exactly how an orphan is created.
+            (4_000, 9, 1),
+            (4_000, 11, 3),
+            (8_000, 7, 4),
+            (8_000, 12, 5),
+            (12_000, 13, 0),
+        ] {
+            let messages = tool_session(30, 60);
+            let config = ContextConfig {
+                max_context_tokens,
+                system_prompt_tokens: 0,
+                keep_recent,
+                keep_first,
+                ..Default::default()
+            };
+            let result = compact_messages(messages, &config);
+
+            let mut open: Vec<String> = Vec::new();
+            for msg in &result {
+                match msg {
+                    AgentMessage::Llm(Message::Assistant { content, .. }) => {
+                        open = content
+                            .iter()
+                            .filter_map(|c| match c {
+                                Content::ToolCall { id, .. } => Some(id.clone()),
+                                _ => None,
+                            })
+                            .collect();
+                    }
+                    AgentMessage::Llm(Message::ToolResult { tool_call_id, .. }) => {
+                        let answered = open.iter().position(|id| id == tool_call_id);
+                        assert!(
+                            answered.is_some(),
+                            "orphaned tool result {} at budget {}",
+                            tool_call_id,
+                            max_context_tokens
+                        );
+                        open.remove(answered.unwrap());
+                    }
+                    _ => {
+                        assert!(
+                            open.is_empty(),
+                            "unanswered tool call {:?} at budget {}",
+                            open,
+                            max_context_tokens
+                        );
+                    }
+                }
+            }
+            assert!(
+                open.is_empty(),
+                "history ends on an unanswered tool call at budget {}",
+                max_context_tokens
+            );
+        }
+    }
+
+    #[test]
+    fn test_compaction_marker_carries_no_drifting_count() {
+        // The marker sits near the front of the request. A message count in it
+        // would change the cached prefix on every compaction pass.
+        let messages = tool_session(40, 120);
+        let config = ContextConfig {
+            max_context_tokens: 2_000,
+            system_prompt_tokens: 0,
+            ..Default::default()
+        };
+        let result = compact_messages(messages, &config);
+
+        let marker = result
+            .iter()
+            .find_map(|m| match m {
+                AgentMessage::Llm(Message::User { content, .. }) => match content.first() {
+                    Some(Content::Text { text }) if text.starts_with("[Context compacted") => {
+                        Some(text.clone())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .expect("expected a compaction marker");
+        assert_eq!(marker, COMPACTION_MARKER);
+        assert!(!marker.chars().any(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn test_truncate_tool_output_helper() {
+        let big = (0..500)
+            .map(|i| format!("l{}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let msg = AgentMessage::Llm(Message::ToolResult {
+            tool_call_id: "tc-1".into(),
+            tool_name: "bash".into(),
+            content: vec![Content::Text { text: big }],
+            is_error: false,
+            timestamp: 7,
+        });
+
+        let once = truncate_tool_output(msg, 50);
+        let twice = truncate_tool_output(once.clone(), 50);
+        assert_eq!(once, twice, "on-append truncation must be idempotent");
+
+        match &once {
+            AgentMessage::Llm(Message::ToolResult {
+                content, timestamp, ..
+            }) => {
+                assert_eq!(*timestamp, 7, "timestamp must survive truncation");
+                let Content::Text { text } = &content[0] else {
+                    panic!("expected text")
+                };
+                assert_eq!(text.lines().count(), 50);
+            }
+            _ => panic!("expected a tool result"),
+        }
+
+        // Non-tool-result messages pass through untouched.
+        let user = AgentMessage::Llm(Message::user("hello"));
+        assert_eq!(truncate_tool_output(user.clone(), 1), user);
     }
 
     #[test]
@@ -640,6 +1109,7 @@ mod tests {
             keep_recent: 5,
             keep_first: 2,
             tool_output_max_lines: 20,
+            ..Default::default()
         };
 
         let result = compact_messages(messages, &config);

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -34,12 +34,33 @@ fn get_image_mime_type(path: &Path) -> Option<&'static str> {
     }
 }
 
+/// Default number of lines returned when the caller gives no explicit `limit`.
+///
+/// An unbounded read used to return whole files. In a real Rust codebase the
+/// median source file runs well over a thousand lines, so a single unqualified
+/// read could spend ~15K tokens — and reads are roughly a fifth of all tool
+/// calls in a coding agent. That is what drives a session to its context budget
+/// and triggers the compaction that rewrites history.
+///
+/// Paging is the right bound for a file: unlike head+tail truncation it is
+/// lossless and directed — the header states the true total, and the agent asks
+/// for the range it actually wants.
+///
+/// 500 was chosen by measurement. Replaying a session modelled on that agent's
+/// tool mix, prefix-cache hit rate is flat between a 300- and 500-line page
+/// (96.2% / 96.0%) and falls off sharply above it (94.2% at 1000, 92.9% at
+/// 2000), so 500 is the largest page that costs nothing extra.
+pub const DEFAULT_READ_MAX_LINES: usize = 500;
+
 /// Read a file's contents. Supports line range for large files.
 pub struct ReadFileTool {
     /// Max file size to read (prevents OOM)
     pub max_bytes: usize,
     /// Allowed directory roots (empty = no restriction)
     pub allowed_paths: Vec<String>,
+    /// Lines returned when the call specifies no `limit`.
+    /// Set to `usize::MAX` to restore unbounded reads.
+    pub max_lines: usize,
 }
 
 impl Default for ReadFileTool {
@@ -47,6 +68,7 @@ impl Default for ReadFileTool {
         Self {
             max_bytes: 1024 * 1024, // 1MB
             allowed_paths: Vec::new(),
+            max_lines: DEFAULT_READ_MAX_LINES,
         }
     }
 }
@@ -68,7 +90,7 @@ impl AgentTool for ReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a file's contents. Supports text files with optional offset/limit, and image files (jpg, png, webp, gif, bmp) which are returned as base64-encoded images."
+        "Read a file's contents. Supports text files with optional offset/limit, and image files (jpg, png, webp, gif, bmp) which are returned as base64-encoded images. Long files are returned one page at a time — the header states the total line count, so pass offset/limit to read further."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -154,17 +176,16 @@ impl AgentTool for ReadFileTool {
         let lines: Vec<&str> = content.lines().collect();
         let total = lines.len();
 
-        let (start, end) = match (offset, limit) {
-            (Some(off), Some(lim)) => {
+        // No explicit limit falls back to `max_lines` rather than the whole
+        // file. The header below reports the true total, so a partial read is
+        // visible and the agent can page with offset/limit.
+        let effective_limit = limit.unwrap_or(self.max_lines);
+        let (start, end) = match offset {
+            Some(off) => {
                 let s = (off - 1).min(total);
-                (s, (s + lim).min(total))
+                (s, s.saturating_add(effective_limit).min(total))
             }
-            (Some(off), None) => {
-                let s = (off - 1).min(total);
-                (s, total)
-            }
-            (None, Some(lim)) => (0, lim.min(total)),
-            (None, None) => (0, total),
+            None => (0, effective_limit.min(total)),
         };
 
         let numbered: Vec<String> = lines[start..end]
@@ -174,7 +195,12 @@ impl AgentTool for ReadFileTool {
             .collect();
 
         let header = if start > 0 || end < total {
-            format!("[Lines {}-{} of {}]", start + 1, end, total)
+            format!(
+                "[Lines {}-{} of {} — use offset/limit to read the rest]",
+                start + 1,
+                end,
+                total
+            )
         } else {
             format!("[{} lines]", total)
         };

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,7 +7,7 @@ pub mod shared_state_tool;
 
 pub use bash::BashTool;
 pub use edit::EditFileTool;
-pub use file::{ReadFileTool, WriteFileTool};
+pub use file::{ReadFileTool, WriteFileTool, DEFAULT_READ_MAX_LINES};
 pub use list::ListFilesTool;
 pub use search::SearchTool;
 pub use shared_state_tool::SharedStateTool;

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -1952,6 +1952,7 @@ async fn test_default_compaction_matches_compact_messages() {
         keep_recent: 5,
         keep_first: 2,
         tool_output_max_lines: 20,
+        ..Default::default()
     };
 
     let result_direct = compact_messages(messages.clone(), &config);
@@ -2015,6 +2016,7 @@ async fn test_custom_compaction_strategy_is_called() {
             keep_recent: 1,
             keep_first: 1,
             tool_output_max_lines: 10,
+            ..Default::default()
         }),
         compaction_strategy: Some(std::sync::Arc::new(MarkerCompaction)),
         execution_limits: None,
@@ -2093,6 +2095,7 @@ async fn test_none_compaction_strategy_uses_default() {
             keep_recent: 1,
             keep_first: 1,
             tool_output_max_lines: 10,
+            ..Default::default()
         }),
         compaction_strategy: None, // Should fall back to DefaultCompaction
         execution_limits: None,
@@ -2271,6 +2274,7 @@ fn calibration_config(
             keep_recent: 1,
             keep_first: 1,
             tool_output_max_lines: 10,
+            ..Default::default()
         }),
         compaction_strategy: Some(strategy),
         execution_limits: Some(ExecutionLimits {
@@ -2357,4 +2361,139 @@ async fn test_calibration_floor_prevents_budget_collapse() {
     assert!(calls.len() >= 2, "expected 2 turns, got {:?}", calls);
     assert_eq!(calls[0], (4000, 500));
     assert_eq!(calls[1], (400, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Tool output capped on append (prefix-cache stability)
+// ---------------------------------------------------------------------------
+
+struct BigOutputTool;
+
+#[async_trait::async_trait]
+impl AgentTool for BigOutputTool {
+    fn name(&self) -> &str {
+        "big_output"
+    }
+    fn label(&self) -> &str {
+        "Big output"
+    }
+    fn description(&self) -> &str {
+        "Returns a long output"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object", "properties": {}})
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let text = (0..500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(ToolResult {
+            content: vec![Content::Text { text }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+fn tool_then_text() -> MockProvider {
+    MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "big_output".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("done".into()),
+    ])
+}
+
+async fn run_with_context_config(
+    config: Option<yoagent::context::ContextConfig>,
+) -> (Vec<AgentMessage>, Vec<AgentEvent>) {
+    let mut loop_config = make_config(tool_then_text());
+    loop_config.context_config = config;
+
+    let mut context = AgentContext {
+        system_prompt: String::new(),
+        messages: Vec::new(),
+        tools: vec![Box::new(BigOutputTool)],
+    };
+    let (tx, rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &loop_config,
+        tx,
+        cancel,
+    )
+    .await;
+
+    (context.messages, collect_events(rx))
+}
+
+fn tool_result_lines(messages: &[AgentMessage]) -> usize {
+    messages
+        .iter()
+        .find_map(|m| match m {
+            AgentMessage::Llm(Message::ToolResult { content, .. }) => match content.first() {
+                Some(Content::Text { text }) => Some(text.lines().count()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("expected a tool result in context")
+}
+
+#[tokio::test]
+async fn tool_output_is_capped_on_append_when_enabled() {
+    let (messages, events) = run_with_context_config(Some(yoagent::context::ContextConfig {
+        // Budget far above the output: without on-append capping nothing is
+        // truncated, which is exactly the history compaction later rewrites.
+        max_context_tokens: 1_000_000,
+        system_prompt_tokens: 0,
+        tool_output_max_lines: 25,
+        truncate_tool_output_on_append: true,
+        ..Default::default()
+    }))
+    .await;
+
+    assert_eq!(tool_result_lines(&messages), 25);
+
+    // The event stream still carries the untruncated output — the cap is a
+    // context concern, not a tool-result one.
+    let full = events.iter().any(|e| match e {
+        AgentEvent::ToolExecutionEnd { result, .. } => match result.content.first() {
+            Some(Content::Text { text }) => text.lines().count() == 500,
+            _ => false,
+        },
+        _ => false,
+    });
+    assert!(full, "ToolExecutionEnd should carry the untruncated output");
+}
+
+#[tokio::test]
+async fn tool_output_is_untouched_on_append_by_default() {
+    let (messages, _) = run_with_context_config(Some(yoagent::context::ContextConfig {
+        max_context_tokens: 1_000_000,
+        system_prompt_tokens: 0,
+        tool_output_max_lines: 25,
+        ..Default::default()
+    }))
+    .await;
+
+    assert_eq!(
+        tool_result_lines(&messages),
+        500,
+        "on-append truncation must stay opt-in"
+    );
+}
+
+#[tokio::test]
+async fn tool_output_is_untouched_without_a_context_config() {
+    let (messages, _) = run_with_context_config(None).await;
+    assert_eq!(tool_result_lines(&messages), 500);
 }

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -2476,7 +2476,7 @@ async fn tool_output_is_capped_on_append_when_enabled() {
 }
 
 #[tokio::test]
-async fn tool_output_is_untouched_on_append_by_default() {
+async fn tool_output_is_capped_on_append_by_default() {
     let (messages, _) = run_with_context_config(Some(yoagent::context::ContextConfig {
         max_context_tokens: 1_000_000,
         system_prompt_tokens: 0,
@@ -2487,9 +2487,42 @@ async fn tool_output_is_untouched_on_append_by_default() {
 
     assert_eq!(
         tool_result_lines(&messages),
-        500,
-        "on-append truncation must stay opt-in"
+        25,
+        "on-append capping is the default"
     );
+}
+
+#[tokio::test]
+async fn on_append_capping_can_be_turned_off() {
+    let (messages, _) = run_with_context_config(Some(yoagent::context::ContextConfig {
+        max_context_tokens: 1_000_000,
+        system_prompt_tokens: 0,
+        tool_output_max_lines: 25,
+        truncate_tool_output_on_append: false,
+        ..Default::default()
+    }))
+    .await;
+
+    assert_eq!(tool_result_lines(&messages), 500);
+}
+
+#[tokio::test]
+async fn per_tool_override_exempts_a_tool_from_capping() {
+    // A tool that head+tail would damage opts out by name rather than by
+    // disabling capping for everything.
+    let mut overrides = std::collections::HashMap::new();
+    overrides.insert("big_output".to_string(), usize::MAX);
+
+    let (messages, _) = run_with_context_config(Some(yoagent::context::ContextConfig {
+        max_context_tokens: 1_000_000,
+        system_prompt_tokens: 0,
+        tool_output_max_lines: 25,
+        tool_output_max_lines_overrides: overrides,
+        ..Default::default()
+    }))
+    .await;
+
+    assert_eq!(tool_result_lines(&messages), 500);
 }
 
 #[tokio::test]

--- a/tests/context_cache_test.rs
+++ b/tests/context_cache_test.rs
@@ -1,0 +1,378 @@
+//! Prefix-cache stability of compaction.
+//!
+//! Providers cache request prefixes — automatically on DeepSeek, explicitly via
+//! `cache_control` on Anthropic. A cache hit requires the new request to share a
+//! byte-identical prefix with the previous one, so any in-place rewrite of
+//! history costs every token from the rewrite point onward.
+//!
+//! These tests replay a synthetic tool-heavy session through `compact_messages`
+//! turn by turn, render each turn's message list the way a provider body would
+//! see it (timestamps excluded — no provider serializes them), and measure the
+//! shared prefix between consecutive turns. The resulting ratio is the direct
+//! analogue of DeepSeek's `cache_hit_tokens / input_tokens`.
+
+use yoagent::context::{compact_messages, ContextConfig};
+use yoagent::types::{AgentMessage, Content, Message, StopReason, Usage};
+
+// ---------------------------------------------------------------------------
+// Wire rendering — what the provider actually receives
+// ---------------------------------------------------------------------------
+
+fn render(messages: &[AgentMessage]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        let AgentMessage::Llm(m) = msg else { continue };
+        match m {
+            Message::User { content, .. } => {
+                out.push_str("<user>");
+                render_content(content, &mut out);
+            }
+            Message::Assistant { content, .. } => {
+                out.push_str("<assistant>");
+                render_content(content, &mut out);
+            }
+            Message::ToolResult {
+                tool_call_id,
+                content,
+                is_error,
+                ..
+            } => {
+                out.push_str("<tool_result id=");
+                out.push_str(tool_call_id);
+                out.push_str(if *is_error { " error>" } else { ">" });
+                render_content(content, &mut out);
+            }
+        }
+    }
+    out
+}
+
+fn render_content(content: &[Content], out: &mut String) {
+    for c in content {
+        match c {
+            Content::Text { text } => {
+                out.push_str("<text>");
+                out.push_str(text);
+            }
+            Content::ToolCall {
+                id,
+                name,
+                arguments,
+                ..
+            } => {
+                out.push_str("<tool_use id=");
+                out.push_str(id);
+                out.push(' ');
+                out.push_str(name);
+                out.push('>');
+                out.push_str(&arguments.to_string());
+            }
+            Content::Thinking { thinking, .. } => {
+                out.push_str("<thinking>");
+                out.push_str(thinking);
+            }
+            Content::Image { data, .. } => {
+                out.push_str("<image>");
+                out.push_str(data);
+            }
+            _ => out.push_str("<other>"),
+        }
+    }
+}
+
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    a.as_bytes()
+        .iter()
+        .zip(b.as_bytes())
+        .take_while(|(x, y)| x == y)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic session
+// ---------------------------------------------------------------------------
+
+fn tool_output(turn: usize) -> String {
+    // Deterministic, varied length: some outputs cross tool_output_max_lines,
+    // some don't — the mix a real coding agent produces.
+    let lines = 20 + (turn * 37) % 160;
+    (0..lines)
+        .map(|i| format!("turn {turn} output line {i}: {}", "data ".repeat(6)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn assistant_with_tool_call(turn: usize) -> AgentMessage {
+    AgentMessage::Llm(
+        Message::assistant(
+            vec![
+                Content::Text {
+                    text: format!("Turn {turn}: inspecting the workspace before the next edit."),
+                },
+                Content::tool_call(
+                    format!("tc-{turn}"),
+                    "bash",
+                    serde_json::json!({ "command": format!("rg --files -g '*.rs' | sed -n '{turn}p'") }),
+                ),
+            ],
+            StopReason::ToolUse,
+            "test-model",
+            "test",
+            Usage::default(),
+        )
+        .with_timestamp(1_700_000_000_000 + turn as u64),
+    )
+}
+
+fn tool_result(turn: usize) -> AgentMessage {
+    AgentMessage::Llm(Message::ToolResult {
+        tool_call_id: format!("tc-{turn}"),
+        tool_name: "bash".into(),
+        content: vec![Content::Text {
+            text: tool_output(turn),
+        }],
+        is_error: false,
+        timestamp: 1_700_000_000_000 + turn as u64,
+    })
+}
+
+struct Replay {
+    /// Bytes the provider would have to re-process (no cache hit).
+    uncached_bytes: usize,
+    /// Total request bytes across all turns.
+    total_bytes: usize,
+    /// Turns whose shared prefix with the previous request was shorter than
+    /// the previous request itself — i.e. history was rewritten.
+    invalidations: Vec<Invalidation>,
+    turns: usize,
+}
+
+struct Invalidation {
+    turn: usize,
+    /// Fraction of the previous request that survived as a shared prefix.
+    retained: f64,
+    /// Index of the first message that differs from the previous request.
+    diverged_at: usize,
+    /// Messages in the previous request.
+    prev_messages: usize,
+    /// Messages in this request.
+    messages: usize,
+}
+
+/// Index of the first message whose rendering differs.
+fn first_divergence(prev: &[String], cur: &[String]) -> usize {
+    prev.iter().zip(cur).take_while(|(a, b)| a == b).count()
+}
+
+impl Replay {
+    fn hit_rate(&self) -> f64 {
+        1.0 - (self.uncached_bytes as f64 / self.total_bytes as f64)
+    }
+
+    fn report(&self, label: &str) {
+        println!(
+            "{label}: {} turns, prefix-cache hit rate {:.2}%, {} invalidations",
+            self.turns,
+            self.hit_rate() * 100.0,
+            self.invalidations.len()
+        );
+        for inv in &self.invalidations {
+            println!(
+                "  turn {:>3}: retained {:>5.1}% | diverged at message {}/{} (now {} messages)",
+                inv.turn,
+                inv.retained * 100.0,
+                inv.diverged_at,
+                inv.prev_messages,
+                inv.messages
+            );
+        }
+    }
+}
+
+/// Replay `turns` turns of a tool-heavy session, compacting before each turn
+/// exactly as the agent loop does, and measure prefix reuse between turns.
+fn replay(turns: usize, config: &ContextConfig) -> Replay {
+    let mut history: Vec<AgentMessage> = vec![AgentMessage::Llm(
+        Message::user("Refactor the provider layer.").with_timestamp(1_700_000_000_000),
+    )];
+    let mut previous = String::new();
+    let mut previous_parts: Vec<String> = Vec::new();
+    let mut uncached_bytes = 0usize;
+    let mut total_bytes = 0usize;
+    let mut invalidations = Vec::new();
+
+    for turn in 1..=turns {
+        if turn % 5 == 0 {
+            history.push(AgentMessage::Llm(
+                Message::user(format!("Also check item {turn} while you are there."))
+                    .with_timestamp(1_700_000_000_000 + turn as u64),
+            ));
+        }
+        history.push(assistant_with_tool_call(turn));
+        let mut result = tool_result(turn);
+        if config.truncate_tool_output_on_append {
+            result = yoagent::context::truncate_tool_output(result, config.tool_output_max_lines);
+        }
+        history.push(result);
+
+        // The loop compacts immediately before streaming and writes the result
+        // back into the live history.
+        history = compact_messages(std::mem::take(&mut history), config);
+
+        let parts: Vec<String> = history
+            .iter()
+            .map(|m| render(std::slice::from_ref(m)))
+            .collect();
+        let current = parts.concat();
+        let shared = common_prefix_len(&previous, &current);
+        uncached_bytes += current.len() - shared;
+        total_bytes += current.len();
+
+        if !previous.is_empty() && shared < previous.len() {
+            invalidations.push(Invalidation {
+                turn,
+                retained: shared as f64 / previous.len() as f64,
+                diverged_at: first_divergence(&previous_parts, &parts),
+                prev_messages: previous_parts.len(),
+                messages: parts.len(),
+            });
+        }
+        previous = current;
+        previous_parts = parts;
+    }
+
+    Replay {
+        uncached_bytes,
+        total_bytes,
+        invalidations,
+        turns,
+    }
+}
+
+/// A tool-heavy session on a mid-sized context window: compaction engages
+/// part-way through and then cycles, which is the regime prefix-cache
+/// behaviour actually matters in.
+fn session_config() -> ContextConfig {
+    ContextConfig {
+        max_context_tokens: 102_400, // a 128K window at the default 80% reserve
+        system_prompt_tokens: 4_000,
+        ..Default::default()
+    }
+}
+
+/// The same session with oversized tool output capped as it is appended.
+fn on_append_config() -> ContextConfig {
+    ContextConfig {
+        truncate_tool_output_on_append: true,
+        ..session_config()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+//
+// Thresholds are regression guards, not targets. The measured figures for this
+// replay at 300 turns are:
+//
+//   yoagent 0.14.2                          95.80%   16 rewrites
+//   + idempotent truncation, hysteresis      96.85%   15 rewrites
+//   + truncate_tool_output_on_append         98.51%    2 rewrites
+//
+// The ceiling is set by request size over per-turn growth: a session that adds
+// 1/50th of its context each turn cannot exceed ~98% however stable compaction
+// is, because that new tail was never cached to begin with.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compaction_preserves_the_prefix_cache_across_a_long_session() {
+    let result = replay(300, &session_config());
+    result.report("default");
+
+    assert!(
+        result.hit_rate() > 0.96,
+        "prefix-cache hit rate regressed to {:.2}%",
+        result.hit_rate() * 100.0
+    );
+}
+
+#[test]
+fn truncating_on_append_keeps_the_prefix_cache_nearly_intact() {
+    let result = replay(300, &on_append_config());
+    result.report("truncate-on-append");
+
+    // Capping output on the way in removes the retroactive rewrites entirely,
+    // leaving only the genuine compaction events.
+    assert!(
+        result.hit_rate() > 0.98,
+        "prefix-cache hit rate regressed to {:.2}%",
+        result.hit_rate() * 100.0
+    );
+    assert!(
+        result.invalidations.len() <= 4,
+        "history was rewritten on {} of 300 turns",
+        result.invalidations.len()
+    );
+}
+
+#[test]
+fn compaction_does_not_fire_every_turn_once_over_budget() {
+    // Without headroom, the first turn past the budget puts the session into a
+    // state where every subsequent turn re-compacts and rewrites history.
+    let result = replay(300, &session_config());
+
+    assert!(
+        result.invalidations.len() <= 25,
+        "history was rewritten on {} of 300 turns; compaction is firing far too often",
+        result.invalidations.len()
+    );
+}
+
+#[test]
+fn compaction_is_deterministic() {
+    // Non-deterministic output (wall-clock timestamps, drifting markers) would
+    // make prefix reuse impossible to reason about — and is itself a rewrite.
+    let config = session_config();
+    let a = replay(60, &config);
+    let b = replay(60, &config);
+    assert_eq!(a.uncached_bytes, b.uncached_bytes);
+    assert_eq!(a.total_bytes, b.total_bytes);
+}
+
+#[test]
+fn repeated_compaction_of_settled_history_is_a_no_op() {
+    // Once compaction has run, running it again on the same history with the
+    // same config must not change a single byte — otherwise every turn past the
+    // budget pays a fresh invalidation.
+    //
+    // Two budgets, so both the truncate-only path and the drop path are
+    // covered: 50K is reachable by Level 1 alone, 8K forces Level 2/3.
+    for max_context_tokens in [50_000usize, 8_000] {
+        let config = ContextConfig {
+            max_context_tokens,
+            system_prompt_tokens: 0,
+            ..Default::default()
+        };
+        let mut history: Vec<AgentMessage> = vec![AgentMessage::Llm(
+            Message::user("start").with_timestamp(1_700_000_000_000),
+        )];
+        for turn in 1..=60 {
+            history.push(assistant_with_tool_call(turn));
+            history.push(tool_result(turn));
+        }
+
+        let once = compact_messages(history, &config);
+        let twice = compact_messages(once.clone(), &config);
+        let thrice = compact_messages(twice.clone(), &config);
+
+        assert_eq!(
+            render(&once),
+            render(&twice),
+            "second compaction pass rewrote settled history at {max_context_tokens} tokens"
+        );
+        assert_eq!(
+            render(&twice),
+            render(&thrice),
+            "third compaction pass rewrote settled history at {max_context_tokens} tokens"
+        );
+    }
+}

--- a/tests/context_cache_test.rs
+++ b/tests/context_cache_test.rs
@@ -92,17 +92,52 @@ fn common_prefix_len(a: &str, b: &str) -> usize {
 // Synthetic session
 // ---------------------------------------------------------------------------
 
-fn tool_output(turn: usize) -> String {
-    // Deterministic, varied length: some outputs cross tool_output_max_lines,
-    // some don't — the mix a real coding agent produces.
-    let lines = 20 + (turn * 37) % 160;
+/// The tool mix a real coding agent produces, measured from 808 archived runs
+/// of an agent built on yoagent: bash 41%, edit/write 36%, read 19%, search 4%.
+/// Output shape differs sharply per tool, which is the whole reason the line
+/// budget is per-tool.
+fn tool_for_turn(turn: usize) -> &'static str {
+    match turn % 100 {
+        0..=40 => "bash",       // build logs, grep, git — head+tail suits these
+        41..=76 => "edit_file", // a confirmation line
+        77..=95 => "read_file", // paged by the tool itself
+        _ => "search",
+    }
+}
+
+thread_local! {
+    static READ_CAP: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(yoagent::tools::DEFAULT_READ_MAX_LINES) };
+}
+
+/// Replay with the read tool's page size overridden.
+fn replay_with_read_cap(turns: usize, config: &ContextConfig, read_cap: usize) -> Replay {
+    READ_CAP.with(|c| c.set(read_cap));
+    let r = replay(turns, config);
+    READ_CAP.with(|c| c.set(yoagent::tools::DEFAULT_READ_MAX_LINES));
+    r
+}
+
+/// Deterministic output whose length distribution reflects the tool.
+fn tool_output(turn: usize, tool: &str) -> String {
+    let lines = match tool {
+        // cargo/grep/git: routinely hundreds of lines, occasionally thousands.
+        "bash" => 40 + (turn * 37) % 700,
+        // The read tool pages itself at DEFAULT_READ_MAX_LINES, so what reaches
+        // the context is already bounded — source files run 100..1500 lines.
+        "read_file" => (100 + (turn * 53) % 1400).min(READ_CAP.with(|c| c.get())),
+        "search" => 10 + (turn * 17) % 120,
+        // edit/write return a short confirmation.
+        _ => 1 + (turn * 3) % 4,
+    };
     (0..lines)
-        .map(|i| format!("turn {turn} output line {i}: {}", "data ".repeat(6)))
+        .map(|i| format!("turn {turn} {tool} line {i}: {}", "data ".repeat(6)))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
 fn assistant_with_tool_call(turn: usize) -> AgentMessage {
+    let tool = tool_for_turn(turn);
     AgentMessage::Llm(
         Message::assistant(
             vec![
@@ -111,8 +146,8 @@ fn assistant_with_tool_call(turn: usize) -> AgentMessage {
                 },
                 Content::tool_call(
                     format!("tc-{turn}"),
-                    "bash",
-                    serde_json::json!({ "command": format!("rg --files -g '*.rs' | sed -n '{turn}p'") }),
+                    tool,
+                    serde_json::json!({ "arg": format!("target-{turn}") }),
                 ),
             ],
             StopReason::ToolUse,
@@ -125,11 +160,12 @@ fn assistant_with_tool_call(turn: usize) -> AgentMessage {
 }
 
 fn tool_result(turn: usize) -> AgentMessage {
+    let tool = tool_for_turn(turn);
     AgentMessage::Llm(Message::ToolResult {
         tool_call_id: format!("tc-{turn}"),
-        tool_name: "bash".into(),
+        tool_name: tool.into(),
         content: vec![Content::Text {
-            text: tool_output(turn),
+            text: tool_output(turn, tool),
         }],
         is_error: false,
         timestamp: 1_700_000_000_000 + turn as u64,
@@ -211,7 +247,7 @@ fn replay(turns: usize, config: &ContextConfig) -> Replay {
         history.push(assistant_with_tool_call(turn));
         let mut result = tool_result(turn);
         if config.truncate_tool_output_on_append {
-            result = yoagent::context::truncate_tool_output(result, config.tool_output_max_lines);
+            result = yoagent::context::truncate_tool_output(result, config);
         }
         history.push(result);
 
@@ -260,10 +296,14 @@ fn session_config() -> ContextConfig {
     }
 }
 
-/// The same session with oversized tool output capped as it is appended.
-fn on_append_config() -> ContextConfig {
+/// The 0.14.2 settings, for comparison: cap every tool at 50 lines, apply it
+/// only retroactively during compaction, and compact to whatever just fits.
+fn legacy_config() -> ContextConfig {
     ContextConfig {
-        truncate_tool_output_on_append: true,
+        tool_output_max_lines: 50,
+        tool_output_max_lines_overrides: Default::default(),
+        truncate_tool_output_on_append: false,
+        compact_target_ratio: 1.0,
         ..session_config()
     }
 }
@@ -271,47 +311,93 @@ fn on_append_config() -> ContextConfig {
 // ---------------------------------------------------------------------------
 // Tests
 //
-// Thresholds are regression guards, not targets. The measured figures for this
-// replay at 300 turns are:
-//
-//   yoagent 0.14.2                          95.80%   16 rewrites
-//   + idempotent truncation, hysteresis      96.85%   15 rewrites
-//   + truncate_tool_output_on_append         98.51%    2 rewrites
-//
-// The ceiling is set by request size over per-turn growth: a session that adds
-// 1/50th of its context each turn cannot exceed ~98% however stable compaction
-// is, because that new tail was never cached to begin with.
+// Thresholds are regression guards, not targets. The ceiling is set by request
+// size over per-turn growth: a session that adds 1/50th of its context each
+// turn cannot exceed ~98% however stable compaction is, because that new tail
+// was never cached to begin with.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn compaction_preserves_the_prefix_cache_across_a_long_session() {
     let result = replay(300, &session_config());
-    result.report("default");
+    result.report("defaults");
 
     assert!(
-        result.hit_rate() > 0.96,
+        result.hit_rate() > 0.955,
         "prefix-cache hit rate regressed to {:.2}%",
         result.hit_rate() * 100.0
+    );
+    assert!(
+        result.invalidations.len() <= 12,
+        "history was rewritten on {} of 300 turns",
+        result.invalidations.len()
     );
 }
 
 #[test]
-fn truncating_on_append_keeps_the_prefix_cache_nearly_intact() {
-    let result = replay(300, &on_append_config());
-    result.report("truncate-on-append");
+fn defaults_beat_the_legacy_settings() {
+    let legacy = replay(300, &legacy_config());
+    let current = replay(300, &session_config());
+    legacy.report("legacy settings");
 
-    // Capping output on the way in removes the retroactive rewrites entirely,
-    // leaving only the genuine compaction events.
     assert!(
-        result.hit_rate() > 0.98,
-        "prefix-cache hit rate regressed to {:.2}%",
-        result.hit_rate() * 100.0
+        current.hit_rate() > legacy.hit_rate(),
+        "defaults ({:.2}%) should beat legacy settings ({:.2}%)",
+        current.hit_rate() * 100.0,
+        legacy.hit_rate() * 100.0
     );
     assert!(
-        result.invalidations.len() <= 4,
-        "history was rewritten on {} of 300 turns",
-        result.invalidations.len()
+        current.invalidations.len() < legacy.invalidations.len(),
+        "defaults should rewrite history less often ({} vs {})",
+        current.invalidations.len(),
+        legacy.invalidations.len()
     );
+}
+
+#[test]
+fn read_output_is_exempt_from_head_tail_truncation() {
+    // Cutting the middle out of a source file removes exactly what was asked
+    // for; the read tool bounds itself by paging instead.
+    let config = session_config();
+    let big = (0..900)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let msg = AgentMessage::Llm(Message::ToolResult {
+        tool_call_id: "tc-1".into(),
+        tool_name: "read_file".into(),
+        content: vec![Content::Text { text: big.clone() }],
+        is_error: false,
+        timestamp: 1,
+    });
+    let out = yoagent::context::truncate_tool_output(msg, &config);
+    let AgentMessage::Llm(Message::ToolResult { content, .. }) = &out else {
+        panic!("expected a tool result")
+    };
+    let Content::Text { text } = &content[0] else {
+        panic!("expected text")
+    };
+    assert_eq!(
+        text, &big,
+        "read_file output must not be head+tail truncated"
+    );
+
+    // The same output from a command tool is capped.
+    let msg = AgentMessage::Llm(Message::ToolResult {
+        tool_call_id: "tc-2".into(),
+        tool_name: "bash".into(),
+        content: vec![Content::Text { text: big }],
+        is_error: false,
+        timestamp: 1,
+    });
+    let out = yoagent::context::truncate_tool_output(msg, &config);
+    let AgentMessage::Llm(Message::ToolResult { content, .. }) = &out else {
+        panic!("expected a tool result")
+    };
+    let Content::Text { text } = &content[0] else {
+        panic!("expected text")
+    };
+    assert_eq!(text.lines().count(), config.tool_output_max_lines);
 }
 
 #[test]
@@ -375,4 +461,39 @@ fn repeated_compaction_of_settled_history_is_a_no_op() {
             "third compaction pass rewrote settled history at {max_context_tokens} tokens"
         );
     }
+}
+
+#[test]
+fn read_page_size_is_the_dominant_lever_on_cache() {
+    // Why DEFAULT_READ_MAX_LINES is 500. File reads are ~19% of tool calls but
+    // the largest token sink, and they are exempt from head+tail truncation
+    // (cutting the middle out of a source file removes what was asked for), so
+    // the tool's page size — not the context cap — is what bounds them.
+    //
+    // Hit rate is flat from 300 to 500 and degrades sharply above it, making
+    // 500 the largest page that costs nothing extra.
+    let config = session_config();
+    let p300 = replay_with_read_cap(300, &config, 300).hit_rate();
+    let p500 = replay_with_read_cap(300, &config, 500).hit_rate();
+    let p1000 = replay_with_read_cap(300, &config, 1000).hit_rate();
+    let p2000 = replay_with_read_cap(300, &config, 2000).hit_rate();
+
+    assert!(
+        (p300 - p500).abs() < 0.01,
+        "300 and 500 should sit on the same plateau ({:.2}% vs {:.2}%)",
+        p300 * 100.0,
+        p500 * 100.0
+    );
+    assert!(
+        p500 > p1000 && p1000 > p2000,
+        "larger read pages must cost cache: 500={:.2}% 1000={:.2}% 2000={:.2}%",
+        p500 * 100.0,
+        p1000 * 100.0,
+        p2000 * 100.0
+    );
+    assert_eq!(
+        yoagent::tools::DEFAULT_READ_MAX_LINES,
+        500,
+        "the default should stay on the measured plateau"
+    );
 }

--- a/tests/tools_test.rs
+++ b/tests/tools_test.rs
@@ -448,3 +448,91 @@ async fn test_read_text_file_unchanged() {
 
     let _ = std::fs::remove_file(tmp);
 }
+
+#[tokio::test]
+async fn test_read_file_pages_long_files_by_default() {
+    let tmp = std::env::temp_dir().join("yoagent-test-paging.txt");
+    let path = tmp.to_str().unwrap();
+
+    let total = yoagent::tools::DEFAULT_READ_MAX_LINES * 2;
+    let content = (1..=total)
+        .map(|i| format!("line {}", i))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&tmp, &content).unwrap();
+
+    let tool = ReadFileTool::new();
+    let result = tool
+        .execute(serde_json::json!({"path": path}), ctx("read_file"))
+        .await
+        .unwrap();
+    let Content::Text { text } = &result.content[0] else {
+        panic!("expected text")
+    };
+
+    // One page, and the header states the true total so the agent can page on.
+    assert!(text.contains(&format!("of {}", total)));
+    assert!(text.contains("offset/limit"));
+    assert!(text.contains("line 1\n") || text.contains("| line 1"));
+    assert!(!text.contains(&format!("| line {}", total)));
+    assert_eq!(
+        text.lines().count(),
+        yoagent::tools::DEFAULT_READ_MAX_LINES + 1, // + header
+    );
+
+    // Paging forward reaches the end.
+    let result = tool
+        .execute(
+            serde_json::json!({"path": path, "offset": yoagent::tools::DEFAULT_READ_MAX_LINES + 1}),
+            ctx("read_file"),
+        )
+        .await
+        .unwrap();
+    let Content::Text { text } = &result.content[0] else {
+        panic!("expected text")
+    };
+    assert!(text.contains(&format!("| line {}", total)));
+
+    // An explicit limit still wins, and short files are unaffected.
+    let result = tool
+        .execute(
+            serde_json::json!({"path": path, "limit": 3}),
+            ctx("read_file"),
+        )
+        .await
+        .unwrap();
+    let Content::Text { text } = &result.content[0] else {
+        panic!("expected text")
+    };
+    assert_eq!(text.lines().count(), 4); // header + 3
+
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
+async fn test_read_file_unbounded_when_max_lines_disabled() {
+    let tmp = std::env::temp_dir().join("yoagent-test-unbounded.txt");
+    let path = tmp.to_str().unwrap();
+    let total = yoagent::tools::DEFAULT_READ_MAX_LINES + 50;
+    let content = (1..=total)
+        .map(|i| format!("line {}", i))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&tmp, &content).unwrap();
+
+    let tool = ReadFileTool {
+        max_lines: usize::MAX,
+        ..Default::default()
+    };
+    let result = tool
+        .execute(serde_json::json!({"path": path}), ctx("read_file"))
+        .await
+        .unwrap();
+    let Content::Text { text } = &result.content[0] else {
+        panic!("expected text")
+    };
+    assert_eq!(text.lines().count(), total + 1);
+    assert!(text.contains(&format!("[{} lines]", total)));
+
+    let _ = std::fs::remove_file(tmp);
+}


### PR DESCRIPTION
Closes #99.

A prefix-cache hit requires a byte-identical prefix, so every rewrite of already-sent history costs full price for every token from the rewrite point onward — automatically on DeepSeek, via `cache_control` on Anthropic. `compact_messages` decided purely on a token budget and never counted that cost.

## Measurement first

`tests/context_cache_test.rs` replays a session through `compact_messages` turn by turn, renders each turn the way a provider body would see it, and measures the shared prefix between consecutive requests — the direct analogue of DeepSeek's `cache_hit_tokens / input_tokens`.

The workload is not invented. The tool mix and file-size distribution come from 808 archived runs of the production agent whose 95.27% hit rate opened the issue, plus its repo:

```
tool mix:   bash 41%   edit/write 36%   read 19%   search 4%
.rs files:  median 1364 lines, 96.2% exceed 200 lines
```

Over 300 turns on a 128K window:

| | prefix-cache hit rate | history rewrites |
|---|---|---|
| 0.14.2 | 93.58% | 23 |
| 0.15.0, 0.14.2-equivalent settings | 94.38% | 22 |
| **0.15.0 defaults** | **96.04%** | **8** |

## 1. Gratuitous churn removed

- **`truncate_text_head_tail` was not idempotent.** The `[... N lines truncated ...]` marker pushed the result past `tool_output_max_lines`, so the next compaction pass re-truncated it and restated the count — `950 lines truncated` became `3 lines truncated`. A second full-prefix invalidation, and a marker that misreported the loss. The marker is now charged against the line budget, so the result fits exactly and re-truncating returns it byte for byte.
- **No hysteresis.** Compaction reduced to whatever just barely fit, so the next turn crossed the budget again and rewrote history *every turn*. New `compact_target_ratio` (default `0.7`) makes the lossy levels reduce to a fraction of the budget while still triggering at the full budget. Level 1 still only has to reach the budget — it is idempotent and cheap to repeat, so there is no reason to escalate early.
- **Drifting marker.** Level 3's marker embedded a message count at a fixed position near the front, changing the cached prefix on every pass. The text is now constant; the count goes to the debug log.
- **Wall-clock timestamps.** Level 2 summaries and the Level 3 marker were stamped with `now_ms()`, so the same history compacted to different bytes each pass. They now inherit the timestamp of the content they replace.

One note from the issue resolves as no-impact: `timestamp` never reaches the wire — no provider serializes it.

## 2. Pre-existing bug: compaction could orphan tool calls

Found while adding pairing tests. Level 2's boundary (`len - keep_recent`) can land mid-turn, summarizing away an assistant message while its tool results stay in the kept section; Level 3 and `keep_within_budget` could cut the mirror image. Every provider rejects both with a 400. Reproduced on 0.14.2 with `keep_recent: 7, keep_first: 4` (orphaned `tc-26`). Boundaries now snap to turn starts, and a new test sweeps budgets and boundary parities.

## 3. Bound tool output at the right layer, per tool

Two findings from the workload data.

**An unqualified `read_file` returned the whole file** — no line cap at all (`(None, None) => (0, total)`). On a median 1364-line source file that is ~15K tokens, on a fifth of all tool calls. That is what drives a session to its budget and triggers the compaction that rewrites history. The cap was downstream of the real problem.

**One global cap cannot serve every tool.** Head+tail suits command output — first error at the top, summary at the bottom, repetition in the middle. It is the *wrong* cut for a file read, where the middle is the part that was asked for.

So each tool is bounded where it can be bounded well:

- `read_file` pages itself at `DEFAULT_READ_MAX_LINES` (500), with a header stating the true total and pointing at `offset`/`limit`. That bound is lossless and directed — the agent picks the window. 500 is measured: hit rate is flat between a 300- and 500-line page (96.2% / 96.0%) and falls to 94.2% at 1000 and 92.9% at 2000, so 500 is the largest page that costs nothing extra. Pinned by a regression test.
- `tool_output_max_lines_overrides` gives per-tool budgets; the default exempts `read_file` from head+tail truncation.
- `tool_output_max_lines` raised 50 → 200, since it now applies on append rather than only under pressure, and 50 lines cuts the error list out of most build output.
- `truncate_tool_output_on_append` defaults to **true**. The categories it affects tolerate head+tail well, and the one that does not is exempt.

Level 3 also now drops the smallest span that reaches the target instead of always collapsing to `keep_first` + `keep_recent`.

## Breaking

- `ContextConfig` gained three public fields; `ReadFileTool` gained `max_lines`. Exhaustive struct literals need `..Default::default()`; `default()`, `new()`, `from_context_window()`, and functional update syntax are unaffected.
- Behaviour: tool output is capped as it enters the context, and an unqualified read returns 500 lines. Restore the old behaviour with `truncate_tool_output_on_append: false` and `ReadFileTool { max_lines: usize::MAX, ..Default::default() }`.

Version bumped to 0.15.0. Under Cargo's 0.x rules `yoagent = "0.14"` will not pick this up automatically.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features` under `-Dwarnings`, and all 23 test suites pass with no failures.

Credit to @lloydzhou — [bash-agent](https://github.com/lloydzhou/bash-agent) documents the economics this is chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)