### PR TITLE
docs: guidance for choosing compact_headroom_turns

### DIFF
--- a/docs/concepts/prompt-caching.md
+++ b/docs/concepts/prompt-caching.md
@@ -154,6 +154,28 @@ Mean turns between compactions:
 
 Set `compact_headroom_turns: None` to restore pure ratio behaviour.
 
+#### Choosing a value
+
+Replaying a 2400-turn session at a 1:10 cache-to-input price ratio:
+
+| setting | mean context | cost | compactions |
+|---|---|---|---|
+| policy off (fixed ratio) | 67,402 | $3.33 | 110 |
+| 20 | 61,740 | $3.02 | 86 |
+| **30 (default)** | **59,033** | **$2.83** | **70** |
+| 40 | 54,069 | $2.58 | 63 |
+| 60 and above | 55,283 | $2.61 | 62 |
+
+**The trade is proportional, so pick on memory rather than cost.** Cost per unit of retained context barely moves across the whole range — 4.94 down to 4.73, about 4%. There is no efficient point in this table for the data to single out: lowering the setting sells retained history for money at a nearly fixed exchange rate. Going from 30 to 40 costs 8.7% less and keeps 8.4% less. Choose it on how much history your agent needs to do its job; the cost follows mechanically.
+
+The 4% that is *not* proportional is the genuinely free part, and it comes from compacting less often rather than from retaining less.
+
+**Above roughly 60 the setting stops doing anything.** The derived ratio hits [`MIN_HEADROOM_RATIO`] (0.15) and clamps, so 60, 80, 100 and 140 produce byte-identical runs. To compact harder than that, lower `compact_target_ratio` — it is the ceiling the headroom policy is capped by, not an independent knob.
+
+**Cheaper cache argues for a smaller context, not a larger one.** The same step from a fixed ratio to headroom 60 saves 19.4% at a 1:4 cache-to-input ratio and 26.0% at 1:50. That reads backwards until you notice that once cached tokens are nearly free per token, they dominate the *count* — and you are re-sending them on every request. Vendor ratios in practice run from about 1:10 to 1:50, so the payoff for a smaller working context is larger than a 1:4 assumption would suggest.
+
+[`MIN_HEADROOM_RATIO`]: https://docs.rs/yoagent/latest/yoagent/context/constant.MIN_HEADROOM_RATIO.html
+
 ### Measured effect
 
 `tests/context_cache_test.rs` replays a session through compaction turn by turn, renders each turn as a provider body would see it, and measures the shared prefix between consecutive requests — the direct analogue of DeepSeek's `prompt_cache_hit_tokens / prompt_tokens`. The tool mix (bash 41%, edit/write 36%, read 19%, search 4%) and file-size distribution come from 808 archived runs of a production agent built on yoagent. Old and new are measured through the identical code path, on a 128K window.


### PR DESCRIPTION
Re-examines the `compact_headroom_turns` default after @lloydzhou posted production measurements on #101. **Docs only — no behaviour change, and the default stays at 30.**

## Why re-examine

Two things from his data:

- For a long-running agent, **average context length** — not compaction frequency — is what drives cost, because history is re-sent on every request.
- Real cache-to-input price ratios are **1:10 to 1:50**. I tuned against 1:4, which was wrong for current models.

I validated his arithmetic (it reproduces to the cent from his component token counts) and reproduced his central claim independently in our replay: cost per unit of mean context is nearly constant across policies differing 23% in retention.

## What the sweep says

2400 turns, 1:10 pricing:

| setting | mean context | cost | compactions |
|---|---|---|---|
| policy off | 67,402 | $3.33 | 110 |
| 20 | 61,740 | $3.02 | 86 |
| **30 (default)** | **59,033** | **$2.83** | **70** |
| 40 | 54,069 | $2.58 | 63 |
| 60+ | 55,283 | $2.61 | 62 |

**1. The trade is proportional — so the data cannot pick the default.** Cost per unit of retained context moves only ~4% across the entire range. 30 → 40 buys 8.7% lower cost for 8.4% less history. That is a slide along one curve, not an optimisation, so the choice is a judgement about how much history an agent needs. The default belongs at the conservative end: users can turn cost down, but cannot recover history they never kept. Keeping 30.

**2. Above ~60 the setting is inert.** The derived ratio clamps to `MIN_HEADROOM_RATIO` (0.15), so 60, 80, 100 and 140 produce byte-identical runs. Someone setting 100 today gets the floor with no indication. Now documented, with a pointer to `compact_target_ratio` as the way to compact harder.

**3. The wrong price ratio did not misplace the default.** Ordering is identical at 1:4, 1:10 and 1:50 — only the magnitude grows. Worth stating, because it is counterintuitive: cheaper cache argues for a *smaller* context, since nearly-free tokens still dominate the count you re-send every request.

## Verification

`cargo test --test context_cache_test --release` green; no source changes. Docs deploy from `main`, so this needs no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)