### PR TITLE
feat: GASP recorder v2 — fingerprints, usage, extensibility (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.16.0
+
+GASP recorder v2 ([#104](https://github.com/yologdev/yoagent/issues/104)): the
+recorded log becomes sufficient for offline cost analysis, compaction
+inference, and call matching — the substrate for measuring whether compaction
+actually hurts an agent, rather than only what it costs.
+
+### Added
+
+- **`tool.called` carries a stable argument fingerprint**
+  (`metadata.args_fingerprint`). `input_summary` is a 200-char human summary,
+  so calls could not be matched across a log. The fingerprint is normalized
+  per tool — path for the file tools, command for `bash`, full args otherwise
+  — because `read_file` pages since 0.15 and a re-read of a lost file arrives
+  with different offset bytes; hashing raw args would undercount re-fetches
+  for exactly the most diagnostic tool. FNV-1a, stable across platforms.
+- **`model.finished` carries token usage** (`metadata.usage`: input, output,
+  cache_read, cache_write). This makes real cost computable from the log, and
+  makes compactions *inferable* — a sharp input-token drop between
+  consecutive model calls in one run is the compaction signature — which is
+  why no compaction event kind (and no `AgentEvent` break) is needed.
+- **`GaspRecorder::with_store` is public** — the extension path for
+  applications recording the goal/task/verdict tier into the same ledger:
+  open the `GitEventStore` yourself, record goals/tasks on your own
+  `YoAgentState`, hand the recorder the same handle. One store, one writer.
+  The writer model (one store per agent, `worker_id` per writer, commit at
+  run close, push-per-run advice for ephemeral runners) is now documented on
+  the method.
+- **`gasp` module re-exports the extension-path types** (`Task`,
+  `TaskStatus`, `StatePatch`, `EvalResult`, `Goal as GaspGoal`, …) so
+  applications need no direct `yoagent-state` dependency kept in version
+  lockstep.
+- Compaction levels 1 and 2 now emit `tracing::debug!` (tokens/messages
+  before → after); previously only level 3 and budget calibration reported.
+
+### Changed
+
+- **Breaking:** `yoagent-state` 0.4 → 0.5. Its types are re-exported from
+  `yoagent::gasp`, so this changes public type identity for code that also
+  depends on `yoagent-state` directly. Sidecar processes with their own
+  `yoagent-state` (separate binaries) are unaffected; 0.5 events are
+  wire-compatible both ways with 0.4 logs.
+
 ## 0.15.0
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"
@@ -45,7 +45,7 @@ base64 = "0.22"
 openapiv3 = { version = "2", optional = true }
 serde_yaml_ng = { version = "0.10", optional = true }
 # 0.4.2 floor: 0.4.1 declared MSRV 1.85 but required 1.88 (let-chain)
-yoagent-state = { version = "0.4.2", optional = true }
+yoagent-state = { version = "0.5", optional = true }
 
 [features]
 openapi = ["dep:openapiv3", "dep:serde_yaml_ng", "reqwest/query"]

--- a/docs/concepts/prompt-caching.md
+++ b/docs/concepts/prompt-caching.md
@@ -154,6 +154,28 @@ Mean turns between compactions:
 
 Set `compact_headroom_turns: None` to restore pure ratio behaviour.
 
+#### Choosing a value
+
+Replaying a 2400-turn session at a 1:10 cache-to-input price ratio:
+
+| setting | mean context | cost | compactions |
+|---|---|---|---|
+| policy off (fixed ratio) | 67,402 | $3.33 | 110 |
+| 20 | 61,740 | $3.02 | 86 |
+| **30 (default)** | **59,033** | **$2.83** | **70** |
+| 40 | 54,069 | $2.58 | 63 |
+| 60 and above | 55,283 | $2.61 | 62 |
+
+**The trade is proportional, so pick on memory rather than cost.** Cost per unit of retained context barely moves across the whole range — 4.94 down to 4.73, about 4%. There is no efficient point in this table for the data to single out: lowering the setting sells retained history for money at a nearly fixed exchange rate. Going from 30 to 40 costs 8.7% less and keeps 8.4% less. Choose it on how much history your agent needs to do its job; the cost follows mechanically.
+
+The 4% that is *not* proportional is the genuinely free part, and it comes from compacting less often rather than from retaining less.
+
+**Above roughly 60 the setting stops doing anything.** The derived ratio hits [`MIN_HEADROOM_RATIO`] (0.15) and clamps, so 60, 80, 100 and 140 produce byte-identical runs. To compact harder than that, lower `compact_target_ratio` — it is the ceiling the headroom policy is capped by, not an independent knob.
+
+**Cheaper cache argues for a smaller context, not a larger one.** The same step from a fixed ratio to headroom 60 saves 19.4% at a 1:4 cache-to-input ratio and 26.0% at 1:50. That reads backwards until you notice that once cached tokens are nearly free per token, they dominate the *count* — and you are re-sending them on every request. Vendor ratios in practice run from about 1:10 to 1:50, so the payoff for a smaller working context is larger than a 1:4 assumption would suggest.
+
+[`MIN_HEADROOM_RATIO`]: https://docs.rs/yoagent/latest/yoagent/context/constant.MIN_HEADROOM_RATIO.html
+
 ### Measured effect
 
 `tests/context_cache_test.rs` replays a session through compaction turn by turn, renders each turn as a provider body would see it, and measures the shared prefix between consecutive requests — the direct analogue of DeepSeek's `prompt_cache_hit_tokens / prompt_tokens`. The tool mix (bash 41%, edit/write 36%, read 19%, search 4%) and file-size distribution come from 808 archived runs of a production agent built on yoagent. Old and new are measured through the identical code path, on a 128K window.

--- a/src/context.rs
+++ b/src/context.rs
@@ -390,17 +390,35 @@ pub fn compact_messages(messages: Vec<AgentMessage>, config: &ContextConfig) -> 
     }
 
     let target = config.compaction_target(budget);
+    let before = total_tokens(&messages);
 
     // Level 1: Truncate tool outputs. Checked against the full budget, not the
     // target: this level is idempotent and cheap to repeat, so there is nothing
     // to gain by escalating to the lossy levels before we have to.
     let compacted = level1_truncate_tool_outputs(&messages, config);
-    if total_tokens(&compacted) <= budget {
+    let after_l1 = total_tokens(&compacted);
+    if after_l1 < before {
+        tracing::debug!(
+            "compaction level 1: tool outputs truncated, {} -> {} tokens",
+            before,
+            after_l1
+        );
+    }
+    if after_l1 <= budget {
         return compacted;
     }
 
     // Level 2: Summarize old turns (keep recent N full, summarize the rest)
+    let before_l2 = compacted.len();
     let compacted = level2_summarize_old_turns(&compacted, config.keep_recent);
+    if compacted.len() != before_l2 {
+        tracing::debug!(
+            "compaction level 2: old turns summarized, {} -> {} messages ({} tokens)",
+            before_l2,
+            compacted.len(),
+            total_tokens(&compacted)
+        );
+    }
     if total_tokens(&compacted) <= target {
         return compacted;
     }

--- a/src/gasp.rs
+++ b/src/gasp.rs
@@ -53,6 +53,14 @@ use yoagent_state::{
     YoAgentToolCalled, YoAgentToolFinished,
 };
 pub use yoagent_state::{GoalId, RunId, StateError};
+// The extension-path types (see [`GaspRecorder::with_store`]): everything the
+// `YoAgentState::record_*` methods take, so applications recording the
+// goal/task/verdict tier need no direct `yoagent-state` dependency (a
+// version-skewed duplicate produces baffling type errors).
+pub use yoagent_state::{
+    Decision, DecisionStatus, EvalResult, EvalStatus, EventStore, Goal as GaspGoal, GoalStatus,
+    Hypothesis, Observation, StatePatch, Task, TaskId, TaskStatus,
+};
 
 /// Which GASP goal recorded runs belong to (stamped into each run-boundary
 /// commit's `Goal:` trailer).
@@ -110,7 +118,28 @@ impl GaspRecorder {
         Self::with_store(store, agent_id, goal).await
     }
 
-    async fn with_store(
+    /// Open a recorder on a store the caller owns.
+    ///
+    /// This is the extension path for applications that record more than the
+    /// run/model/tool tier — goals, tasks, verdicts, evals — into the *same*
+    /// ledger: open the [`GitEventStore`] yourself, build a
+    /// [`YoAgentState`](yoagent_state::YoAgentState) on a clone of it for your
+    /// own `record_*` calls, and hand the recorder this handle. One store, one
+    /// writer process, no cross-process coordination.
+    ///
+    /// # Writer model
+    ///
+    /// - **One store per agent**; concurrent writer *processes* on one clone
+    ///   are not supported (the open-run check below assumes it).
+    /// - `worker_id` (in [`GitEventStore::open`]) distinguishes writers in the
+    ///   log; use a distinct id per host/CI lane.
+    /// - The recorder commits at **run close** (stream end). Events appended
+    ///   between commits are durable in the working tree but unpushed —
+    ///   callers on ephemeral runners should push after each run, or crashed
+    ///   sessions vanish from the corpus.
+    /// - A run left open by a crashed process is closed as `"interrupted"` on
+    ///   the next open.
+    pub async fn with_store(
         store: GitEventStore,
         agent_id: &str,
         goal: GoalRef,
@@ -319,6 +348,7 @@ async fn record_event(
                     content,
                     model,
                     stop_reason,
+                    usage,
                     ..
                 }),
         } if tracking.started => {
@@ -340,10 +370,22 @@ async fn record_event(
                     _ => None,
                 })
                 .unwrap_or("(no text)");
+            // Token usage makes the log sufficient for offline cost analysis,
+            // and makes compactions inferable: a sharp drop in input tokens
+            // between consecutive model calls in one run is the compaction
+            // signature (no separate event kind needed).
             sink.on_model_finished(YoAgentModelFinished {
                 run_id: tracking.run_id.clone(),
                 model: model.clone(),
                 output_summary: summarize(text),
+                metadata: serde_json::json!({
+                    "usage": {
+                        "input": usage.input,
+                        "output": usage.output,
+                        "cache_read": usage.cache_read,
+                        "cache_write": usage.cache_write,
+                    }
+                }),
             })
             .await?;
             tracking.outcome = outcome_for(stop_reason).to_string();
@@ -355,6 +397,9 @@ async fn record_event(
                 run_id: tracking.run_id.clone(),
                 tool: tool_name.clone(),
                 input_summary: summarize(&args.to_string()),
+                metadata: serde_json::json!({
+                    "args_fingerprint": args_fingerprint(tool_name, args),
+                }),
             })
             .await?;
         }
@@ -439,6 +484,48 @@ fn commit_scaffolding(store: &GitEventStore) -> Result<(), StateError> {
 
 /// One-line, bounded summary for semantic events — full content belongs in
 /// the transcripts tier, not the event log.
+/// Stable identity for a tool call, so calls can be *matched* across a log —
+/// `input_summary` is a truncated human summary and cannot be.
+///
+/// Normalized per tool rather than hashing the raw argument bytes: the file
+/// tools page and re-slice (`offset`/`limit` on `read_file` since 0.15), so a
+/// re-read of the same file arrives with different argument bytes. Hashing the
+/// full JSON would then undercount re-fetches for exactly the tools where they
+/// are most diagnostic. Identity per tool:
+///
+/// - `read_file` / `edit_file` / `write_file` / `list_files`: the `path` /
+///   `directory` argument
+/// - `bash`: the `command`
+/// - anything else: the full arguments, serialized
+fn args_fingerprint(tool_name: &str, args: &serde_json::Value) -> String {
+    let identity = match tool_name {
+        "read_file" | "edit_file" | "write_file" => args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        "list_files" => args
+            .get("directory")
+            .or_else(|| args.get("path"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        "bash" => args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        _ => None,
+    }
+    .unwrap_or_else(|| args.to_string());
+
+    // FNV-1a: stable across runs and platforms (DefaultHasher is neither
+    // guaranteed stable across Rust releases nor documented as such).
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in identity.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{tool_name}:{hash:016x}")
+}
+
 fn summarize(text: &str) -> String {
     let one_line = text.split_whitespace().collect::<Vec<_>>().join(" ");
     if one_line.chars().count() <= 200 {
@@ -461,7 +548,55 @@ fn outcome_for(stop_reason: &StopReason) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::summarize;
+    use super::{args_fingerprint, summarize};
+
+    #[test]
+    fn fingerprint_is_stable_and_tool_scoped() {
+        let args = serde_json::json!({"path": "src/main.rs"});
+        let a = args_fingerprint("read_file", &args);
+        let b = args_fingerprint("read_file", &args);
+        assert_eq!(a, b, "same call must fingerprint identically");
+        assert!(a.starts_with("read_file:"));
+        // Same args through a different tool is a different call.
+        assert_ne!(a, args_fingerprint("edit_file", &args));
+    }
+
+    #[test]
+    fn fingerprint_ignores_read_paging() {
+        // read_file pages since 0.15: a re-read of a lost file arrives with
+        // different offset/limit bytes. Identity is the path, or re-fetches
+        // of exactly the most diagnostic tool go uncounted.
+        let full = serde_json::json!({"path": "src/big.rs"});
+        let page = serde_json::json!({"path": "src/big.rs", "offset": 501, "limit": 500});
+        assert_eq!(
+            args_fingerprint("read_file", &full),
+            args_fingerprint("read_file", &page)
+        );
+        // Different files stay distinct.
+        let other = serde_json::json!({"path": "src/other.rs"});
+        assert_ne!(
+            args_fingerprint("read_file", &full),
+            args_fingerprint("read_file", &other)
+        );
+    }
+
+    #[test]
+    fn fingerprint_bash_keys_on_command_and_default_on_full_args() {
+        let a = serde_json::json!({"command": "cargo test"});
+        let b = serde_json::json!({"command": "cargo test", "timeout": 60});
+        // bash identity is the command; ancillary knobs don't split it.
+        assert_eq!(args_fingerprint("bash", &a), args_fingerprint("bash", &b));
+        // Unknown tools fall back to full-args identity.
+        let x = serde_json::json!({"q": "foo"});
+        let y = serde_json::json!({"q": "bar"});
+        assert_ne!(
+            args_fingerprint("web_search", &x),
+            args_fingerprint("web_search", &y)
+        );
+        // Malformed / non-object args must not panic.
+        let weird = serde_json::json!("just a string");
+        assert!(args_fingerprint("read_file", &weird).starts_with("read_file:"));
+    }
 
     #[test]
     fn summarize_collapses_and_truncates_on_char_boundaries() {

--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -622,3 +622,54 @@ async fn tee_delivers_the_complete_event_stream() {
 
     assert_eq!(direct, teed, "tee must deliver every event, in order");
 }
+
+#[tokio::test]
+async fn tool_fingerprint_and_usage_reach_the_log() {
+    ensure_git_identity();
+    let dir = tempfile::tempdir().unwrap();
+    let recorder = GaspRecorder::init(
+        dir.path(),
+        "test-agent",
+        "w1",
+        GoalRef::New {
+            title: "measurement goal".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut agent = Agent::from_provider(tool_then_text_provider(), ModelConfig::mock())
+        .with_tools(vec![Box::new(NoopTool)]);
+    let (tx, handle) = recorder.recording_sender("measured run", None);
+    agent.prompt_with_sender("measured run", tx).await;
+    handle.await.unwrap().unwrap().expect("run recorded");
+
+    let raw = std::fs::read_to_string(dir.path().join("state/events.jsonl")).unwrap();
+    let events: Vec<serde_json::Value> = raw
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+    // tool.called must carry a stable fingerprint so calls can be matched
+    // across the log — input_summary is truncated and cannot be.
+    let tool_called = events
+        .iter()
+        .find(|e| e["kind"] == "tool.called")
+        .expect("tool.called recorded");
+    let fp = tool_called["payload"]["metadata"]["args_fingerprint"]
+        .as_str()
+        .expect("args_fingerprint present");
+    assert!(fp.starts_with("noop:"), "got {fp}");
+
+    // model.finished must carry usage — this is what makes the log
+    // sufficient for cost analysis and compaction inference.
+    let model_finished = events
+        .iter()
+        .find(|e| e["kind"] == "model.finished")
+        .expect("model.finished recorded");
+    let usage = &model_finished["payload"]["metadata"]["usage"];
+    assert!(usage["input"].is_number(), "usage.input missing: {usage}");
+    assert!(usage["output"].is_number());
+    assert!(usage["cache_read"].is_number());
+    assert!(usage["cache_write"].is_number());
+}


### PR DESCRIPTION
Implements #104. **Draft until [yologdev/yoagent-state#3](https://github.com/yologdev/yoagent-state/pull/3) merges and 0.5.0 publishes** — this PR depends on it, so CI is red by construction until then.

## What the log can now answer

| question | before | after |
|---|---|---|
| "is this the same call as earlier?" | no — `input_summary` truncates at 200 chars | `metadata.args_fingerprint`, per-tool normalized |
| "what did this session cost?" | no token data at all | `metadata.usage` on every `model.finished` |
| "when did compaction fire?" | invisible | inferable: sharp input-token drop between consecutive model calls in one run |

That third row is why **no `CompactionEnd` event exists in this PR** — inference from usage makes the `AgentEvent` break unnecessary, per the revised #104.

## Fingerprint normalization (the flaw fix)

Per-tool identity, not `hash(raw args)`: 0.15 made `read_file` paged, so a re-read of a lost file arrives as `{"path": X, "offset": 501}` — different bytes, same file. Identity is the path for file tools, the command for `bash`, full args otherwise. FNV-1a for cross-run/platform stability (`DefaultHasher` guarantees neither). Tests cover paging-invariance, tool-scoping, and malformed args.

## Extensibility

`GaspRecorder::with_store` is now public — an application recording goals/tasks/verdicts (what yoyo's sidecar does) opens the `GitEventStore` itself, records its tier on its own `YoAgentState`, and hands the recorder the same handle. **One store, one writer** — this is the clean resolution to the two-writer question in yologdev/yoyo-evolve#683. The writer model is documented on the method, including push-per-run advice for ephemeral runners (or crashed sessions vanish from the measurement corpus — the selection-bias flaw).

The `gasp` module re-exports the extension-path types so adopters don't carry a version-locked `yoagent-state` dependency.

## Also

- Compaction levels 1/2 now emit `tracing::debug!` — they were completely silent; only level 3 reported.
- 0.16.0, not 0.15.1: `yoagent-state` types are re-exported from `yoagent::gasp`, so the 0.4→0.5 bump changes public type identity. Sidecar processes (separate binaries, like yoyo's `gasp-emit`) are unaffected; the wire format is compatible both ways.

## Verification (with a local path override standing in for 0.5.0)

- 487 tests green across all suites, including new fingerprint unit tests and an end-to-end check that the fingerprint and usage actually land in `events.jsonl`
- The **pinned** GASP conformance checker (08a60a2) passes 7/7 against a fresh clone of an emitted repo — the new metadata does not break conformance
- fmt + clippy clean under `-Dwarnings`, all features

## Merge order

1. yologdev/yoagent-state#3 → release 0.5.0 (its publish workflow fires on release)
2. Re-run CI here → green → un-draft → merge → release 0.16.0
3. yologdev/yoyo-evolve#677 should then target `"0.16"` instead of `"0.15"` (same two-line fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)