### PR TITLE
release: 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.16.1
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Patch release per convention — exactly two files: `Cargo.toml` and `CHANGELOG.md` (`## Unreleased` renamed in place).

Carries #98 (@Coooder-Crypto): `SkillSet::load_resilient` / `load_dir_resilient` — one malformed `SKILL.md` no longer discards the whole set. Closes-out #74. Additive API only.

- [x] `cargo check --all-features` clean
- [x] version and CHANGELOG heading both read 0.16.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)