### PR TITLE
fix: enforce allowed_paths, redact secrets from Debug, document bash limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- **`allowed_paths` was declared but never enforced.** `ReadFileTool` accepted
+  an allowlist of directory roots, defaulted it, and then ignored it — callers
+  who set it believed reads were sandboxed and they were not. It is now
+  enforced, and the same allowlist was added to `WriteFileTool`,
+  `EditFileTool`, `ListFilesTool` and `SearchTool`, which previously had no
+  path restriction at all.
+
+  Checks run against the **resolved** path via the new
+  [`tools::PathSandbox`], so `..` and symlinks cannot escape, and a
+  not-yet-created file resolves through its real parent so writes are covered.
+  Rejections do not echo the allowed roots (tool results reach the model's
+  transcript). Default stays unrestricted — no behaviour change unless the
+  allowlist is set.
+
+- **Credentials could reach `Debug` output.** `StreamConfig` derived `Debug`
+  with a plaintext `api_key`, and `ModelConfig` derived it with a `headers`
+  map that conventionally carries `Authorization` / `x-api-key`. Any `{:?}` in
+  a log line or panic message printed them. Both now have manual `Debug` impls
+  that redact — `StreamConfig` still distinguishes a set key from an empty
+  one, and `ModelConfig` keeps header *names*. `ModelConfig`'s `Serialize` is
+  intentionally unchanged so saved configs still round-trip.
+
+### Added
+
+- `BashTool::with_env_allowlist` — pass only named environment variables (plus
+  `PATH`, `HOME`, `PWD`) to commands. Commands otherwise inherit the agent's
+  full environment, so a model-authored command can read any `*_API_KEY` the
+  process holds. Default behaviour unchanged.
+
+### Changed
+
+- Documented plainly that **`BashTool` is not a sandbox**: `deny_patterns` is
+  a substring check for typos, bypassed by whitespace, quoting or encoding.
+  Isolation belongs in a container/VM or `ToolMiddleware`.
+
 ## 0.16.1
 
 ### Added

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -133,6 +133,37 @@ tools.push(Box::new(WeatherTool));
 let agent = Agent::from_config(ModelConfig::anthropic("claude-sonnet-5", "Claude Sonnet 5")).with_tools(tools);
 ```
 
+## Sandboxing the built-in file tools
+
+`ReadFileTool`, `WriteFileTool`, `EditFileTool`, `ListFilesTool` and `SearchTool` accept an allowlist of directory roots. Empty (the default) means unrestricted:
+
+```rust
+let roots = vec!["/srv/workspace".to_string()];
+
+let tools: Vec<Box<dyn AgentTool>> = vec![
+    Box::new(ReadFileTool::new().with_allowed_paths(roots.clone())),
+    Box::new(WriteFileTool::new().with_allowed_paths(roots.clone())),
+    Box::new(EditFileTool::new().with_allowed_paths(roots)),
+];
+```
+
+Enforcement is against the **resolved** path, not the string, so neither `..` nor a symlink pointing outside can escape — and a file that does not exist yet still resolves through its real parent, so writes are checked too. The rejection message deliberately does not echo the allowed roots, since tool results reach the model's transcript.
+
+## `BashTool` is not a sandbox
+
+`BashTool` runs whatever the model asks through `bash -c`, with the agent process's own environment and filesystem access.
+
+`deny_patterns` is a substring check that catches typos and obvious mistakes — `rm  -rf /` with two spaces, a base64-decoded pipe, or an equivalent `find -delete` all sail past it. Treat it as a guardrail, never as a security boundary.
+
+Real isolation belongs outside the tool: run the agent in a container or VM, or gate calls through [`ToolMiddleware`](#tool-middleware), which sees the arguments before execution and can deny them.
+
+For credentials specifically, commands inherit every environment variable the agent process holds — including any `*_API_KEY`. When the model composes the command, restrict what it can read:
+
+```rust
+let bash = BashTool::default()
+    .with_env_allowlist(vec!["RUST_LOG".to_string()]);  // plus PATH, HOME, PWD
+```
+
 ## Error Handling
 
 **Return `Err(ToolError)` on failure, not `Ok` with error text.** When a tool returns `Err`, the agent loop converts it to a `Message::ToolResult` with `is_error: true` and sends it to the LLM. The LLM sees the error and can self-correct — retry with different arguments, try a different approach, or explain the failure to the user.

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -322,7 +322,7 @@ impl OpenCodeGateway {
 /// (`ModelConfig { .. }`) no longer compile; field mutation is the supported
 /// pattern. New fields must carry `#[serde(default)]` so previously
 /// persisted configs keep deserializing.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ModelConfig {
     /// Model identifier sent to the API (e.g. "gpt-4o", "claude-sonnet-4-20250514").
@@ -349,6 +349,11 @@ pub struct ModelConfig {
     #[serde(default)]
     pub cost: CostConfig,
     /// Additional headers to send with requests.
+    ///
+    /// May carry credentials (`Authorization`, `x-api-key`). `Debug` prints
+    /// header *names* with redacted values, but `Serialize` is intentionally
+    /// lossless so configs round-trip — do not serialize a `ModelConfig` into
+    /// logs or telemetry.
     #[serde(default)]
     pub headers: HashMap<String, String>,
     /// OpenAI-compat quirk flags (only for OpenAiCompletions protocol).
@@ -358,6 +363,25 @@ pub struct ModelConfig {
     /// `None` behaves like `AnthropicCompat::default()` (current generation).
     #[serde(default)]
     pub anthropic: Option<AnthropicCompat>,
+}
+
+/// Redacts header values. Headers routinely carry credentials, and a
+/// derived `Debug` would print them into any log line or panic message.
+impl std::fmt::Debug for ModelConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let headers: Vec<&str> = self.headers.keys().map(String::as_str).collect();
+        f.debug_struct("ModelConfig")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("api", &self.api)
+            .field("provider", &self.provider)
+            .field("base_url", &self.base_url)
+            .field("reasoning", &self.reasoning)
+            .field("context_window", &self.context_window)
+            .field("max_tokens", &self.max_tokens)
+            .field("header_names", &headers)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ModelConfig {

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -40,7 +40,7 @@ pub enum StreamEvent {
 /// let mut config = StreamConfig::new("claude-sonnet-5", "sk-key");
 /// config.system_prompt = "be brief".into();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct StreamConfig {
     pub model: String,
@@ -61,6 +61,39 @@ pub struct StreamConfig {
     /// response format; Gemini: `responseSchema`). Providers without support
     /// log a warning and ignore it.
     pub output_schema: Option<OutputSchema>,
+}
+
+/// Redacts `api_key`. A `{:?}` of this struct reaches logs and panic
+/// messages; a derived `Debug` would print the credential verbatim.
+impl std::fmt::Debug for StreamConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamConfig")
+            .field("model", &self.model)
+            .field("system_prompt", &self.system_prompt)
+            .field("messages", &self.messages)
+            .field("tools", &self.tools)
+            .field("thinking_level", &self.thinking_level)
+            .field("api_key", &Redacted(&self.api_key))
+            .field("max_tokens", &self.max_tokens)
+            .field("temperature", &self.temperature)
+            .field("model_config", &self.model_config)
+            .field("cache_config", &self.cache_config)
+            .field("output_schema", &self.output_schema)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Prints a placeholder instead of a secret, preserving only whether one is set.
+pub(crate) struct Redacted<'a>(pub(crate) &'a str);
+
+impl std::fmt::Debug for Redacted<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            f.write_str("\"\"")
+        } else {
+            f.write_str("\"[redacted]\"")
+        }
+    }
 }
 
 impl StreamConfig {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1,4 +1,21 @@
 //! Bash tool — execute shell commands with timeout and output capture.
+//!
+//! # This is not a sandbox
+//!
+//! `BashTool` runs whatever the model asks through `bash -c`, with the
+//! process's own environment and filesystem access. [`deny_patterns`] is a
+//! substring check that catches *typos and obvious mistakes* — it is trivially
+//! bypassed by any command that means to (`rm  -rf /` with two spaces, a
+//! base64-decoded pipe, an equivalent `find -delete`). Treat it as a guardrail,
+//! never as a security boundary.
+//!
+//! Real isolation belongs outside this tool: run the agent in a container or
+//! VM, or gate every call through
+//! [`ToolMiddleware`](crate::types::ToolMiddleware), which sees the arguments
+//! before execution and can deny them. For credentials specifically, see
+//! [`BashTool::env_allowlist`].
+//!
+//! [`deny_patterns`]: BashTool::deny_patterns
 
 use crate::types::*;
 
@@ -16,8 +33,20 @@ pub struct BashTool {
     pub timeout: Duration,
     /// Max output bytes to capture (prevents OOM on huge outputs)
     pub max_output_bytes: usize,
-    /// Commands/patterns that are always blocked (e.g., "rm -rf /")
+    /// Substrings that block a command outright.
+    ///
+    /// A convenience guardrail against typos, **not** a security control: a
+    /// substring match is bypassed by whitespace, quoting, or encoding. See
+    /// the module docs.
     pub deny_patterns: Vec<String>,
+    /// When set, the child process receives only these environment variables
+    /// (plus `PATH`, `HOME`, `PWD` if present).
+    ///
+    /// Commands otherwise inherit the agent's whole environment, including
+    /// any `*_API_KEY` the process holds — so a model-authored command can
+    /// read them. An allowlist is the cheap mitigation when running commands
+    /// the model composed.
+    pub env_allowlist: Option<Vec<String>>,
     /// Optional callback for confirming dangerous commands
     pub confirm_fn: Option<ConfirmFn>,
 }
@@ -36,6 +65,7 @@ impl Default for BashTool {
                 ":(){:|:&};:".into(), // fork bomb
             ],
             confirm_fn: None,
+            env_allowlist: None,
         }
     }
 }
@@ -52,6 +82,13 @@ impl BashTool {
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Pass only these environment variables to commands (plus `PATH`,
+    /// `HOME`, `PWD`). Use when the model composes the command.
+    pub fn with_env_allowlist(mut self, vars: Vec<String>) -> Self {
+        self.env_allowlist = Some(vars);
         self
     }
 
@@ -103,7 +140,7 @@ impl AgentTool for BashTool {
             .as_str()
             .ok_or_else(|| ToolError::InvalidArgs("missing 'command' parameter".into()))?;
 
-        // Check deny patterns
+        // Guardrail only — see the module docs; this is not a security boundary.
         for pattern in &self.deny_patterns {
             if command.contains(pattern.as_str()) {
                 return Err(ToolError::Failed(format!(
@@ -124,6 +161,19 @@ impl AgentTool for BashTool {
 
         let mut cmd = Command::new("bash");
         cmd.arg("-c").arg(command);
+
+        // Keep credentials out of model-authored commands when configured.
+        if let Some(ref allow) = self.env_allowlist {
+            let keep: Vec<(String, String)> = std::env::vars()
+                .filter(|(k, _)| {
+                    allow.iter().any(|a| a == k) || matches!(k.as_str(), "PATH" | "HOME" | "PWD")
+                })
+                .collect();
+            cmd.env_clear();
+            for (k, v) in keep {
+                cmd.env(k, v);
+            }
+        }
 
         if let Some(ref cwd) = self.cwd {
             cmd.current_dir(cwd);

--- a/src/tools/edit.rs
+++ b/src/tools/edit.rs
@@ -8,7 +8,13 @@ use crate::types::*;
 use async_trait::async_trait;
 
 /// Surgical file editing via exact text search/replace.
-pub struct EditFileTool;
+pub struct EditFileTool {
+    /// Allowed directory roots (empty = no restriction).
+    ///
+    /// Enforced against the *resolved* path, so `..` and symlinks cannot
+    /// escape. See [`PathSandbox`](crate::tools::PathSandbox).
+    pub allowed_paths: Vec<String>,
+}
 
 impl Default for EditFileTool {
     fn default() -> Self {
@@ -18,7 +24,15 @@ impl Default for EditFileTool {
 
 impl EditFileTool {
     pub fn new() -> Self {
-        Self
+        Self {
+            allowed_paths: Vec::new(),
+        }
+    }
+
+    /// Restrict edits to these directory roots.
+    pub fn with_allowed_paths(mut self, paths: Vec<String>) -> Self {
+        self.allowed_paths = paths;
+        self
     }
 }
 
@@ -76,6 +90,8 @@ impl AgentTool for EditFileTool {
         if cancel.is_cancelled() {
             return Err(ToolError::Cancelled);
         }
+
+        crate::tools::PathSandbox::new(self.allowed_paths.clone()).check(path)?;
 
         // Read existing file
         let content = tokio::fs::read_to_string(path).await.map_err(|e| {

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -61,7 +61,10 @@ pub const DEFAULT_READ_MAX_LINES: usize = 500;
 pub struct ReadFileTool {
     /// Max file size to read (prevents OOM)
     pub max_bytes: usize,
-    /// Allowed directory roots (empty = no restriction)
+    /// Allowed directory roots (empty = no restriction).
+    ///
+    /// Enforced against the *resolved* path, so `..` and symlinks cannot
+    /// escape. See [`PathSandbox`](crate::tools::PathSandbox).
     pub allowed_paths: Vec<String>,
     /// Lines returned when the call specifies no `limit`.
     /// Set to `usize::MAX` to restore unbounded reads.
@@ -81,6 +84,12 @@ impl Default for ReadFileTool {
 impl ReadFileTool {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Restrict reads to these directory roots.
+    pub fn with_allowed_paths(mut self, paths: Vec<String>) -> Self {
+        self.allowed_paths = paths;
+        self
     }
 }
 
@@ -131,6 +140,8 @@ impl AgentTool for ReadFileTool {
         if ctx.cancel.is_cancelled() {
             return Err(ToolError::Cancelled);
         }
+
+        crate::tools::PathSandbox::new(self.allowed_paths.clone()).check(path)?;
 
         // Check file exists and size
         let metadata = tokio::fs::metadata(path)
@@ -222,7 +233,13 @@ impl AgentTool for ReadFileTool {
 // ---------------------------------------------------------------------------
 
 /// Write content to a file. Creates parent directories if needed.
-pub struct WriteFileTool;
+pub struct WriteFileTool {
+    /// Allowed directory roots (empty = no restriction).
+    ///
+    /// Enforced against the *resolved* path, so `..` and symlinks cannot
+    /// escape. See [`PathSandbox`](crate::tools::PathSandbox).
+    pub allowed_paths: Vec<String>,
+}
 
 impl Default for WriteFileTool {
     fn default() -> Self {
@@ -232,7 +249,15 @@ impl Default for WriteFileTool {
 
 impl WriteFileTool {
     pub fn new() -> Self {
-        Self
+        Self {
+            allowed_paths: Vec::new(),
+        }
+    }
+
+    /// Restrict writes to these directory roots.
+    pub fn with_allowed_paths(mut self, paths: Vec<String>) -> Self {
+        self.allowed_paths = paths;
+        self
     }
 }
 
@@ -282,6 +307,8 @@ impl AgentTool for WriteFileTool {
         if ctx.cancel.is_cancelled() {
             return Err(ToolError::Cancelled);
         }
+
+        crate::tools::PathSandbox::new(self.allowed_paths.clone()).check(path)?;
 
         // Create parent directories
         if let Some(parent) = std::path::Path::new(path).parent() {

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -9,6 +9,19 @@ use tokio::process::Command;
 pub struct ListFilesTool {
     pub max_results: usize,
     pub timeout: Duration,
+    /// Allowed directory roots (empty = no restriction).
+    ///
+    /// Enforced against the *resolved* path, so `..` and symlinks cannot
+    /// escape. See [`PathSandbox`](crate::tools::PathSandbox).
+    pub allowed_paths: Vec<String>,
+}
+
+impl ListFilesTool {
+    /// Restrict listing to these directory roots.
+    pub fn with_allowed_paths(mut self, paths: Vec<String>) -> Self {
+        self.allowed_paths = paths;
+        self
+    }
 }
 
 impl Default for ListFilesTool {
@@ -16,6 +29,7 @@ impl Default for ListFilesTool {
         Self {
             max_results: 200,
             timeout: Duration::from_secs(10),
+            allowed_paths: Vec::new(),
         }
     }
 }
@@ -73,6 +87,8 @@ impl AgentTool for ListFilesTool {
         if cancel.is_cancelled() {
             return Err(ToolError::Cancelled);
         }
+
+        crate::tools::PathSandbox::new(self.allowed_paths.clone()).check(path)?;
 
         // Check path exists
         if !std::path::Path::new(path).exists() {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,7 @@ pub mod bash;
 pub mod edit;
 pub mod file;
 pub mod list;
+pub mod sandbox;
 pub mod search;
 pub mod shared_state_tool;
 
@@ -9,6 +10,7 @@ pub use bash::BashTool;
 pub use edit::EditFileTool;
 pub use file::{ReadFileTool, WriteFileTool, DEFAULT_READ_MAX_LINES};
 pub use list::ListFilesTool;
+pub use sandbox::PathSandbox;
 pub use search::SearchTool;
 pub use shared_state_tool::SharedStateTool;
 

--- a/src/tools/sandbox.rs
+++ b/src/tools/sandbox.rs
@@ -1,0 +1,212 @@
+//! Path sandboxing for the built-in file tools.
+//!
+//! A tool configured with allowed roots must reject every path outside them —
+//! including paths that *reach* outside via `..` or a symlink. Resolving the
+//! path lexically is not enough: `allowed/../../etc/passwd` and a symlink from
+//! `allowed/link` to `/etc` both look fine as strings.
+//!
+//! [`PathSandbox`] resolves the path against the filesystem first, then
+//! compares. An empty sandbox allows everything, which is the default for all
+//! built-in tools — sandboxing is opt-in, but once opted into it is enforced.
+//!
+//! # Example
+//!
+//! ```rust
+//! use yoagent::tools::sandbox::PathSandbox;
+//!
+//! let sandbox = PathSandbox::new(vec!["/srv/workspace".to_string()]);
+//! assert!(sandbox.check("/etc/passwd").is_err());
+//! ```
+
+use crate::types::ToolError;
+use std::path::{Component, Path, PathBuf};
+
+/// Allowed filesystem roots for a tool. Empty means unrestricted.
+#[derive(Debug, Clone, Default)]
+pub struct PathSandbox {
+    roots: Vec<PathBuf>,
+}
+
+impl PathSandbox {
+    /// Build a sandbox from allowed root paths.
+    ///
+    /// Roots are canonicalized when they exist; a root that does not exist is
+    /// kept as given (normalized) so a workspace created later still matches.
+    pub fn new(roots: Vec<String>) -> Self {
+        let roots = roots
+            .iter()
+            .map(|r| {
+                let p = PathBuf::from(r);
+                std::fs::canonicalize(&p).unwrap_or_else(|_| normalize_lexically(&p))
+            })
+            .collect();
+        Self { roots }
+    }
+
+    /// Whether any restriction applies.
+    pub fn is_unrestricted(&self) -> bool {
+        self.roots.is_empty()
+    }
+
+    /// Resolve `path` and verify it falls inside an allowed root.
+    ///
+    /// Returns the resolved path on success. For paths that do not exist yet
+    /// (a file about to be written), the nearest existing ancestor is resolved
+    /// and the remainder appended — so a write through a symlinked parent is
+    /// still checked against the symlink's target.
+    pub fn check(&self, path: &str) -> Result<PathBuf, ToolError> {
+        let resolved = resolve(Path::new(path));
+        if self.is_unrestricted() {
+            return Ok(resolved);
+        }
+        if self.roots.iter().any(|root| resolved.starts_with(root)) {
+            Ok(resolved)
+        } else {
+            // Deliberately does not echo the allowed roots: the model does not
+            // need the sandbox layout, and tool results reach the transcript.
+            Err(ToolError::Failed(format!(
+                "path '{path}' is outside the allowed directories"
+            )))
+        }
+    }
+}
+
+/// Resolve a path against the filesystem, falling back to lexical
+/// normalization for the part that does not exist yet.
+fn resolve(path: &Path) -> PathBuf {
+    if let Ok(c) = std::fs::canonicalize(path) {
+        return c;
+    }
+    // Walk up to the nearest existing ancestor, canonicalize that, and
+    // re-append the trailing components. This is what makes a not-yet-created
+    // file under a symlinked directory resolve to its real location.
+    let mut trailing = Vec::new();
+    let mut current = path;
+    loop {
+        match current.parent() {
+            Some(parent) => {
+                if let Some(name) = current.file_name() {
+                    trailing.push(name.to_owned());
+                }
+                if let Ok(base) = std::fs::canonicalize(parent) {
+                    let mut out = base;
+                    for part in trailing.iter().rev() {
+                        out.push(part);
+                    }
+                    return normalize_lexically(&out);
+                }
+                current = parent;
+            }
+            None => return normalize_lexically(path),
+        }
+    }
+}
+
+/// Collapse `.` and `..` textually. Only used when the filesystem cannot
+/// resolve the path at all.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        // A purely relative path that collapsed to nothing resolves against cwd.
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else if out.is_relative() {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&out))
+            .unwrap_or(out)
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn empty_sandbox_allows_anything() {
+        let s = PathSandbox::default();
+        assert!(s.is_unrestricted());
+        assert!(s.check("/etc/passwd").is_ok());
+    }
+
+    #[test]
+    fn inside_allowed_root_passes_outside_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("ok.txt"), "x").unwrap();
+        let s = PathSandbox::new(vec![tmp.path().to_string_lossy().to_string()]);
+
+        assert!(s.check(tmp.path().join("ok.txt").to_str().unwrap()).is_ok());
+        assert!(s.check("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn traversal_out_of_the_root_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(tmp.path().join("secret.txt"), "s").unwrap();
+        let s = PathSandbox::new(vec![root.to_string_lossy().to_string()]);
+
+        // Lexically this starts with the root; it must still be rejected.
+        let escape = root.join("../secret.txt");
+        assert!(
+            s.check(escape.to_str().unwrap()).is_err(),
+            "`..` must not escape the sandbox"
+        );
+    }
+
+    #[test]
+    fn nonexistent_file_under_allowed_root_is_permitted() {
+        // Writes target paths that do not exist yet — they must still resolve.
+        let tmp = TempDir::new().unwrap();
+        let s = PathSandbox::new(vec![tmp.path().to_string_lossy().to_string()]);
+        let new_file = tmp.path().join("nested/deep/new.txt");
+        assert!(s.check(new_file.to_str().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn nonexistent_path_outside_root_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let s = PathSandbox::new(vec![tmp.path().join("ws").to_string_lossy().to_string()]);
+        assert!(s.check("/nonexistent-elsewhere/x.txt").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_out_of_the_root_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "s").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
+
+        let s = PathSandbox::new(vec![root.to_string_lossy().to_string()]);
+        assert!(
+            s.check(root.join("link/secret.txt").to_str().unwrap())
+                .is_err(),
+            "a symlink pointing out of the sandbox must not grant access"
+        );
+    }
+
+    #[test]
+    fn error_does_not_disclose_the_allowed_roots() {
+        let s = PathSandbox::new(vec!["/srv/secret-workspace-name".to_string()]);
+        let err = s.check("/etc/passwd").unwrap_err().to_string();
+        assert!(
+            !err.contains("secret-workspace-name"),
+            "leaked roots: {err}"
+        );
+    }
+}

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -13,6 +13,19 @@ pub struct SearchTool {
     pub max_results: usize,
     /// Timeout
     pub timeout: Duration,
+    /// Allowed directory roots (empty = no restriction).
+    ///
+    /// Enforced against the *resolved* path, so `..` and symlinks cannot
+    /// escape. See [`PathSandbox`](crate::tools::PathSandbox).
+    pub allowed_paths: Vec<String>,
+}
+
+impl SearchTool {
+    /// Restrict searching to these directory roots.
+    pub fn with_allowed_paths(mut self, paths: Vec<String>) -> Self {
+        self.allowed_paths = paths;
+        self
+    }
 }
 
 impl Default for SearchTool {
@@ -21,6 +34,7 @@ impl Default for SearchTool {
             root: None,
             max_results: 50,
             timeout: Duration::from_secs(30),
+            allowed_paths: Vec::new(),
         }
     }
 }
@@ -97,6 +111,8 @@ impl AgentTool for SearchTool {
         if cancel.is_cancelled() {
             return Err(ToolError::Cancelled);
         }
+
+        crate::tools::PathSandbox::new(self.allowed_paths.clone()).check(&search_path)?;
 
         // Try ripgrep first, fall back to grep
         let (cmd_name, args) = if which_exists("rg") {

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -630,3 +630,67 @@ fn test_agent_event_deserializes_from_raw_json() {
     assert_eq!(tool_name, "read");
     assert_eq!(args["path"], "a.rs");
 }
+
+// ---------------------------------------------------------------------------
+// Secrets must not reach Debug output — it lands in logs and panic messages.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stream_config_debug_redacts_the_api_key() {
+    let mut config = yoagent::provider::StreamConfig::new("m", "sk-super-secret-key");
+    config.system_prompt = "be brief".into();
+    let rendered = format!("{:?}", config);
+
+    assert!(
+        !rendered.contains("sk-super-secret-key"),
+        "api_key leaked into Debug: {rendered}"
+    );
+    assert!(
+        rendered.contains("[redacted]"),
+        "no redaction marker: {rendered}"
+    );
+    // Still useful for debugging.
+    assert!(rendered.contains("be brief"));
+}
+
+#[test]
+fn stream_config_debug_distinguishes_an_empty_key() {
+    let config = yoagent::provider::StreamConfig::new("m", "");
+    let rendered = format!("{:?}", config);
+    assert!(
+        !rendered.contains("[redacted]"),
+        "an unset key should not look like a set one: {rendered}"
+    );
+}
+
+#[test]
+fn model_config_debug_redacts_header_values_but_keeps_names() {
+    let mut config = yoagent::provider::ModelConfig::anthropic("claude-sonnet-5", "Sonnet");
+    config
+        .headers
+        .insert("Authorization".into(), "Bearer sk-leaked-token".into());
+    let rendered = format!("{:?}", config);
+
+    assert!(
+        !rendered.contains("sk-leaked-token"),
+        "header credential leaked into Debug: {rendered}"
+    );
+    assert!(
+        rendered.contains("Authorization"),
+        "header names should survive for debugging: {rendered}"
+    );
+}
+
+#[test]
+fn model_config_serialization_stays_lossless() {
+    // Debug redacts; Serialize must not, or saved configs lose their headers.
+    let mut config = yoagent::provider::ModelConfig::anthropic("claude-sonnet-5", "Sonnet");
+    config.headers.insert("x-api-key".into(), "keep-me".into());
+
+    let json = serde_json::to_string(&config).unwrap();
+    let back: yoagent::provider::ModelConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        back.headers.get("x-api-key").map(String::as_str),
+        Some("keep-me")
+    );
+}

--- a/tests/tools_test.rs
+++ b/tests/tools_test.rs
@@ -536,3 +536,198 @@ async fn test_read_file_unbounded_when_max_lines_disabled() {
 
     let _ = std::fs::remove_file(tmp);
 }
+
+// ---------------------------------------------------------------------------
+// Path sandboxing — allowed_paths must actually be enforced, on every tool
+// that takes a path, against the resolved path (not the string).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn read_tool_rejects_paths_outside_allowed_roots() {
+    let tmp = std::env::temp_dir().join("yoagent-sandbox-read");
+    let ws = tmp.join("workspace");
+    std::fs::create_dir_all(&ws).unwrap();
+    std::fs::write(ws.join("ok.txt"), "inside").unwrap();
+    std::fs::write(tmp.join("secret.txt"), "outside").unwrap();
+
+    let tool = ReadFileTool::new().with_allowed_paths(vec![ws.to_string_lossy().to_string()]);
+
+    // Inside the root: allowed.
+    assert!(tool
+        .execute(
+            serde_json::json!({"path": ws.join("ok.txt").to_str().unwrap()}),
+            ctx("read_file")
+        )
+        .await
+        .is_ok());
+
+    // Absolute path outside: rejected.
+    assert!(tool
+        .execute(
+            serde_json::json!({"path": tmp.join("secret.txt").to_str().unwrap()}),
+            ctx("read_file")
+        )
+        .await
+        .is_err());
+
+    // Traversal that is lexically "inside" the root: rejected.
+    let escape = ws.join("../secret.txt");
+    assert!(
+        tool.execute(
+            serde_json::json!({"path": escape.to_str().unwrap()}),
+            ctx("read_file")
+        )
+        .await
+        .is_err(),
+        "`..` must not escape the sandbox"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn write_and_edit_tools_reject_paths_outside_allowed_roots() {
+    let tmp = std::env::temp_dir().join("yoagent-sandbox-write");
+    let ws = tmp.join("workspace");
+    std::fs::create_dir_all(&ws).unwrap();
+    std::fs::write(ws.join("edit.txt"), "hello").unwrap();
+    let outside = tmp.join("victim.txt");
+    std::fs::write(&outside, "original").unwrap();
+
+    let roots = vec![ws.to_string_lossy().to_string()];
+    let write = WriteFileTool::new().with_allowed_paths(roots.clone());
+    let edit = EditFileTool::new().with_allowed_paths(roots);
+
+    // A write outside the sandbox must fail *and* leave the file untouched.
+    assert!(write
+        .execute(
+            serde_json::json!({"path": outside.to_str().unwrap(), "content": "pwned"}),
+            ctx("write_file")
+        )
+        .await
+        .is_err());
+    assert_eq!(std::fs::read_to_string(&outside).unwrap(), "original");
+
+    // Writing a not-yet-existing file inside the sandbox still works.
+    assert!(write
+        .execute(
+            serde_json::json!({"path": ws.join("new/deep.txt").to_str().unwrap(), "content": "ok"}),
+            ctx("write_file")
+        )
+        .await
+        .is_ok());
+
+    assert!(edit
+        .execute(
+            serde_json::json!({
+                "path": outside.to_str().unwrap(),
+                "old_text": "original",
+                "new_text": "pwned"
+            }),
+            ctx("edit_file")
+        )
+        .await
+        .is_err());
+    assert_eq!(std::fs::read_to_string(&outside).unwrap(), "original");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn list_and_search_tools_reject_paths_outside_allowed_roots() {
+    let tmp = std::env::temp_dir().join("yoagent-sandbox-scan");
+    let ws = tmp.join("workspace");
+    std::fs::create_dir_all(&ws).unwrap();
+    std::fs::write(tmp.join("secret.txt"), "needle").unwrap();
+
+    let roots = vec![ws.to_string_lossy().to_string()];
+    let list = ListFilesTool::default().with_allowed_paths(roots.clone());
+    let search = SearchTool::default().with_allowed_paths(roots);
+
+    assert!(list
+        .execute(
+            serde_json::json!({"path": tmp.to_str().unwrap()}),
+            ctx("list_files")
+        )
+        .await
+        .is_err());
+    assert!(search
+        .execute(
+            serde_json::json!({"pattern": "needle", "path": tmp.to_str().unwrap()}),
+            ctx("search")
+        )
+        .await
+        .is_err());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn unrestricted_tools_are_unchanged_by_default() {
+    // The default is no sandbox; adding enforcement must not break it.
+    let tmp = std::env::temp_dir().join("yoagent-sandbox-default");
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("f.txt"), "content").unwrap();
+
+    let tool = ReadFileTool::new();
+    assert!(tool
+        .execute(
+            serde_json::json!({"path": tmp.join("f.txt").to_str().unwrap()}),
+            ctx("read_file")
+        )
+        .await
+        .is_ok());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn bash_env_allowlist_hides_other_variables() {
+    // Model-authored commands inherit the agent's environment by default,
+    // including credentials. The allowlist is the mitigation.
+    unsafe {
+        std::env::set_var("YOAGENT_TEST_SECRET", "leaked-value");
+        std::env::set_var("YOAGENT_TEST_KEEP", "kept-value");
+    }
+
+    let guarded = BashTool::default().with_env_allowlist(vec!["YOAGENT_TEST_KEEP".to_string()]);
+    let result = guarded
+        .execute(
+            serde_json::json!({"command": "echo \"$YOAGENT_TEST_SECRET|$YOAGENT_TEST_KEEP\""}),
+            ctx("bash"),
+        )
+        .await
+        .unwrap();
+    let out = match &result.content[0] {
+        Content::Text { text } => text.clone(),
+        _ => panic!("expected text"),
+    };
+    assert!(
+        !out.contains("leaked-value"),
+        "secret reached the command: {out}"
+    );
+    assert!(out.contains("kept-value"), "allowlisted var missing: {out}");
+
+    // Default behaviour is unchanged: the full environment is inherited.
+    let plain = BashTool::default();
+    let result = plain
+        .execute(
+            serde_json::json!({"command": "echo \"$YOAGENT_TEST_SECRET\""}),
+            ctx("bash"),
+        )
+        .await
+        .unwrap();
+    let out = match &result.content[0] {
+        Content::Text { text } => text.clone(),
+        _ => panic!("expected text"),
+    };
+    assert!(
+        out.contains("leaked-value"),
+        "default should inherit env: {out}"
+    );
+
+    unsafe {
+        std::env::remove_var("YOAGENT_TEST_SECRET");
+        std::env::remove_var("YOAGENT_TEST_KEEP");
+    }
+}


### PR DESCRIPTION
Security hardening from an audit of the crate as an agent backbone. Three findings, none exploitable through yoagent itself, all of the same class: **the library promises something it does not deliver.**

## 1. `allowed_paths` was a dead field

`ReadFileTool` declared an allowlist of directory roots, defaulted it, and **never read it** — grep found only the declaration and the default. A caller who set it believed reads were sandboxed; they were not. `WriteFileTool`, `EditFileTool`, `ListFilesTool` and `SearchTool` had no path restriction at all, so `{"path": "../../.ssh/id_rsa"}` or `/etc/passwd` worked everywhere.

A dead security field is worse than none, so this enforces it rather than deleting it. New `tools::PathSandbox` checks the **resolved** path:

- `..` cannot escape, even when the string is lexically inside the root
- symlinks pointing out of the sandbox are rejected
- a file that does not exist yet resolves through its real parent, so **writes** are checked, not just reads
- rejections do not echo the allowed roots — tool results reach the model's transcript

Default stays unrestricted: no behaviour change unless you opt in.

```rust
let roots = vec!["/srv/workspace".to_string()];
ReadFileTool::new().with_allowed_paths(roots.clone());
WriteFileTool::new().with_allowed_paths(roots);
```

## 2. Credentials reached `Debug`

`StreamConfig` derived `Debug` with a plaintext `api_key`. `ModelConfig` derived it with a `headers` map that conventionally carries `Authorization` / `x-api-key`. Any `{:?}` in a log line or panic message printed them verbatim.

Manual `Debug` impls now redact while keeping what is useful: `StreamConfig` still distinguishes a set key from an empty one, `ModelConfig` keeps header *names*. **`ModelConfig`'s `Serialize` is deliberately unchanged** — redacting it would silently break config round-trips, so the risk is documented on the field instead.

## 3. `BashTool` is not a sandbox — say so

`deny_patterns` reads like a security control. It is five substrings, defeated by `rm  -rf /` with two spaces, quoting, or `$(echo … | base64 -d | sh)`. Now documented plainly as a typo guardrail, with isolation pointed at containers/VMs and `ToolMiddleware`.

Commands also inherited the agent's entire environment — including any `*_API_KEY` the process holds, readable by any model-authored command. Added `BashTool::with_env_allowlist` (opt-in, default unchanged).

## Verification

510 tests green, clippy clean under `-Dwarnings`, all features. New coverage includes symlink and `..` escapes end-to-end per tool, "a rejected write leaves the target file untouched", redaction with serialization round-trip, and env isolation with the default-inherits case asserted too.

## Not in this PR

Two design items from the same audit, both wanting an intentional break: `AgentEvent` is not `#[non_exhaustive]` (every new event is breaking — we routed around this in #104), and `SharedState` has no isolation between sub-agents (`list` enumerates every key). Worth bundling into the next major-ish bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)