### PR TITLE
feat!: non_exhaustive on growing enums, opt-in SharedState scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- **Breaking: `AgentEvent`, `StreamEvent`, `StreamDelta`, `StopReason` and
+  `ApiProtocol` are now `#[non_exhaustive]`.** These five grow with provider
+  and protocol features, so every addition was previously a breaking change —
+  the reason yoagent#104 routed around adding a compaction event rather than
+  adding one. Downstream `match` arms need a `_ =>` wildcard; new variants are
+  additive from here.
+
+  Other enums were deliberately left exhaustive: `Message`, `AgentMessage`,
+  `FilterResult`, `ToolDecision` and the config enums are closed shapes, and
+  marking them would break a great deal of downstream code for no expected
+  growth.
+
+  The `AgentEvent` / `StreamDelta` **wire-tag freeze moved into the crate**
+  (`types::wire_tag_freeze`). It relies on exhaustive matching to fail
+  compilation until a new variant's serde tag is pinned — a guarantee that no
+  longer holds from an integration test once the enum is `#[non_exhaustive]`.
+  Verified by adding a probe variant: it still fails to compile.
+
+### Added
+
+- **`SharedState::scoped` — opt-in isolation between sub-agents.** The store
+  is a shared flat namespace by design, so this is a view rather than a
+  default: keys are transparently prefixed, and `keys()` / `summary()` report
+  only that scope. A scoped sub-agent cannot read, overwrite or enumerate
+  anything outside it (prefixing is applied on the way in, so a crafted key
+  cannot escape), while the parent's unscoped handle still sees everything —
+  which is what lets it collect results. Scoping nests, so a view can narrow
+  but never widen.
+
+  `summary()` matters most here: it is injected into the sub-agent's system
+  prompt, so an unscoped one disclosed every sibling's key names.
+- `SubAgentTool::with_scoped_shared_state` — the isolating counterpart to
+  `with_shared_state`.
+
 ## 0.16.2
 
 ### Fixed

--- a/docs/concepts/sub-agents.md
+++ b/docs/concepts/sub-agents.md
@@ -204,6 +204,28 @@ This works with all providers: OpenAI, Groq, DeepSeek, Gemini, Mistral, xAI, and
 - **Cancellation propagation**: The parent's cancellation token is forwarded. Aborting the parent aborts all sub-agents.
 - **Turn limiting**: The default 10-turn limit prevents runaway execution. The parent's execution limits also apply to total wall-clock time.
 
+## Isolating sub-agents from each other
+
+`SharedState` is a single flat namespace by design — a parent stores an artifact once and several sub-agents read it by reference, which is the whole point of the type. Every holder sees every key.
+
+When a sub-agent should *not* see its siblings' data, hand it a scoped view:
+
+```rust
+let state = SharedState::new();
+
+let researcher = SubAgentTool::from_config("researcher", config.clone())
+    .with_scoped_shared_state(state.clone(), "researcher");
+let writer = SubAgentTool::from_config("writer", config)
+    .with_scoped_shared_state(state.clone(), "writer");
+
+// The parent's unscoped handle still sees everything both wrote.
+for key in state.keys().await { /* … */ }
+```
+
+Keys are transparently prefixed, so a scoped sub-agent cannot read, overwrite, or **enumerate** anything outside its scope — including via a crafted key, since the prefix is applied on the way in. `summary()` is scoped too, which matters most: it is injected into the sub-agent's system prompt, so an unscoped summary would disclose every sibling's key names.
+
+Scoping nests (`state.scoped("a").scoped("b")`), so a sub-agent can narrow its own view but never widen it. Keep plain `with_shared_state` when sharing is the intent.
+
 ## Examples
 
 - [`examples/sub_agent.rs`](../../examples/sub_agent.rs) — Coordinator with researcher and coder sub-agents

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 /// Which API protocol a model uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ApiProtocol {
     AnthropicMessages,
     OpenAiCompletions,

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -6,6 +6,7 @@ use super::model::ModelConfig;
 
 /// Events emitted during LLM streaming
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum StreamEvent {
     /// Stream started, partial assistant message
     Start,

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -329,13 +329,47 @@ impl SharedStateBackend for FileBackend {
 // SharedState (public API)
 // ---------------------------------------------------------------------------
 
+/// Separator between a scope name and a key. Non-printable, so it cannot
+/// collide with a key a caller would plausibly choose.
+const SCOPE_SEP: char = '\u{1f}';
+
 /// A shared string key-value store for sub-agent communication.
 ///
 /// Cheaply cloneable (wraps `Arc`). Delegates all operations to a
 /// pluggable [`SharedStateBackend`].
+///
+/// # Scoping
+///
+/// Sharing is the point of this type — a parent stores an artifact once and
+/// several sub-agents read it by reference. So the default is a single flat
+/// namespace where every holder sees every key.
+///
+/// When a sub-agent should *not* see its siblings' data, hand it a scoped
+/// view via [`scoped`](Self::scoped). Keys are transparently prefixed, and
+/// [`keys`](Self::keys) / [`summary`](Self::summary) report only that scope
+/// with the prefix stripped — so the sub-agent cannot enumerate, read, or
+/// overwrite anything outside it. Prefixing is applied on the way in, so a
+/// crafted key cannot escape the scope. The unscoped handle still sees
+/// everything, which is what lets the parent collect results.
+///
+/// ```rust
+/// # use yoagent::shared_state::SharedState;
+/// # async fn demo() {
+/// let state = SharedState::new();
+/// let researcher = state.scoped("researcher");
+/// researcher.set("notes", "…".into()).await.unwrap();
+///
+/// // A sibling sees nothing of it.
+/// assert!(state.scoped("writer").get("notes").await.is_none());
+/// // The parent does.
+/// assert!(researcher.get("notes").await.is_some());
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct SharedState {
     backend: Arc<dyn SharedStateBackend>,
+    /// `None` = the root view: full, unprefixed access.
+    scope: Option<Arc<str>>,
 }
 
 impl SharedState {
@@ -343,6 +377,7 @@ impl SharedState {
     pub fn new() -> Self {
         Self {
             backend: Arc::new(MemoryBackend::new()),
+            scope: None,
         }
     }
 
@@ -350,6 +385,7 @@ impl SharedState {
     pub fn with_max_bytes(max_bytes: usize) -> Self {
         Self {
             backend: Arc::new(MemoryBackend::with_max_bytes(max_bytes)),
+            scope: None,
         }
     }
 
@@ -357,12 +393,47 @@ impl SharedState {
     pub fn with_backend(backend: impl SharedStateBackend + 'static) -> Self {
         Self {
             backend: Arc::new(backend),
+            scope: None,
         }
+    }
+
+    /// A view of this store restricted to `scope`.
+    ///
+    /// The view shares the same backend, so the parent still sees everything
+    /// the scope writes. Scoping a scoped view nests (`a` then `b` behaves as
+    /// `a/b`), so a sub-agent cannot widen its own access.
+    pub fn scoped(&self, scope: impl AsRef<str>) -> Self {
+        let scope = match &self.scope {
+            Some(existing) => format!("{existing}{SCOPE_SEP}{}", scope.as_ref()),
+            None => scope.as_ref().to_string(),
+        };
+        Self {
+            backend: Arc::clone(&self.backend),
+            scope: Some(scope.into()),
+        }
+    }
+
+    /// The scope this view is restricted to, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Map a caller-facing key to its backend key.
+    fn full_key(&self, key: &str) -> String {
+        match &self.scope {
+            Some(scope) => format!("{scope}{SCOPE_SEP}{key}"),
+            None => key.to_string(),
+        }
+    }
+
+    /// The backend-key prefix for this view, if scoped.
+    fn prefix(&self) -> Option<String> {
+        self.scope.as_ref().map(|s| format!("{s}{SCOPE_SEP}"))
     }
 
     /// Get a value by key. Returns `None` if the key doesn't exist.
     pub async fn get(&self, key: &str) -> Option<String> {
-        match self.backend.get(key).await {
+        match self.backend.get(&self.full_key(key)).await {
             Ok(val) => val,
             Err(e) => {
                 eprintln!("[SharedState] get({:?}) error: {}", key, e);
@@ -373,12 +444,12 @@ impl SharedState {
 
     /// Store a value. Returns `Err` if the backend rejects it (capacity, I/O, etc.).
     pub async fn set(&self, key: &str, value: String) -> Result<(), SharedStateError> {
-        self.backend.set(key, value).await
+        self.backend.set(&self.full_key(key), value).await
     }
 
     /// Remove a key. Returns `true` if the key existed.
     pub async fn remove(&self, key: &str) -> bool {
-        match self.backend.remove(key).await {
+        match self.backend.remove(&self.full_key(key)).await {
             Ok(existed) => existed,
             Err(e) => {
                 eprintln!("[SharedState] remove({:?}) error: {}", key, e);
@@ -387,10 +458,16 @@ impl SharedState {
         }
     }
 
-    /// List all keys (sorted).
+    /// List keys (sorted). A scoped view lists only its own, prefix stripped.
     pub async fn keys(&self) -> Vec<String> {
         match self.backend.keys().await {
-            Ok(keys) => keys,
+            Ok(keys) => match self.prefix() {
+                Some(prefix) => keys
+                    .into_iter()
+                    .filter_map(|k| k.strip_prefix(&prefix).map(str::to_string))
+                    .collect(),
+                None => keys,
+            },
             Err(e) => {
                 eprintln!("[SharedState] keys() error: {}", e);
                 Vec::new()
@@ -400,14 +477,28 @@ impl SharedState {
 
     /// Human-readable summary of stored variables (key names + byte sizes).
     /// Suitable for injecting into a system prompt.
+    ///
+    /// A scoped view summarizes only its own keys. This matters more than the
+    /// other accessors: the summary is injected into the sub-agent's system
+    /// prompt, so an unscoped one would disclose every sibling's key names.
     pub async fn summary(&self) -> String {
-        match self.backend.summary().await {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[SharedState] summary() error: {}", e);
-                "(error reading state)".to_string()
-            }
+        if self.scope.is_none() {
+            return match self.backend.summary().await {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("[SharedState] summary() error: {}", e);
+                    "(error reading state)".to_string()
+                }
+            };
         }
+        // Scoped: rebuild from this view's keys so nothing outside leaks.
+        let mut entries: Vec<(String, usize)> = Vec::new();
+        for key in self.keys().await {
+            let len = self.get(&key).await.map(|v| v.len()).unwrap_or(0);
+            entries.push((key, len));
+        }
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        format_summary(entries.iter().map(|(k, n)| (k.as_str(), *n)))
     }
 }
 

--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -256,6 +256,21 @@ impl SubAgentTool {
         self
     }
 
+    /// Attach a shared store restricted to this sub-agent's own namespace.
+    ///
+    /// Equivalent to [`with_shared_state(state.scoped(name))`](Self::with_shared_state),
+    /// spelled out because the isolating variant is easy to forget. The
+    /// sub-agent cannot read, overwrite, or even enumerate keys outside its
+    /// scope, while the parent's unscoped handle still sees everything it
+    /// writes.
+    ///
+    /// Use when sub-agents should not see each other's data; keep
+    /// `with_shared_state` when sharing is the point.
+    pub fn with_scoped_shared_state(mut self, state: SharedState, scope: impl AsRef<str>) -> Self {
+        self.shared_state = Some(state.scoped(scope));
+        self
+    }
+
     /// Add an inter-turn delay to throttle API requests.
     /// Useful when using OAuth tokens or providers with low rate limits.
     /// The delay is applied before each turn except the first.

--- a/src/types.rs
+++ b/src/types.rs
@@ -290,6 +290,7 @@ impl From<Message> for AgentMessage {
 /// downstream matches rather than silently falling into a wildcard arm.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum StopReason {
     Stop,
     Length,
@@ -552,6 +553,7 @@ pub enum ToolError {
     rename_all = "camelCase",
     rename_all_fields = "camelCase"
 )]
+#[non_exhaustive]
 pub enum AgentEvent {
     AgentStart,
     AgentEnd {
@@ -608,6 +610,7 @@ pub enum AgentEvent {
     rename_all = "camelCase",
     rename_all_fields = "camelCase"
 )]
+#[non_exhaustive]
 pub enum StreamDelta {
     Text { delta: String },
     Thinking { delta: String },
@@ -729,5 +732,63 @@ impl fmt::Display for StopReason {
             Self::Aborted => write!(f, "aborted"),
             Self::Refusal => write!(f, "refusal"),
         }
+    }
+}
+
+/// Wire-tag freeze for [`AgentEvent`] and [`StreamDelta`].
+///
+/// These matches deliberately have **no wildcard arm**: adding a variant must
+/// fail to compile here until its serde tag is pinned. That guarantee is the
+/// reason they live in this crate rather than in `tests/` — both enums are
+/// `#[non_exhaustive]`, so an integration test *cannot* match them
+/// exhaustively and the compile-time freeze would silently degrade to a
+/// wildcard. Inside the defining crate, exhaustiveness still applies.
+///
+/// A tag change is a breaking change for wire clients — do not edit casually.
+/// `tests/serialization_test.rs` covers the round-trips and payload shapes;
+/// this covers only "no variant escapes without a pinned tag".
+#[cfg(test)]
+mod wire_tag_freeze {
+    use super::*;
+
+    fn expected_event_tag(event: &AgentEvent) -> &'static str {
+        match event {
+            AgentEvent::AgentStart => "agentStart",
+            AgentEvent::AgentEnd { .. } => "agentEnd",
+            AgentEvent::TurnStart => "turnStart",
+            AgentEvent::TurnEnd { .. } => "turnEnd",
+            AgentEvent::MessageStart { .. } => "messageStart",
+            AgentEvent::MessageUpdate { .. } => "messageUpdate",
+            AgentEvent::MessageEnd { .. } => "messageEnd",
+            AgentEvent::ToolExecutionStart { .. } => "toolExecutionStart",
+            AgentEvent::ToolExecutionUpdate { .. } => "toolExecutionUpdate",
+            AgentEvent::ToolExecutionEnd { .. } => "toolExecutionEnd",
+            AgentEvent::ProgressMessage { .. } => "progressMessage",
+            AgentEvent::InputRejected { .. } => "inputRejected",
+        }
+    }
+
+    fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
+        match delta {
+            StreamDelta::Text { .. } => "text",
+            StreamDelta::Thinking { .. } => "thinking",
+            StreamDelta::ToolCallDelta { .. } => "toolCallDelta",
+        }
+    }
+
+    #[test]
+    fn every_event_variant_has_a_pinned_tag() {
+        // Sampling one variant is enough: the compiler enforces coverage, this
+        // just proves the mapping matches what serde actually emits.
+        let event = AgentEvent::AgentStart;
+        let v = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(v["type"], expected_event_tag(&event));
+    }
+
+    #[test]
+    fn every_delta_variant_has_a_pinned_tag() {
+        let delta = StreamDelta::Text { delta: "x".into() };
+        let v = serde_json::to_value(&delta).expect("serialize");
+        assert_eq!(v["type"], expected_delta_tag(&delta));
     }
 }

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -81,6 +81,7 @@ async fn test_simple_text_response() {
             AgentEvent::ToolExecutionEnd { .. } => "ToolExecEnd",
             AgentEvent::ProgressMessage { .. } => "ProgressMessage",
             AgentEvent::InputRejected { .. } => "InputRejected",
+            _ => "Unknown",
         })
         .collect();
 
@@ -177,6 +178,7 @@ async fn test_tool_call_and_response() {
             AgentEvent::ToolExecutionEnd { .. } => "ToolExecEnd",
             AgentEvent::ProgressMessage { .. } => "ProgressMessage",
             AgentEvent::InputRejected { .. } => "InputRejected",
+            _ => "Unknown",
         })
         .collect();
 

--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -586,6 +586,7 @@ async fn tee_delivers_the_complete_event_stream() {
             AgentEvent::ToolExecutionEnd { .. } => "ToolExecutionEnd",
             AgentEvent::ProgressMessage { .. } => "ProgressMessage",
             AgentEvent::InputRejected { .. } => "InputRejected",
+            _ => "Unknown",
         }
     }
 

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -375,10 +375,13 @@ fn test_stream_delta_every_variant_roundtrips() {
 }
 
 /// The frozen `"type"` tag for every `AgentEvent` variant. Exhaustive match
-/// with NO wildcard arm on purpose: adding a variant fails to compile here
-/// until its wire tag is pinned. Keep [`EVENT_VARIANT_COUNT`] and the sample
-/// in `all_agent_events` in step — the count assertion below fails until the
-/// new variant is actually exercised, closing the other half of the freeze.
+/// The compile-time half of this freeze moved into `src/types.rs`
+/// (`wire_tag_freeze`) when `AgentEvent` and `StreamDelta` became
+/// `#[non_exhaustive]` — an integration test can no longer match them
+/// exhaustively, so the "adding a variant fails to compile" guarantee only
+/// holds inside the defining crate. What remains here is the round-trip and
+/// payload-shape coverage, plus [`EVENT_VARIANT_COUNT`], which still fails
+/// until a new variant gets a sample in `all_agent_events`.
 /// A tag change is a breaking change for wire clients — do not edit casually.
 fn expected_event_tag(event: &AgentEvent) -> &'static str {
     match event {
@@ -394,6 +397,7 @@ fn expected_event_tag(event: &AgentEvent) -> &'static str {
         AgentEvent::ToolExecutionEnd { .. } => "toolExecutionEnd",
         AgentEvent::ProgressMessage { .. } => "progressMessage",
         AgentEvent::InputRejected { .. } => "inputRejected",
+        _ => "unknown",
     }
 }
 
@@ -403,6 +407,7 @@ fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
         StreamDelta::Text { .. } => "text",
         StreamDelta::Thinking { .. } => "thinking",
         StreamDelta::ToolCallDelta { .. } => "toolCallDelta",
+        _ => "unknown",
     }
 }
 

--- a/tests/shared_state_test.rs
+++ b/tests/shared_state_test.rs
@@ -248,3 +248,98 @@ async fn test_shared_state_summary_in_system_prompt() {
     };
     assert_eq!(text, "Listed state");
 }
+
+// ---------------------------------------------------------------------------
+// Scoped views — opt-in isolation between sub-agents.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scoped_views_cannot_see_or_touch_each_other() {
+    let state = SharedState::new();
+    let a = state.scoped("researcher");
+    let b = state.scoped("writer");
+
+    a.set("notes", "secret research".into()).await.unwrap();
+    b.set("notes", "draft prose".into()).await.unwrap();
+
+    // Same key name, independent values.
+    assert_eq!(a.get("notes").await.as_deref(), Some("secret research"));
+    assert_eq!(b.get("notes").await.as_deref(), Some("draft prose"));
+
+    // Neither can enumerate the other.
+    assert_eq!(a.keys().await, vec!["notes".to_string()]);
+    assert_eq!(b.keys().await, vec!["notes".to_string()]);
+
+    // A sibling's remove does not reach across.
+    assert!(b.remove("notes").await);
+    assert_eq!(a.get("notes").await.as_deref(), Some("secret research"));
+}
+
+#[tokio::test]
+async fn scoped_summary_does_not_disclose_sibling_keys() {
+    // The summary goes into the sub-agent's system prompt — the leak that
+    // matters most.
+    let state = SharedState::new();
+    state
+        .scoped("writer")
+        .set("private_draft", "x".into())
+        .await
+        .unwrap();
+    let researcher = state.scoped("researcher");
+    researcher.set("sources", "y".into()).await.unwrap();
+
+    let summary = researcher.summary().await;
+    assert!(summary.contains("sources"), "own key missing: {summary}");
+    assert!(
+        !summary.contains("private_draft"),
+        "sibling key leaked into the prompt: {summary}"
+    );
+}
+
+#[tokio::test]
+async fn a_scoped_view_cannot_escape_its_scope() {
+    let state = SharedState::new();
+    state.set("root_secret", "topsecret".into()).await.unwrap();
+    let sub = state.scoped("sub");
+
+    // Neither a plain key nor one crafted with a separator reaches the root.
+    assert!(sub.get("root_secret").await.is_none());
+    assert!(sub.get("\u{1f}root_secret").await.is_none());
+    assert!(sub.get("../root_secret").await.is_none());
+
+    // Nesting narrows, never widens.
+    let deeper = sub.scoped("deeper");
+    deeper.set("k", "v".into()).await.unwrap();
+    assert!(sub.get("k").await.is_none());
+    assert_eq!(deeper.get("k").await.as_deref(), Some("v"));
+}
+
+#[tokio::test]
+async fn the_parent_still_sees_everything_scopes_write() {
+    // Collecting sub-agent results is the reason scoping is a view, not a
+    // separate store.
+    let state = SharedState::new();
+    state
+        .scoped("researcher")
+        .set("out", "findings".into())
+        .await
+        .unwrap();
+
+    let all = state.keys().await;
+    assert_eq!(all.len(), 1);
+    assert!(all[0].contains("researcher"), "got {all:?}");
+    assert_eq!(
+        state.scoped("researcher").get("out").await.as_deref(),
+        Some("findings")
+    );
+}
+
+#[tokio::test]
+async fn unscoped_behaviour_is_unchanged() {
+    let state = SharedState::new();
+    state.set("k", "v".into()).await.unwrap();
+    assert_eq!(state.get("k").await.as_deref(), Some("v"));
+    assert_eq!(state.keys().await, vec!["k".to_string()]);
+    assert!(state.scope().is_none());
+    assert!(state.summary().await.contains("k"));
+}


### PR DESCRIPTION
The two design items from the backbone audit, bundled so the break is paid once. Stacks conceptually on #107 (independent code; both touch `CHANGELOG.md`, so whichever lands second needs a trivial rebase).

## 1. `#[non_exhaustive]` on the five enums that actually grow

`AgentEvent`, `StreamEvent`, `StreamDelta`, `StopReason`, `ApiProtocol`. Every addition to these was previously a breaking change — which is precisely why #104 chose to *infer* compaction from token usage rather than add a `CompactionEnd` event. New variants are additive from here.

**Deliberately not marked:** the audit found 26 unmarked `pub enum`s; marking all of them would be vandalism. `Message`, `AgentMessage`, `FilterResult`, `ToolDecision` and the config enums are closed shapes — breaking every downstream `match` for growth we don't expect isn't a trade worth making. The error enums are a judgement call I'd rather make separately.

**The subtle part.** `tests/serialization_test.rs` carried a wire-tag freeze with an explicit comment: *"with NO wildcard arm on purpose: adding a variant fails to compile here until its wire tag is pinned."* An integration test is an external crate, so `#[non_exhaustive]` makes that match illegal — and the obvious fix, adding `_ => "unknown"`, would have **silently disabled a wire-contract safety net** while leaving the reassuring comment in place.

So the compile-time half moved into the crate as `types::wire_tag_freeze`, where exhaustiveness still applies. Verified rather than assumed: inserting a probe variant fails with `non-exhaustive patterns: &types::AgentEvent::TempProbe not covered`. The round-trip and payload-shape coverage stays in `tests/`.

## 2. `SharedState::scoped` — opt-in isolation

The audit flagged that any sub-agent can enumerate, read and overwrite every other sub-agent's keys. But **a shared flat namespace is the entire point of the type** — one artifact, many readers, no re-pasting into prompts. Forcing isolation would have broken its main use case, so this is a view you opt into:

```rust
let researcher = SubAgentTool::from_config("researcher", cfg.clone())
    .with_scoped_shared_state(state.clone(), "researcher");
```

- keys are prefixed **on the way in**, so a crafted key cannot escape the scope
- `keys()` and `summary()` report only that scope, prefix stripped
- the parent's unscoped handle still sees everything — that's what lets it collect results
- scoping nests, so a view narrows but never widens

`summary()` is the one that mattered: it's injected into the sub-agent's system prompt, so unscoped it disclosed every sibling's key names.

## Tests

Isolation is asserted through its failure modes, not just the happy path: siblings with the same key name stay independent, a sibling's `remove` doesn't reach across, escape attempts via plain keys / `../` / a literal separator character all fail, nesting narrows, the parent still sees everything, and unscoped behaviour is byte-identical to before.

501 tests green, clippy clean under `-Dwarnings`, all features.

## Release

Breaking → **0.17.0**. Version not bumped in this PR; happy to fold it in or leave it to a release PR, whichever you prefer given #107 is also in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)