### PR TITLE
release: 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.16.2
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Patch release per convention — exactly two files: `Cargo.toml` and `CHANGELOG.md` (`## Unreleased` renamed in place).

Carries #107: `allowed_paths` enforced across all five path-taking tools, credentials redacted from `Debug`, `BashTool` limits documented plus an opt-in env allowlist. Additive API only — the sandbox defaults to unrestricted, so no behaviour change unless opted into.

- [x] `cargo check --all-features` clean
- [x] version and CHANGELOG heading both read 0.16.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)