### PR TITLE
chore: enable GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# .github/FUNDING.yml
+github: yologdev
+# ko_fi: yuanhao


### PR DESCRIPTION
Adds `.github/FUNDING.yml` (same config as yoyo-evolve), which enables the **Sponsor** button in the repo header and issue sidebar.

One file, no README or docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)