### PR TITLE
fix: make the gasp extension path reachable (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- **The documented `gasp` extension path was unreachable**
+  ([#111](https://github.com/yologdev/yoagent/issues/111)). 0.16.0 re-exported
+  the types the `YoAgentState::record_*` methods *take* but not the receiver
+  they are called *on*, and `GaspRecorder` kept its state, store and actor
+  private — so an application could construct a `Task` and have nothing to
+  record it with. The workaround was a direct `yoagent-state` dependency,
+  precisely the version-skew hazard the doc comment warned against.
+
+  Both halves are fixed: `ActorRef`, `GitEventStore`, `Node`, `NodeId` and
+  `YoAgentState` are now re-exported, and `GaspRecorder` gained
+  [`state()`](https://docs.rs/yoagent/latest/yoagent/gasp/struct.GaspRecorder.html#method.state),
+  `store()` and `actor()`.
+
+  Prefer the accessors over opening your own store: a GASP repo is
+  single-writer behind a 600-second lease, so a second `GitEventStore` on the
+  same root collides with the recorder's rather than cooperating.
+
 ### Changed
 
 - **Breaking: `AgentEvent`, `StreamEvent`, `StreamDelta`, `StopReason` and

--- a/src/gasp.rs
+++ b/src/gasp.rs
@@ -48,18 +48,36 @@ use crate::types::*;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use yoagent_state::{
-    ActorRef, GitEventStore, Goal, NodeId, YoAgentModelCalled, YoAgentModelFinished,
-    YoAgentRunFinished, YoAgentRunStarted, YoAgentState, YoAgentStateAdapter, YoAgentStateSink,
-    YoAgentToolCalled, YoAgentToolFinished,
+    Goal, YoAgentModelCalled, YoAgentModelFinished, YoAgentRunFinished, YoAgentRunStarted,
+    YoAgentStateAdapter, YoAgentStateSink, YoAgentToolCalled, YoAgentToolFinished,
 };
 pub use yoagent_state::{GoalId, RunId, StateError};
-// The extension-path types (see [`GaspRecorder::with_store`]): everything the
-// `YoAgentState::record_*` methods take, so applications recording the
-// goal/task/verdict tier need no direct `yoagent-state` dependency (a
-// version-skewed duplicate produces baffling type errors).
+// The extension path (see [`GaspRecorder::state`]): applications recording the
+// goal/task/verdict tier need no direct `yoagent-state` dependency, so both
+// halves must be nameable here — the *arguments* to `YoAgentState::record_*`
+// and the *receiver* those methods are called on. Exporting only the arguments
+// left the path documented but unreachable (#111).
 pub use yoagent_state::{
-    Decision, DecisionStatus, EvalResult, EvalStatus, EventStore, Goal as GaspGoal, GoalStatus,
-    Hypothesis, Observation, StatePatch, Task, TaskId, TaskStatus,
+    // Receiver side.
+    ActorRef,
+    // Argument side.
+    Decision,
+    DecisionStatus,
+    EvalResult,
+    EvalStatus,
+    EventStore,
+    GitEventStore,
+    Goal as GaspGoal,
+    GoalStatus,
+    Hypothesis,
+    Node,
+    NodeId,
+    Observation,
+    StatePatch,
+    Task,
+    TaskId,
+    TaskStatus,
+    YoAgentState,
 };
 
 /// Which GASP goal recorded runs belong to (stamped into each run-boundary
@@ -211,6 +229,44 @@ impl GaspRecorder {
 
     /// The goal this recorder's runs belong to (persist it to reuse across
     /// processes via [`GoalRef::Existing`]).
+    /// The recorder's own [`YoAgentState`], for recording tiers this crate
+    /// does not model — goals, tasks, evals, decisions, patches.
+    ///
+    /// Prefer this over opening a second [`GitEventStore`] on the same root: a
+    /// GASP repo is single-writer behind a 600-second lease, so a second store
+    /// collides with this one rather than cooperating.
+    ///
+    /// ```no_run
+    /// # use yoagent::gasp::{GaspRecorder, GoalRef, Task, TaskId, TaskStatus};
+    /// # async fn demo(recorder: &GaspRecorder) -> Result<(), Box<dyn std::error::Error>> {
+    /// recorder.state().record_task(Task {
+    ///     id: TaskId::new("task_1"),
+    ///     title: "ship the thing".into(),
+    ///     summary: "planned this session".into(),
+    ///     status: TaskStatus::Open,
+    ///     goal: Some(recorder.goal().clone()),
+    ///     created_by: recorder.actor().clone(),
+    ///     metadata: serde_json::json!({}),
+    /// }).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn state(&self) -> &YoAgentState<GitEventStore> {
+        &self.state
+    }
+
+    /// The underlying event store, for callers that need it directly (e.g. to
+    /// scan events). Shares this recorder's lease — see [`state`](Self::state).
+    pub fn store(&self) -> &GitEventStore {
+        &self.store
+    }
+
+    /// The actor recorded events are attributed to — the first argument of the
+    /// `YoAgentState::record_*` methods.
+    pub fn actor(&self) -> &ActorRef {
+        &self.actor
+    }
+
     pub fn goal(&self) -> &GoalId {
         &self.goal
     }

--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -674,3 +674,84 @@ async fn tool_fingerprint_and_usage_reach_the_log() {
     assert!(usage["cache_read"].is_number());
     assert!(usage["cache_write"].is_number());
 }
+
+// ---------------------------------------------------------------------------
+// The documented extension path must actually be reachable (#111): recording
+// the goal/task/verdict tier alongside the recorder's run/tool tier, using
+// only `yoagent::gasp` — no direct `yoagent-state` dependency.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn extension_path_records_the_task_tier_without_a_direct_state_dependency() {
+    use yoagent::gasp::{ActorRef, NodeId, Task, TaskId, TaskStatus, YoAgentState};
+
+    ensure_git_identity();
+    let dir = tempfile::tempdir().unwrap();
+    let recorder = GaspRecorder::init(
+        dir.path(),
+        "test-agent",
+        "w1",
+        GoalRef::New {
+            title: "extension goal".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Every type the extension path needs must be nameable from `yoagent::gasp`.
+    let state: &YoAgentState<yoagent::gasp::GitEventStore> = recorder.state();
+    let actor: &ActorRef = recorder.actor();
+    let goal = recorder.goal().clone();
+
+    state
+        .record_task(Task {
+            id: TaskId::new("task_1"),
+            title: "ship the thing".into(),
+            summary: "planned this session".into(),
+            status: TaskStatus::Open,
+            goal: Some(goal.clone()),
+            created_by: actor.clone(),
+            metadata: serde_json::json!({"kind": "feature"}),
+        })
+        .await
+        .expect("record_task via the recorder's own state");
+
+    // And the graph is queryable — how a caller checks whether a node exists.
+    let graph = state.graph().await;
+    let node = graph
+        .nodes
+        .get(&NodeId::new("task_1"))
+        .expect("task folded into the graph");
+    assert_eq!(node.props["title"], "ship the thing");
+
+    // The task tier lands in the same log as the run tier, one writer.
+    let kinds = event_kinds_lenient(dir.path());
+    assert!(kinds.iter().any(|k| k == "task.created"), "got {kinds:?}");
+    assert!(kinds.iter().any(|k| k == "goal.created"), "got {kinds:?}");
+}
+
+#[tokio::test]
+async fn recorder_store_accessor_shares_the_lease_rather_than_colliding() {
+    use yoagent::gasp::EventStore;
+
+    ensure_git_identity();
+    let dir = tempfile::tempdir().unwrap();
+    let recorder = GaspRecorder::init(
+        dir.path(),
+        "test-agent",
+        "w1",
+        GoalRef::New {
+            title: "lease goal".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Reading through the recorder's own store works while it holds the lease.
+    // Opening a second GitEventStore on this root is what would collide.
+    let events = recorder.store().scan().await.expect("scan via accessor");
+    assert!(
+        events.iter().any(|e| e.kind == "goal.created"),
+        "expected the goal event through the shared store"
+    );
+}


### PR DESCRIPTION
Closes #111. Thanks for the report — the diagnosis was exactly right, and it's a regression from #105 where I added the argument side of the re-export and stopped there.

## The bug

0.16.0 documented recording the goal/task/verdict tier alongside `GaspRecorder`'s run/tool tier, and shipped a path that could not be taken:

- the re-export list covered the types `YoAgentState::record_*` **takes** but not the receiver they are called **on**
- `GaspRecorder` kept `state`, `store` and `actor` private, exposing only `goal()`

So a caller could construct a `Task` and had nothing to record it with, no actor to attribute it to, and no way to check whether the goal node already existed. The workaround — a direct `yoagent-state` dependency — is precisely the version-skew hazard the doc comment warned against.

## The fix — both halves

Either would technically unblock, but each alone leaves a rough edge, so both:

1. **Re-export the receiver side**: `ActorRef`, `GitEventStore`, `Node`, `NodeId`, `YoAgentState`. The module's private import list is now *merged into* the `pub use`, so the two cannot silently drift apart again — which is how this happened.
2. **`GaspRecorder::state()` / `store()` / `actor()`**, with a runnable doc example on `state()`.

The accessors are the better default and the docs now say why: a GASP repo is single-writer behind a 600-second lease, so a second `GitEventStore` on the same root collides with the recorder's rather than cooperating — the exact failure hit while implementing yoyo-evolve#683. `with_store` stays for callers who genuinely own the store.

## Test

The gap was a coverage gap as much as an API one: nothing exercised the extension path, so nothing noticed it was unreachable. New test walks the whole thing using **only `yoagent::gasp`** — records a `Task` through `recorder.state()`, reads it back out of the graph by `NodeId`, and asserts `task.created` and `goal.created` land in the same log. It fails to compile without the re-exports.

521 tests green, clippy clean under `-Dwarnings`, all features.

## Release

Additive → patch. Note `main` already carries #108's breaking changes unreleased, so this rides in **0.17.0** rather than a 0.16.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)