### PR TITLE
fix: MSRV-aware dependency resolution (resolver = "3")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **CI's MSRV job broke on unrelated PRs.** `Cargo.lock` is not committed, so
+  every run re-resolves to the newest compatible releases — and when `icu_*`
+  2.3.0 (via `reqwest` → `url` → `idna`) raised its own rust-version to 1.88,
+  the MSRV job started failing on `main` and every open PR without a commit
+  causing it. Setting `resolver = "3"` turns on cargo's MSRV-aware resolution,
+  so dependency versions are chosen against our `rust-version` instead of
+  ignoring it. No CI or dependency changes; downstream consumers resolve with
+  their own resolver and are unaffected.
+
 - **`allowed_paths` was declared but never enforced.** `ReadFileTool` accepted
   an allowlist of directory roots, defaulted it, and then ignored it — callers
   who set it believed reads were sandboxed and they were not. It is now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "yoagent"
 version = "0.16.2"
 edition = "2021"
+# MSRV-aware dependency resolution (cargo 1.84+): prefer dependency versions
+# whose own rust-version fits ours. Without it CI re-resolves to whatever is
+# newest and any transitive bump breaks the MSRV job on unrelated PRs.
+resolver = "3"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"
 repository = "https://github.com/yologdev/yoagent"


### PR DESCRIPTION
**`main` is currently red and no commit caused it.** Unblocks #112 and anything else open.

## What happened

`Cargo.lock` is not committed, so CI re-resolves dependencies every run. `icu_*` 2.3.0 (pulled via `reqwest` → `url` → `idna`) raised its own `rust-version` to **1.88**, above our declared **1.86** — so the MSRV job began failing everywhere at once.

Confirmed environmental rather than assumed: I re-ran the MSRV job on the **unchanged** `main` commit that passed on Aug 8. It now fails identically.

## The fix

One line in `Cargo.toml`:

```toml
resolver = "3"
```

That enables cargo's MSRV-aware resolution (cargo 1.84+, so available to any toolchain meeting our own MSRV). Cargo now says:

```
Adding icu_properties v2.2.0 (available: v2.3.0, requires Rust 1.88)
```

and resolves the compatible line instead of failing.

## Alternatives considered

- **Commit `Cargo.lock`** — fixes CI, but pins what we test against, so upstream breakage stops being visible until someone updates. Bigger change, ongoing maintenance.
- **Pin versions in the workflow** — needs nightly `-Zmsrv-policy` plus a `continue-on-error` fallback. I drafted it; it was materially worse to read and reason about.
- **Raise MSRV to 1.88** — a real cost to downstream users, imposed by a transitive dependency rather than anything we need.

`resolver = "3"` applies to this workspace only; downstream consumers resolve with their own resolver and are unaffected.

518 tests green locally with the new resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)