### PR TITLE
fix: correct Claude Sonnet 5 pricing and add measured cost to the live eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@ adheres to [Semantic Versioning](https://semver.org/).
   not have it: the maintenance branch would have been ahead of the development
   branch on this fix, so 0.17.0 would have regressed it.
 
+- **`ModelConfig::claude_sonnet_5` carried Sonnet 4.6's prices**, overstating
+  every `cost_usd` for that model by 50%. It shipped as $3/$15 per MTok
+  ($3.75 write, $0.30 read) against the published $2/$10 ($2.50 write, $0.20
+  read) — the introductory rate that has since become standard. Callers using
+  `CostConfig::cost_usd`, `Agent::session_cost_usd`, or the `cost_usd` field on
+  the `llm_stream` tracing span will see Sonnet 5 figures drop by a third.
+  Fable 5, Opus 5, Opus 4.8 and Haiku 4.5 were checked against the same table
+  and were correct.
+
 - **The `gasp` extension path could not construct its arguments**
   ([#115](https://github.com/yologdev/yoagent/issues/115)). The recorded
   structs were re-exported without the id types their fields require, so

--- a/docs/concepts/prompt-caching.md
+++ b/docs/concepts/prompt-caching.md
@@ -230,33 +230,63 @@ look roughly ten times cheaper than it is.
 | | DeepSeek v4 Flash | Claude Sonnet 5 |
 |---|---|---|
 | session hit rate | **79.0–83.7%** (n=5) | **75.5–79.2%** (n=5) |
-| steady-state turn | ~98% | ~81% |
+| mature-turn hit rate, median | **98.4%** | 88.8% |
+| mature-turn hit rate, peak | **99.7%** | 96.0% |
 | `cache_write` per session | **0** | 92,733 |
 | not-cached tokens from compaction | 91.9% | 49.6% |
+| session cost | **$0.031** | $0.783 |
+| cost per turn | **$0.0021** | $0.0392 |
+| same session with caching off | $0.066 (**−53%**) | $1.377 (**−43%**) |
+| output share of the bill | 73% | 61% |
 | turns | 14–15 | 19–20 |
 
 The session hit rate is measured across five runs per provider; the per-turn
 figures come from one run each, because earlier runs did not record per-turn
-`cache_write` and could not be re-derived.
+`cache_write` and could not be re-derived. Costs are computed from the recorded
+token counts at list prices — Anthropic's from `ModelConfig::claude_sonnet_5`,
+DeepSeek's at its **peak-window** rate (it charges half off-peak, so that column
+over-reports an off-peak run by up to 2×).
+
+**There is no single "steady-state" number.** Within one compaction cycle the
+hit rate climbs monotonically, because each turn adds a roughly constant amount
+of new content to a prefix that keeps growing: on DeepSeek the residual is
+26–158 tokens a turn, so it goes 88% → 95% → 99.6% across ten turns, then resets
+when compaction truncates the prefix. Quote the **peak** for what a mature prefix
+achieves and the **median** for what a session with this budget actually
+experiences; the median moves with how often you compact, so it is a property of
+your configuration, not of the provider.
+
+DeepSeek also quantises hits to 64-token blocks — every `cache_read` figure in
+that run is an exact multiple of 64 — so a trailing partial block is always
+uncached. That alone caps a single turn a fraction of a point below 100%.
 
 **Session rates are close; the mechanisms are not.** Both providers land near
 80%, even though yoagent places explicit `cache_control` breakpoints for
 Anthropic and sends nothing at all to DeepSeek. What differs is where the cost
 falls.
 
-**DeepSeek pays almost nothing between compactions.** Its steady-state turns run
-~98%: populating the cache is free, so the only non-cached tokens are the turn's
-genuinely new content. Consequently **92% of its non-cached tokens come from the
-two turns where compaction rewrote history** — for this provider, compaction is
-essentially the whole cache story.
+**DeepSeek pays almost nothing between compactions.** Populating the cache is
+free, so the only non-cached tokens are the turn's genuinely new content.
+Consequently **92% of its non-cached tokens come from the two turns where
+compaction rewrote history** — for this provider, compaction is essentially the
+whole cache story.
 
-**Anthropic pays a write premium continuously.** Every turn writes ~3,600–4,600
-tokens at 1.25× to extend the cached prefix, which holds steady-state turns near
-81% rather than 98%. Compaction accounts for only ~50% of its non-cached tokens;
-the other half is that ongoing write traffic. The trade is real rather than
-wasteful — those writes buy the 99%-cheap reads that follow — but it means the
-two providers reach a similar hit rate with materially different bills, which is
-the point of the section below.
+**Anthropic pays a write premium continuously.** Every turn writes ~2,000–4,600
+tokens at 1.25× to extend the cached prefix, which is why its curve climbs more
+slowly and tops out at 96% rather than 99.7%. Compaction accounts for only ~50%
+of its non-cached tokens; the other half is that ongoing write traffic. In
+dollars those writes cost **3.3× the reads they enable** ($0.232 vs $0.071) —
+which sounds damning until you price the counterfactual: the same session with
+caching off costs $1.377, so the writes are still a 43% saving. Buying reads with
+writes is the correct trade; it just means the two providers reach a similar hit
+rate with materially different bills.
+
+**Do not read the 25× cost gap as a caching result.** The two sessions are not
+matched: Sonnet ran 20 turns to DeepSeek's 15 and emitted 2.8× the output
+tokens, and output is the majority of both bills (61% and 73%). The comparison
+that is controlled is the *shape* — zero writes versus continuous writes, 92%
+versus 50% of waste attributable to compaction. The absolute dollars are one
+session each and should be treated as illustrative.
 
 One null result worth recording: lowering `DEFAULT_TRIGGER_RATIO` from 0.6 to
 0.35, on the theory that a slow summarizer needs more wall-clock headroom before

--- a/docs/evals/llm-compaction-live.md
+++ b/docs/evals/llm-compaction-live.md
@@ -29,26 +29,58 @@ the two are not comparable on `input` alone. The figures below supersede that.
 | | DeepSeek v4 Flash | Claude Sonnet 5 |
 |---|---|---|
 | session hit rate | **79.0–83.7%** (n=5) | **75.5–79.2%** (n=5) |
-| steady-state turn | ~98% | ~81% |
+| mature-turn hit rate, median | **98.4%** | 88.8% |
+| mature-turn hit rate, peak | **99.7%** | 96.0% |
 | `cache_write` per session | 0 | 92,733 |
 | not-cached from compaction | 91.9% | 49.6% |
+| session cost | **$0.031** | $0.783 |
+| cost per turn | **$0.0021** | $0.0392 |
+| same session with caching off | $0.066 (**−53%**) | $1.377 (**−43%**) |
+| output share of the bill | 73% | 61% |
 | turns | 14–15 | 19–20 |
 
 - **Session rates are close** despite yoagent placing explicit `cache_control`
   breakpoints for Anthropic and sending nothing to DeepSeek.
 - **DeepSeek's cost is almost entirely compaction** (91.9%): populating its cache
   is free, so between rewrites it pays only for genuinely new content.
-- **Anthropic pays continuously** — ~3,600–4,600 cache-write tokens per turn at
-  1.25× — which is why its steady-state sits near 81% and compaction is only
-  half its non-cached total. Those writes buy the cheap reads that follow.
+- **Anthropic pays continuously** — ~2,000–4,600 cache-write tokens per turn at
+  1.25× — so its curve climbs more slowly and tops out at 96%, and compaction is
+  only half its non-cached total. Those writes cost 3.3× the reads they enable
+  ($0.232 vs $0.071) yet still leave the session 43% cheaper than no caching at
+  all, so the trade is right even though the ratio looks wrong.
 - **Trigger ratio 0.6 → 0.35 was a null result** across eight earlier runs.
 
+**"Steady state" is a range, not a number.** Within a compaction cycle the hit
+rate climbs monotonically — each turn adds a roughly fixed amount of new content
+(26–158 tokens on DeepSeek, 532–4,592 on Sonnet) to a prefix that keeps growing —
+then resets when compaction truncates the prefix. DeepSeek's cycle reads 88.3 →
+92.8 → 95.2 → … → 99.6%. The **peak** is what a mature prefix achieves; the
+**median** is what this budget actually delivers, and it moves with compaction
+frequency, so it describes the configuration rather than the provider. A
+supporting floor on DeepSeek: it quantises hits to 64-token blocks (every
+`cache_read` in the run is an exact multiple of 64), so a trailing partial block
+never hits.
+
+An earlier version of this page reported Sonnet's steady state as ~81%. That was
+read off the middle of its ramp rather than computed, and it understated the
+mature-prefix figure by 15 points.
+
 Session hit rate spans five runs per provider — that metric always counted
-`cache_write` and was unaffected by the bug. The per-turn figures (steady state,
-compaction share) are n=1 each: earlier runs did not record per-turn
+`cache_write` and was unaffected by the bug. The per-turn figures (mature-turn
+rates, compaction share, cost) are n=1 each: earlier runs did not record per-turn
 `cache_write`, so they could not be re-derived and had to be re-measured.
 
-Session lengths differ, so percentages compare and absolute totals do not.
+Costs come from the recorded token counts at list prices —
+`ModelConfig::claude_sonnet_5` ($2/$10 per MTok, $2.50 write, $0.20 read) and
+DeepSeek's **peak-window** rate, which is double its off-peak rate, so that
+column over-reports an off-peak run by up to 2×.
+
+**The 25× cost gap is not a caching result.** The sessions are not matched:
+Sonnet ran 20 turns to DeepSeek's 15 and emitted 2.8× the output tokens, and
+output is the majority of both bills. What the runs do compare cleanly is the
+shape — zero writes versus continuous writes, 92% versus 50% of non-cached
+tokens attributable to compaction. Session lengths differ, so percentages
+compare and absolute totals do not.
 
 ### Why these numbers are lower than the replay figures
 
@@ -88,7 +120,9 @@ git checkout feat/llm-compaction
 # prefix-cache measurements (no API key needed)
 cargo test --test prefix_cache_harness -- --ignored --nocapture --test-threads=1
 
-# live briefing evaluation (needs ANTHROPIC_API_KEY; ~$0.15/run)
+# live briefing evaluation (needs ANTHROPIC_API_KEY; measured $0.78 for a
+# 20-turn Sonnet 5 run — set YO_MAX_TURNS lower to spend less, or point
+# YO_MODEL/YO_SUMMARIZER at deepseek-v4-flash for ~$0.03)
 cargo run --example llm_compaction_live --features gasp
 
 # harness plumbing only, no key, no bill

--- a/examples/llm_compaction_live.rs
+++ b/examples/llm_compaction_live.rs
@@ -34,7 +34,9 @@ use std::sync::Arc;
 use yoagent::context::ContextConfig;
 use yoagent::gasp::{GaspRecorder, GoalRef};
 use yoagent::llm_compaction::SUMMARY_MARKER;
-use yoagent::provider::{ModelConfig, ProviderError, StreamConfig, StreamEvent, StreamProvider};
+use yoagent::provider::{
+    CostConfig, ModelConfig, ProviderError, StreamConfig, StreamEvent, StreamProvider,
+};
 use yoagent::*;
 
 /// Dry-run double (`YO_DRY_RUN=1`): bulky deterministic text, so the harness's
@@ -99,14 +101,35 @@ fn priced(id: &str) -> ModelConfig {
         // `cache_control` on the OpenAI-compat path, and `openai_compat.rs`
         // maps `prompt_cache_hit_tokens` onto `Usage::cache_read`. So a hit
         // rate here measures *their* caching, not yoagent's placement.
-        // `ModelConfig::deepseek` carries no rates, so the cost column stays
-        // blank rather than this harness guessing at prices.
+        //
+        // Rates live here rather than in `ModelConfig::deepseek` because
+        // DeepSeek prices by time of day — off-peak is exactly half of peak
+        // (peak = 01:00-04:00 and 06:00-10:00 UTC). A crate-level preset would
+        // be wrong half the day. These are the **peak** rates, so the cost
+        // column over-reports rather than under-reports off-peak runs.
+        // DeepSeek has no cache-write category at all: populating its cache
+        // is free, which is the asymmetry the provider comparison turns on.
+        "deepseek-v4-flash" => deepseek_priced("deepseek-v4-flash", 0.44, 1.32, 0.014),
+        "deepseek-v4-pro" => deepseek_priced("deepseek-v4-pro", 1.32, 3.96, 0.044),
         other if other.starts_with("deepseek") => ModelConfig::deepseek(other, other),
         other => {
             eprintln!("note: no priced preset for '{other}' — the cost column will be blank");
             ModelConfig::anthropic(other, other)
         }
     }
+}
+
+/// A DeepSeek config carrying peak-window rates. `cache_write` is 0 because
+/// DeepSeek has no write category — populating its cache is free.
+fn deepseek_priced(id: &str, input: f64, output: f64, cache_read: f64) -> ModelConfig {
+    let mut config = ModelConfig::deepseek(id, id);
+    config.cost = CostConfig {
+        input_per_million: input,
+        output_per_million: output,
+        cache_read_per_million: cache_read,
+        cache_write_per_million: 0.0,
+    };
+    config
 }
 
 fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -515,10 +515,10 @@ impl ModelConfig {
             context_window: 1_000_000,
             max_tokens: 64_000,
             cost: CostConfig {
-                input_per_million: 3.0,
-                output_per_million: 15.0,
-                cache_read_per_million: 0.3,
-                cache_write_per_million: 3.75,
+                input_per_million: 2.0,
+                output_per_million: 10.0,
+                cache_read_per_million: 0.2,
+                cache_write_per_million: 2.5,
             },
             ..Self::anthropic("claude-sonnet-5", "Claude Sonnet 5")
         }
@@ -1006,7 +1006,7 @@ mod tests {
 
         let sonnet = ModelConfig::claude_sonnet_5();
         assert_eq!(sonnet.id, "claude-sonnet-5");
-        assert_eq!(sonnet.cost.output_per_million, 15.0);
+        assert_eq!(sonnet.cost.output_per_million, 10.0);
 
         let haiku = ModelConfig::claude_haiku_4_5();
         assert_eq!(haiku.id, "claude-haiku-4-5");


### PR DESCRIPTION
`ModelConfig::claude_sonnet_5` shipped **Sonnet 4.6's rates** — $3/$15 per MTok
($3.75 write, $0.30 read) against the published **$2/$10** ($2.50 write, $0.20
read). Every `cost_usd` for that model was overstated by 50%.

Affected: `CostConfig::cost_usd`, `Agent::session_cost_usd`, and the `cost_usd`
field recorded on the `llm_stream` tracing span.

Fable 5, Opus 5, Opus 4.8 and Haiku 4.5 were audited against the same published
table and are correct — Sonnet 5 was the only stale preset.

## The live eval gains a cost column

`ModelConfig::deepseek` carries no rates, so that run had been reporting
`$0.0000`. The harness now prices `deepseek-v4-flash` and `-pro` itself rather
than the crate, because DeepSeek halves its prices off-peak and a crate constant
would be wrong half the day. Peak rates are used, so the column over-reports an
off-peak run rather than under-reporting it.

| | DeepSeek v4 Flash | Claude Sonnet 5 |
|---|---|---|
| session hit rate | **79.0–83.7%** (n=5) | **75.5–79.2%** (n=5) |
| mature-turn hit rate, median | **98.4%** | 88.8% |
| mature-turn hit rate, peak | **99.7%** | 96.0% |
| `cache_write` per session | **0** | 92,733 |
| not-cached from compaction | 91.9% | 49.6% |
| session cost | **$0.031** | $0.783 |
| cost per turn | **$0.0021** | $0.0392 |
| same session with caching off | $0.066 (**−53%**) | $1.377 (**−43%**) |
| output share of the bill | 73% | 61% |
| turns | 14–15 | 19–20 |

## Two corrections to previously reported numbers

**Sonnet's "steady state ~81%" was read off the middle of its ramp rather than
computed.** The mature-turn median is 88.8% and the peak 96.0%. Within a
compaction cycle the hit rate climbs monotonically — a roughly constant per-turn
residual against a growing prefix — so a single steady-state figure was never
well defined. Both docs now report median *and* peak, and note that the median
tracks compaction frequency, i.e. configuration rather than provider.

**DeepSeek quantises hits to 64-token blocks.** Every `cache_read` in the run is
an exact multiple of 64, so a trailing partial block never hits. That is the
floor under its 99.7%.

## Confounds kept attached to the dollar figures

The sessions are not matched — 20 turns vs 15, and 2.8× the output tokens — and
output is the majority of both bills, so the 25× gap is mostly **not** a caching
result. What compares cleanly is the shape: zero writes vs continuous writes,
92% vs 50% of non-cached tokens from compaction.

Sonnet's writes cost **3.3× the reads they enable** ($0.232 vs $0.071), which
reads as damning until you price the counterfactual: the same session with
caching off costs $1.377, so the writes are still a 43% saving. The trade is
right even where the ratio looks wrong.

## Verification

- 502 tests pass, 0 failed, across 24 binaries (`cargo test --features gasp`)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- Test count unchanged from before the fix; the updated assertion is the only
  test touched

## Note for the release cut

This is a behaviour change for anyone reading `cost_usd`, currently queued in
`Unreleased` behind 0.17.0's breaking changes. It touches one constant, one
assertion, and docs — it cherry-picks cleanly onto the 0.16.x maintenance line
if it should not wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)