### PR TITLE
fix: forward-port the gasp method-surface closure (#117) to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 
 > The fixes below also shipped on the **0.16.x maintenance line** — the gasp
-> extension-path and MSRV fixes in [0.16.3], and the gasp id types in [0.16.4]
-> — cut from `v0.16.2` so consumers could take them without the breaking
-> changes queued here for 0.17.0.
+> extension-path and MSRV fixes in [0.16.3], the gasp id types in [0.16.4], and
+> the method-surface closure in [0.16.5] — cut from `v0.16.2` so consumers could
+> take them without the breaking changes queued here for 0.17.0.
 
 ### Added
 
@@ -92,6 +92,24 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The `gasp` method surface is now closed mechanically, not by judgement**
+  ([#117](https://github.com/yologdev/yoagent/issues/117)). Three rounds of the
+  same bug — [#111] (the receiver), [#115] (the recorded structs' id types),
+  [#117] (those structs' *field* types and every `YoAgentState` method's
+  argument types) — each found one more tier of `yoagent-state` type that the
+  documented extension path needs but could not name. (3) subsumes the others:
+  a struct can be constructible without being usable, because a smart
+  constructor defaults a field whose type the caller can never name.
+
+  Now also re-exported: `Event`, `EventId`, `Frame`, `FrameId`, `ModelCall`,
+  `PatchStatus`, `ProjectSnapshot`, and `ToolCall as GaspToolCall`. The rule is
+  enforced by `tests/gasp_test.rs` rather than by inspection, which is what
+  makes a fourth round unlikely.
+
+  Forward-ported from the 0.16.x line, where it shipped as [0.16.5]. `main` did
+  not have it: the maintenance branch would have been ahead of the development
+  branch on this fix, so 0.17.0 would have regressed it.
+
 - **The `gasp` extension path could not construct its arguments**
   ([#115](https://github.com/yologdev/yoagent/issues/115)). The recorded
   structs were re-exported without the id types their fields require, so
@@ -114,6 +132,10 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 [0.16.3]: https://github.com/yologdev/yoagent/releases/tag/v0.16.3
 [0.16.4]: https://github.com/yologdev/yoagent/releases/tag/v0.16.4
+[0.16.5]: https://github.com/yologdev/yoagent/releases/tag/v0.16.5
+[#111]: https://github.com/yologdev/yoagent/issues/111
+[#115]: https://github.com/yologdev/yoagent/issues/115
+[#117]: https://github.com/yologdev/yoagent/issues/117
 
 
 ### Fixed

--- a/src/gasp.rs
+++ b/src/gasp.rs
@@ -51,46 +51,26 @@ use yoagent_state::{
     Goal, YoAgentModelCalled, YoAgentModelFinished, YoAgentRunFinished, YoAgentRunStarted,
     YoAgentStateAdapter, YoAgentStateSink, YoAgentToolCalled, YoAgentToolFinished,
 };
-pub use yoagent_state::{GoalId, RunId, StateError};
 // The extension path (see [`GaspRecorder::state`]): applications recording the
-// goal/task/verdict tier need no direct `yoagent-state` dependency, so both
-// halves must be nameable here — the *arguments* to `YoAgentState::record_*`
-// and the *receiver* those methods are called on. Exporting only the arguments
-// left the path documented but unreachable (#111).
+// goal/task/verdict tier need no direct `yoagent-state` dependency, so every
+// type on that path must be nameable here. Three rounds of bug reports each
+// found one tier still missing, so the rule is now mechanical rather than
+// judged — see `tests/gasp_test.rs`:
+//
+//   1. the receiver (`YoAgentState`) and what it needs        — #111
+//   2. the recorded structs and their id types                — #115
+//   3. those structs' *field* types, and the argument types
+//      of every `YoAgentState` method                         — #117
+//
+// (3) is the one that subsumes the others: a struct can be constructible
+// without being usable, because a smart constructor defaults a field whose
+// type the caller can never name.
 pub use yoagent_state::{
-    // Receiver side: what `record_*` is called on, and what it needs.
-    ActorRef,
-    // ...and every id / field type needed to *construct* them. A struct whose
-    // id type is missing is nameable but unbuildable — the gap behind #111 and
-    // #115, invisible by inspection because the list looks complete.
-    ArtifactRef,
-    // Argument side: the recorded structs...
-    Decision,
-    DecisionId,
-    // ...their status enums...
-    DecisionStatus,
-    EvalId,
-    EvalResult,
-    EvalStatus,
-    EventStore,
-    ExpectedEffect,
-    GitEventStore,
-    Goal as GaspGoal,
-    GoalStatus,
-    Hypothesis,
-    HypothesisId,
-    Node,
-    NodeId,
-    Observation,
-    ObservationId,
-    PatchId,
-    Precondition,
-    ProjectRef,
-    StateOp,
-    StatePatch,
-    Task,
-    TaskId,
-    TaskStatus,
+    ActorRef, ArtifactRef, Decision, DecisionId, DecisionStatus, EvalId, EvalResult, EvalStatus,
+    Event, EventId, EventStore, ExpectedEffect, Frame, FrameId, GitEventStore, Goal as GaspGoal,
+    GoalId, GoalStatus, Hypothesis, HypothesisId, ModelCall, Node, NodeId, Observation,
+    ObservationId, PatchId, PatchStatus, Precondition, ProjectRef, ProjectSnapshot, RunId,
+    StateError, StateOp, StatePatch, Task, TaskId, TaskStatus, ToolCall as GaspToolCall,
     YoAgentState,
 };
 

--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -837,3 +837,57 @@ fn every_reexported_struct_is_constructible_from_gasp_alone() {
     let _evidence: Vec<NodeId> = vec![NodeId::new("node_1")];
     let _artifacts: Vec<ArtifactRef> = Vec::new();
 }
+
+/// Stronger than the test above, and the reason #117 slipped past it:
+/// **constructibility is weaker than usability.** `StatePatch::new` defaults
+/// `status: PatchStatus::Proposed` internally, so a `StatePatch` can be built
+/// without the caller ever naming `PatchStatus` — construction passed while
+/// the type stayed unreachable, and advancing a patch was impossible.
+///
+/// Binding each field to an explicitly named type closes that: a field whose
+/// type is not re-exported fails to compile here. Same for the argument types
+/// of the `YoAgentState` methods the extension path calls — re-exporting the
+/// receiver makes them callable in principle, so their arguments must be
+/// nameable too.
+///
+/// This test exists to *compile*.
+#[test]
+fn every_field_and_argument_type_is_nameable_from_gasp_alone() {
+    use yoagent::gasp::{
+        ActorRef, ArtifactRef, DecisionStatus, EvalStatus, Event, EventId, ExpectedEffect, Frame,
+        FrameId, GoalId, GoalStatus, ModelCall, NodeId, PatchId, PatchStatus, Precondition,
+        ProjectRef, ProjectSnapshot, RunId, StateOp, StatePatch, TaskStatus,
+    };
+
+    let patch = StatePatch::new(PatchId::new("p1"), "t", "s", ActorRef::agent("yoyo"));
+
+    // Every field bound to a named type. `status` is the one #117 was about.
+    let _: PatchId = patch.id.clone();
+    let _: PatchStatus = patch.status.clone();
+    let _: u64 = patch.base_state_version;
+    let _: Option<ProjectRef> = patch.base_project_ref.clone();
+    let _: Vec<StateOp> = patch.ops.clone();
+    let _: Vec<Precondition> = patch.preconditions.clone();
+    let _: Vec<ExpectedEffect> = patch.expected_effects.clone();
+    let _: Vec<NodeId> = patch.evidence.clone();
+    let _: Vec<ArtifactRef> = patch.artifacts.clone();
+
+    // The status enums a caller compares or assigns.
+    let _: [PatchStatus; 1] = [PatchStatus::Proposed];
+    let _: [TaskStatus; 1] = [TaskStatus::Open];
+    let _: [GoalStatus; 1] = [GoalStatus::Open];
+    let _: [EvalStatus; 1] = [EvalStatus::Passed];
+    let _: [DecisionStatus; 1] = [DecisionStatus::Pending];
+
+    // Argument types of the remaining YoAgentState methods, so "the receiver
+    // is re-exported" actually means its methods can be called.
+    fn _takes<T>(_: Option<T>) {}
+    _takes::<Event>(None);
+    _takes::<EventId>(None);
+    _takes::<Frame>(None);
+    _takes::<FrameId>(None);
+    _takes::<ModelCall>(None);
+    _takes::<ProjectSnapshot>(None);
+    _takes::<GoalId>(None);
+    _takes::<RunId>(None);
+}


### PR DESCRIPTION
[#118](https://github.com/yologdev/yoagent/pull/118) landed the #117 fix on
`release/0.16.3` only. `main` had **none** of it — its `src/gasp.rs` re-export
block was byte-identical to the pre-fix state — so 0.17.0 would have shipped the
regression, and the maintenance branch would have been ahead of the development
branch on a fix. That inversion is how this bug class keeps coming back.

## What transfers

Re-exports added: `Event`, `EventId`, `Frame`, `FrameId`, `ModelCall`,
`PatchStatus`, `ProjectSnapshot`, `ToolCall as GaspToolCall`.

Plus the test that closes the surface **mechanically rather than by
inspection** — the part that actually matters, since three rounds of human
review each missed one more tier:

| round | what was missing | issue |
|---|---|---|
| 1 | the receiver (`YoAgentState`) and what it needs | [#111](https://github.com/yologdev/yoagent/issues/111) |
| 2 | the recorded structs and their id types | [#115](https://github.com/yologdev/yoagent/issues/115) |
| 3 | those structs' *field* types, and every `YoAgentState` method's argument types | [#117](https://github.com/yologdev/yoagent/issues/117) |

Round 3 subsumes the others: a struct can be constructible without being
usable, because a smart constructor defaults a field whose type the caller can
never name. That is invisible to inspection — the re-export list *looks*
complete — which is why it needed a test instead.

## One difference between the branches, handled

`src/gasp.rs` was identical on both, so it transfers verbatim.
`tests/gasp_test.rs` was not: `main` carries a `_ => "Unknown"` match arm the
0.16.x line has no need for, because `AgentEvent` is `#[non_exhaustive]` here
and gained `ContextCompacted`. That arm is preserved — taking the maintenance
file wholesale would have broken the build.

The `Cargo.toml` version bump stays behind on the maintenance line; only the
fix and its test come forward, with a CHANGELOG entry under `Unreleased`.

## Verification

- 503 tests pass, 0 failed (502 before; +1 is the new surface test)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean

## Note

`release/0.16.3` is now at `version = "0.16.5"` in `Cargo.toml` but has **no
`v0.16.5` tag or GitHub Release**, so it is staged-but-unpublished. The
`[0.16.5]` link in this CHANGELOG entry will 404 until that release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)