### PR TITLE
feat: session telemetry rollup on AgentEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,47 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `StopReason` is documented as `#[non_exhaustive]`, which it has been since
   0.17.0 — the doc comment still claimed the opposite.
 
+- **`AgentEvent::AgentEnd` carries a `SessionStats` rollup**
+  ([#124](https://github.com/yologdev/yoagent/issues/124)). Every per-turn
+  number already existed — `Usage` on each assistant message, `tokens_cached`
+  on the `llm_stream` span, `cache_read` in the GASP record — but nothing
+  summed them, so "what was this run's cache hit rate" meant replaying the
+  event stream. Cache-affecting changes were judged by hand-built harnesses
+  instead of a number the library reports; #123 and the #119 evaluation both
+  had to do exactly that.
+
+  ```rust,ignore
+  AgentEvent::AgentEnd { stats, .. } => {
+      println!("{:.1}% cached over {} turns", stats.cache_hit_rate() * 100.0, stats.turns);
+  }
+  ```
+
+  Carries summed `usage`, `turns`, `cost_usd` when rates are configured, and
+  `compactions`. Hit rate delegates to `Usage::cache_hit_rate` so there is one
+  definition rather than two that drift — and it counts `cache_write` against
+  you, because those are prompt tokens the provider processed and billed.
+
+  `usage.total_tokens` is deliberately **not** summed and stays 0. It is a
+  per-response provider report and the providers disagree: `anthropic.rs` never
+  sets it, `bedrock.rs` computes `input + output` and excludes cache, and the
+  rest pass through a payload value that includes cached tokens. Summing it
+  would launder that into a session-level figure that reads as authoritative
+  and is 0 for every Anthropic run. Derive a total from the four components.
+
+  Scope: a run's own turns. `SubAgentTool` runs its own loop on a private
+  channel, so a delegating agent's real spend is higher than this reports.
+
+  `compactions` counts turns where the strategy changed the message count *or*
+  the token total, so in-place tool-output truncation is included rather than
+  missed by a length check. It is deliberately not split into spliced-summary
+  vs deterministic fallback and carries no summarization spend: that detail
+  lives on `AgentEvent::ContextCompacted`, and `CompactionStrategy::compact` is
+  synchronous with no event channel, so the loop cannot see it. Wire
+  `LlmCompaction::with_event_sender` to the same channel to aggregate both.
+
+  The GASP run-close record now carries the same rollup, so an audit can
+  compare runs without replaying every `model.finished` entry.
+
 - **`CacheStrategy` is no longer Anthropic-only**
   ([#123](https://github.com/yologdev/yoagent/issues/123)). The 0.16.x line
   engineered byte-stable compaction so cached prefixes survive — and that
@@ -142,6 +183,19 @@ adheres to [Semantic Versioning](https://semver.org/).
   automatic — with a per-protocol table. Anthropic behaviour is unchanged.
 
 ### Changed
+
+- **Breaking: `AgentEvent::AgentEnd` gained a `stats` field** and the variant is
+  now `#[non_exhaustive]`. Match with `..`, and construct via
+  `AgentEvent::agent_end(messages, stats)` rather than a struct literal. The
+  field and every `SessionStats` field carry `#[serde(default)]`, so archived
+  event streams written before this release still deserialize — `AgentEvent` is
+  a frozen wire format, and a missing-field error would have broken every
+  replay consumer.
+
+- **Breaking: `MockResponse` is `#[non_exhaustive]`** and gained
+  `TextWithUsage(String, Usage)`, so a test can set a turn's usage. `Text`
+  reports `Usage::default()`, which cannot distinguish a rollup that sums from
+  one that copies the last turn.
 
 - **Breaking: `CacheConfig` is `#[non_exhaustive]`** and gained `session_key`.
   Construct with `CacheConfig::new()` / `::disabled()` / `::default()` and the

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -51,12 +51,33 @@ fn print_banner() {
     println!("{DIM}  Type /quit to exit, /clear to reset{RESET}\n");
 }
 
-fn print_usage(usage: &Usage) {
-    if usage.input > 0 || usage.output > 0 {
+/// Print the session rollup that `AgentEnd` carries.
+///
+/// Hit rate counts `cache_write` against you — those are prompt tokens the
+/// provider processed and billed. Read it against the session length rather
+/// than against 100%: every turn's new content is necessarily a miss.
+fn print_stats(stats: &SessionStats) {
+    let u = &stats.usage;
+    if u.input == 0 && u.output == 0 && u.cache_read == 0 && u.cache_write == 0 {
+        return;
+    }
+    println!(
+        "\n{DIM}  tokens: {} in / {} out over {} turn(s){RESET}",
+        u.input, u.output, stats.turns
+    );
+    if u.cache_read > 0 || u.cache_write > 0 {
         println!(
-            "\n{DIM}  tokens: {} in / {} out{RESET}",
-            usage.input, usage.output
+            "{DIM}  cache: {:.1}% hit ({} read, {} write){RESET}",
+            stats.cache_hit_rate() * 100.0,
+            u.cache_read,
+            u.cache_write
         );
+    }
+    if stats.compactions > 0 {
+        println!("{DIM}  compactions: {}{RESET}", stats.compactions);
+    }
+    if let Some(cost) = stats.cost_usd {
+        println!("{DIM}  cost: ${cost:.4}{RESET}");
     }
 }
 
@@ -197,7 +218,7 @@ async fn main() {
 
         // Send to agent
         let mut rx = agent.prompt(input).await;
-        let mut last_usage = Usage::default();
+        let mut session_stats = SessionStats::default();
         let mut in_text = false;
 
         while let Some(event) = rx.recv().await {
@@ -292,14 +313,8 @@ async fn main() {
                         .unwrap_or("request declined by the model's safety system");
                     println!("{RED}  refused: {msg}{RESET}");
                 }
-                AgentEvent::AgentEnd { messages } => {
-                    // Extract usage from the last assistant message
-                    for msg in messages.iter().rev() {
-                        if let AgentMessage::Llm(Message::Assistant { usage, .. }) = msg {
-                            last_usage = usage.clone();
-                            break;
-                        }
-                    }
+                AgentEvent::AgentEnd { stats, .. } => {
+                    session_stats = stats.clone();
                 }
                 _ => {}
             }
@@ -308,7 +323,7 @@ async fn main() {
         if in_text {
             println!();
         }
-        print_usage(&last_usage);
+        print_stats(&session_stats);
         println!();
     }
 

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -157,7 +157,11 @@ pub async fn agent_loop(
                         reason: reason.clone(),
                     })
                     .ok();
-                    tx.send(AgentEvent::AgentEnd { messages: vec![] }).ok();
+                    tx.send(AgentEvent::AgentEnd {
+                        messages: vec![],
+                        stats: SessionStats::default(),
+                    })
+                    .ok();
                     return vec![];
                 }
             }
@@ -208,15 +212,16 @@ pub async fn agent_loop(
         .ok();
     }
 
-    {
+    let stats = {
         use tracing::Instrument;
         run_loop(context, &mut new_messages, config, &tx, &cancel)
             .instrument(tracing::info_span!("agent_loop", model = %config.model))
-            .await;
-    }
+            .await
+    };
 
     tx.send(AgentEvent::AgentEnd {
         messages: new_messages.clone(),
+        stats,
     })
     .ok();
     new_messages
@@ -246,15 +251,16 @@ pub async fn agent_loop_continue(
     tx.send(AgentEvent::AgentStart).ok();
     tx.send(AgentEvent::TurnStart).ok();
 
-    {
+    let stats = {
         use tracing::Instrument;
         run_loop(context, &mut new_messages, config, &tx, &cancel)
             .instrument(tracing::info_span!("agent_loop", model = %config.model))
-            .await;
-    }
+            .await
+    };
 
     tx.send(AgentEvent::AgentEnd {
         messages: new_messages.clone(),
+        stats,
     })
     .ok();
     new_messages
@@ -270,7 +276,8 @@ async fn run_loop(
     config: &AgentLoopConfig,
     tx: &mpsc::UnboundedSender<AgentEvent>,
     cancel: &tokio_util::sync::CancellationToken,
-) {
+) -> SessionStats {
+    let mut stats = SessionStats::default();
     let mut first_turn = true;
     let mut turn_number: usize = 0;
     // Rolling growth measurement feeding `compact_headroom_turns`.
@@ -294,7 +301,7 @@ async fn run_loop(
     // Outer loop: follow-ups after agent would stop
     loop {
         if cancel.is_cancelled() {
-            return;
+            return stats;
         }
 
         let mut steering_after_tools: Option<Vec<AgentMessage>> = None;
@@ -302,7 +309,7 @@ async fn run_loop(
         // Inner loop: runs at least once, then continues if tool calls or pending messages
         loop {
             if cancel.is_cancelled() {
-                return;
+                return stats;
             }
 
             if !first_turn {
@@ -347,14 +354,14 @@ async fn run_loop(
                     .ok();
                     context.messages.push(limit_msg.clone());
                     new_messages.push(limit_msg);
-                    return;
+                    return stats;
                 }
             }
 
             // before_turn callback — abort if it returns false
             if let Some(ref before_turn) = config.before_turn {
                 if !before_turn(&context.messages, turn_number) {
-                    return;
+                    return stats;
                 }
             }
 
@@ -451,13 +458,22 @@ async fn run_loop(
                     .as_deref()
                     .unwrap_or(&DefaultCompaction);
                 let before_len = context.messages.len();
+                // Already computed above over the same unmutated history.
+                let before_tokens = estimated;
                 context.messages =
                     strategy.compact(std::mem::take(&mut context.messages), effective_config);
-                if context.messages.len() != before_len {
-                    // Messages shifted; re-baseline from the next real usage.
+                let after_tokens = context::total_tokens(&context.messages);
+                // Length alone would miss level-1 truncation, which rewrites
+                // tool outputs in place and leaves the count unchanged — and
+                // that is exactly the case where the tracker's baseline goes
+                // stale, so both the reset and the counter key off the same
+                // test rather than the reset keying off length alone.
+                if context.messages.len() != before_len || after_tokens != before_tokens {
+                    // History moved; re-baseline from the next real usage.
                     context_tracker.reset();
+                    stats.compactions += 1;
                 }
-                last_context_tokens = Some(context::total_tokens(&context.messages));
+                last_context_tokens = Some(after_tokens);
             }
 
             // Stream assistant response, under an llm_stream span that
@@ -502,6 +518,7 @@ async fn run_loop(
             new_messages.push(agent_msg.clone());
             if let Message::Assistant { usage, .. } = &message {
                 context_tracker.record_usage(usage, context.messages.len() - 1);
+                stats.record_turn(usage, config.model_config.as_ref().map(|mc| &mc.cost));
             }
 
             // Check for error/abort
@@ -528,7 +545,7 @@ async fn run_loop(
                         tool_results: vec![],
                     })
                     .ok();
-                    return;
+                    return stats;
                 }
             }
 
@@ -648,6 +665,8 @@ async fn run_loop(
 
         break;
     }
+
+    stats
 }
 
 /// Stream an assistant response from the LLM.

--- a/src/gasp.rs
+++ b/src/gasp.rs
@@ -480,11 +480,30 @@ async fn record_event(
             // durable log.
             tracking.outcome = "rejected".to_string();
         }
-        AgentEvent::AgentEnd { .. } if tracking.started && !tracking.finished => {
+        AgentEvent::AgentEnd { stats, .. } if tracking.started && !tracking.finished => {
+            // The session rollup goes into the durable record so an audit can
+            // compare runs without replaying every model.finished entry.
             sink.on_run_finished(YoAgentRunFinished {
                 run_id: tracking.run_id.clone(),
                 outcome: tracking.outcome.clone(),
-                metadata: serde_json::json!({}),
+                metadata: {
+                    // Serialize the struct rather than hand-building the
+                    // object: a second hand-maintained shape would drift from
+                    // the event wire format, and an auditor comparing the two
+                    // would silently be comparing different keys.
+                    let mut m = serde_json::to_value(stats).unwrap_or_else(
+                        |_| serde_json::json!({ "error": "session stats not serializable" }),
+                    );
+                    // Derived, so it is not a struct field — but it is the
+                    // number an audit actually reads.
+                    if let Some(obj) = m.as_object_mut() {
+                        obj.insert(
+                            "cacheHitRate".into(),
+                            serde_json::json!(stats.cache_hit_rate()),
+                        );
+                    }
+                    m
+                },
             })
             .await?;
             tracking.finished = true;

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -5,11 +5,20 @@ use crate::types::*;
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
-/// A mock response: either plain text or tool calls
+/// A mock response: either plain text or tool calls.
+///
+/// `#[non_exhaustive]`: this is a test double whose shapes grow with the
+/// features under test — `TextWithUsage` was itself a later addition.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum MockResponse {
     Text(String),
     ToolCalls(Vec<MockToolCall>),
+    /// Text plus a chosen `Usage`, for asserting on token accounting.
+    ///
+    /// `Text` reports `Usage::default()`, which cannot distinguish a rollup
+    /// that sums from one that copies the last turn.
+    TextWithUsage(String, Usage),
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +81,21 @@ impl StreamProvider for MockProvider {
         let _ = tx.send(StreamEvent::Start);
 
         let message = match response {
+            MockResponse::TextWithUsage(text, usage) => {
+                let _ = tx.send(StreamEvent::TextDelta {
+                    content_index: 0,
+                    delta: text.clone(),
+                });
+                Message::Assistant {
+                    content: vec![Content::Text { text }],
+                    stop_reason: StopReason::Stop,
+                    model: "mock".into(),
+                    provider: "mock".into(),
+                    usage,
+                    timestamp: now_ms(),
+                    error_message: None,
+                }
+            }
             MockResponse::Text(text) => {
                 let _ = tx.send(StreamEvent::TextDelta {
                     content_index: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -700,8 +700,18 @@ pub enum ToolError {
 #[non_exhaustive]
 pub enum AgentEvent {
     AgentStart,
+    /// The run finished. Carries the messages it produced and a
+    /// [`SessionStats`] rollup of what they cost.
+    ///
+    /// The variant is `#[non_exhaustive]` — the payload is expected to grow.
+    /// Match with `..`.
+    #[non_exhaustive]
     AgentEnd {
         messages: Vec<AgentMessage>,
+        /// `#[serde(default)]`: `AgentEvent` is a frozen wire format, and
+        /// archived streams predate this field.
+        #[serde(default)]
+        stats: SessionStats,
     },
     TurnStart,
     TurnEnd {
@@ -764,6 +774,150 @@ pub enum AgentEvent {
         /// cannot disagree with each other.
         summary: Option<SummaryStats>,
     },
+}
+
+impl AgentEvent {
+    /// Construct an [`AgentEvent::AgentEnd`].
+    ///
+    /// The variant is `#[non_exhaustive]` — its payload grows — so downstream
+    /// crates (and tests) build it here rather than with a struct literal.
+    pub fn agent_end(messages: Vec<AgentMessage>, stats: SessionStats) -> Self {
+        Self::AgentEnd { messages, stats }
+    }
+}
+
+/// Session-level rollup carried by [`AgentEvent::AgentEnd`].
+///
+/// The per-turn numbers already existed — `Usage` on every assistant message,
+/// `tokens_cached` on the `llm_stream` span, `cache_read` in the GASP record —
+/// but nothing summed them, so answering "what was this run's cache hit rate"
+/// meant replaying the whole event stream. Any change that moves caching
+/// (breakpoint placement, compaction strategy, model choice) had to be judged
+/// by hand-built harnesses instead of a number the library reports.
+///
+/// ```
+/// # use yoagent::{SessionStats, Usage};
+/// # let stats = SessionStats::default();
+/// // Reading your cache hit rate:
+/// println!("{:.1}% cached over {} turns", stats.cache_hit_rate() * 100.0, stats.turns);
+/// ```
+///
+/// **Hit rate is `cache_read / (input + cache_read + cache_write)`** — cache
+/// writes count against you, because they are prompt tokens the provider
+/// processed and billed. Counting only `input` shrinks the denominator and so
+/// **overstates** the rate for a write-charging provider: Anthropic books a
+/// re-processed prefix to `cache_write`, and an `input`-only metric makes it
+/// look roughly ten times cheaper than it is. See
+/// `docs/evals/llm-compaction-live.md`, where that error was made and caught.
+///
+/// Read a rate against its session length, not against 100%: every turn's new
+/// content is necessarily a miss, so the ceiling is about `(n-1)/(n+1)` — ~88%
+/// at 15 turns, ~96% only past 49.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SessionStats {
+    /// Provider usage summed over every LLM turn in this run.
+    ///
+    /// `total_tokens` is **not** summed and stays 0 — see [`record_turn`] for
+    /// why. Derive a total from the four components instead.
+    ///
+    /// [`record_turn`]: SessionStats::record_turn
+    #[serde(default)]
+    pub usage: Usage,
+    /// LLM turns taken. Tool executions are not turns; an errored turn counts,
+    /// because the provider billed it, and provider retries within one turn do
+    /// not appear separately.
+    #[serde(default)]
+    pub turns: u32,
+    /// Dollar cost of [`usage`](Self::usage), when the model's rates are
+    /// configured (see [`CostConfig`](crate::provider::CostConfig)).
+    ///
+    /// `None` means "cannot price this", never "free" — all-zero rates mean
+    /// pricing is unknown, which is the case for custom and local models.
+    ///
+    /// Scope: this run's own turns. A [`SubAgentTool`](crate::SubAgentTool)
+    /// runs its own loop on a private channel, so a delegating agent's real
+    /// spend is higher than this reports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    /// Times the loop observed compaction rewrite history.
+    ///
+    /// Counts any turn where the strategy returned a different message count or
+    /// a different *estimated* token total ([`context::total_tokens`]), so
+    /// in-place tool-output truncation is included alongside reshaping. A
+    /// compaction that runs and reclaims nothing is indistinguishable from no
+    /// compaction at all.
+    ///
+    /// [`context::total_tokens`]: crate::context::total_tokens
+    ///
+    /// Deliberately **not** split into spliced-summary vs deterministic
+    /// fallback, and carrying no summarization spend. That detail exists — on
+    /// [`AgentEvent::ContextCompacted`], with its [`SummaryStats`] — but
+    /// [`CompactionStrategy::compact`](crate::context::CompactionStrategy::compact)
+    /// is synchronous and has no event channel, so the loop cannot see it. Wire
+    /// `LlmCompaction::with_event_sender` to the same channel and aggregate the
+    /// two together — the events *describe* the same compactions this counts,
+    /// with the breakdown attached, so do not sum the two. Folding a guess in
+    /// here would be worse than the gap.
+    #[serde(default)]
+    pub compactions: u32,
+}
+
+impl SessionStats {
+    /// A rollup with the given figures.
+    ///
+    /// This struct is `#[non_exhaustive]`, so downstream crates cannot use a
+    /// struct literal; without this the only construction path would be
+    /// `Default::default()` plus field assignment.
+    pub fn new(usage: Usage, turns: u32, cost_usd: Option<f64>, compactions: u32) -> Self {
+        Self {
+            usage,
+            turns,
+            cost_usd,
+            compactions,
+        }
+    }
+
+    /// Fraction of prompt tokens served from cache across the whole session
+    /// (0.0–1.0). Delegates to [`Usage::cache_hit_rate`] so there is one
+    /// definition of the metric rather than two that can drift.
+    pub fn cache_hit_rate(&self) -> f64 {
+        self.usage.cache_hit_rate()
+    }
+
+    /// Fold one turn's usage into the rollup, costing it when rates are known.
+    ///
+    /// `total_tokens` is deliberately not summed. It is a per-response provider
+    /// report, and the providers disagree on it: `anthropic.rs` never sets it
+    /// at all, `bedrock.rs` computes `input + output` and so excludes cache,
+    /// and the rest pass through a payload value that includes cached tokens.
+    /// Summing it would launder that inconsistency into a session-level number
+    /// that reads as authoritative and is 0 for every Anthropic run. The four
+    /// components sum cleanly; derive a total from those.
+    ///
+    /// Cost accrues per turn rather than once at the end. Today that is
+    /// arithmetically identical — `CostConfig::cost_usd` is linear in every
+    /// `Usage` field and `config.model_config` is fixed for the life of a run
+    /// (`run_loop` holds `&AgentLoopConfig`, and `set_model` needs `&mut self`).
+    /// It is written this way so a per-turn model override stays correct if one
+    /// is ever introduced, and so `cost_usd` reflects whether any turn was
+    /// priceable rather than requiring a separate check.
+    pub(crate) fn record_turn(
+        &mut self,
+        usage: &Usage,
+        cost: Option<&crate::provider::CostConfig>,
+    ) {
+        self.usage.input += usage.input;
+        self.usage.output += usage.output;
+        self.usage.cache_read += usage.cache_read;
+        self.usage.cache_write += usage.cache_write;
+        self.turns += 1;
+
+        if let Some(cost) = cost.filter(|c| c.is_configured()) {
+            *self.cost_usd.get_or_insert(0.0) += cost.cost_usd(usage);
+        }
+    }
 }
 
 /// What a summarization request produced, carried by

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -1777,7 +1777,7 @@ async fn test_filter_reject_returns_empty() {
     assert!(events.iter().any(|e| matches!(e, AgentEvent::AgentStart)));
     assert!(events
         .iter()
-        .any(|e| matches!(e, AgentEvent::AgentEnd { messages } if messages.is_empty())));
+        .any(|e| matches!(e, AgentEvent::AgentEnd { messages, .. } if messages.is_empty())));
 }
 
 #[tokio::test]
@@ -2531,4 +2531,387 @@ async fn per_tool_override_exempts_a_tool_from_capping() {
 async fn tool_output_is_untouched_without_a_context_config() {
     let (messages, _) = run_with_context_config(None).await;
     assert_eq!(tool_result_lines(&messages), 500);
+}
+
+// ---------------------------------------------------------------------------
+// Session rollup on AgentEnd (issue #124)
+// ---------------------------------------------------------------------------
+
+fn usage(input: u64, output: u64, cache_read: u64, cache_write: u64) -> Usage {
+    Usage {
+        input,
+        output,
+        cache_read,
+        cache_write,
+        total_tokens: input + output + cache_read + cache_write,
+    }
+}
+
+fn agent_end_stats(events: &[AgentEvent]) -> SessionStats {
+    events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::AgentEnd { stats, .. } => Some(stats.clone()),
+            _ => None,
+        })
+        .expect("AgentEnd must be emitted")
+}
+
+/// Distinct usage per turn, so a rollup that copies the last turn instead of
+/// summing cannot pass.
+#[tokio::test]
+async fn agent_end_carries_a_summed_session_rollup() {
+    let provider = MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "silent_tool".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::TextWithUsage("done".into(), usage(7, 70, 700, 7000)),
+    ]);
+
+    // The first turn's usage rides on the tool-call response, which
+    // MockProvider reports as Usage::default() — so this asserts the loop sums
+    // whatever each turn reported, zeros included.
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(SilentTool)],
+        system_prompt: String::new(),
+    };
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &make_config(provider),
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    let stats = agent_end_stats(&collect_events(rx));
+    assert_eq!(stats.turns, 2, "two LLM turns: tool call, then text");
+    assert_eq!(stats.usage.input, 7);
+    assert_eq!(stats.usage.output, 70);
+    assert_eq!(stats.usage.cache_read, 700);
+    assert_eq!(stats.usage.cache_write, 7000);
+
+    // 700 / (7 + 700 + 7000) — cache_write counts against the rate, because
+    // those are prompt tokens the provider processed and billed.
+    let expected = 700.0 / 7707.0;
+    assert!(
+        (stats.cache_hit_rate() - expected).abs() < 1e-9,
+        "hit rate {} != {expected}",
+        stats.cache_hit_rate()
+    );
+}
+
+/// Three turns with different usage each: proves accumulation, not overwrite.
+#[tokio::test]
+async fn rollup_accumulates_across_every_turn() {
+    let provider = MockProvider::new(vec![
+        MockResponse::TextWithUsage("a".into(), usage(1, 2, 3, 4)),
+        MockResponse::TextWithUsage("b".into(), usage(10, 20, 30, 40)),
+        MockResponse::TextWithUsage("c".into(), usage(100, 200, 300, 400)),
+    ]);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(provider);
+    // Two follow-ups, so the loop takes three turns in one run.
+    let pending = std::sync::Arc::new(std::sync::Mutex::new(vec![
+        AgentMessage::Llm(Message::user("second")),
+        AgentMessage::Llm(Message::user("third")),
+    ]));
+    let handout = pending.clone();
+    config.get_follow_up_messages = Some(Box::new(move || {
+        let mut q = handout.lock().unwrap();
+        if q.is_empty() {
+            vec![]
+        } else {
+            vec![q.remove(0)]
+        }
+    }));
+
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("first"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    let stats = agent_end_stats(&collect_events(rx));
+    assert_eq!(stats.turns, 3);
+    assert_eq!(stats.usage.input, 111);
+    assert_eq!(stats.usage.output, 222);
+    assert_eq!(stats.usage.cache_read, 333);
+    assert_eq!(stats.usage.cache_write, 444);
+}
+
+/// A run that produced no LLM turn reports zeros rather than a bogus rate.
+#[tokio::test]
+async fn rollup_of_an_empty_run_is_zero_not_nan() {
+    let stats = SessionStats::default();
+    assert_eq!(stats.turns, 0);
+    assert_eq!(stats.cache_hit_rate(), 0.0);
+    assert!(stats.cache_hit_rate().is_finite());
+}
+
+/// The wire format is frozen and archived streams predate `stats`. Without
+/// `#[serde(default)]` on the field and on every `SessionStats` field, replaying
+/// yesterday's JSONL fails outright.
+#[test]
+fn archived_agent_end_without_stats_still_deserializes() {
+    let legacy = r#"{"type":"agentEnd","messages":[]}"#;
+    let event: AgentEvent = serde_json::from_str(legacy).expect("legacy agentEnd must load");
+    match event {
+        AgentEvent::AgentEnd { stats, .. } => assert_eq!(stats, SessionStats::default()),
+        other => panic!("wrong variant: {other:?}"),
+    }
+
+    // ...and a partially-written rollup, which is what a future field addition
+    // looks like to an older reader.
+    let partial = r#"{"type":"agentEnd","messages":[],"stats":{"turns":3}}"#;
+    let event: AgentEvent = serde_json::from_str(partial).expect("partial stats must load");
+    match event {
+        AgentEvent::AgentEnd { stats, .. } => {
+            assert_eq!(stats.turns, 3);
+            assert_eq!(stats.compactions, 0);
+            assert_eq!(stats.cost_usd, None);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+/// `cost_usd` accrues only when the model has configured rates. `None` means
+/// "cannot price this", never "free".
+#[tokio::test]
+async fn cost_accrues_when_rates_are_configured_and_stays_none_otherwise() {
+    let responses = || {
+        vec![
+            MockResponse::TextWithUsage("a".into(), usage(1_000_000, 0, 0, 0)),
+            MockResponse::TextWithUsage("b".into(), usage(0, 1_000_000, 0, 0)),
+        ]
+    };
+
+    // Unpriced: no model_config at all.
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(responses()));
+    config.get_follow_up_messages = follow_up_once();
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+    assert_eq!(
+        agent_end_stats(&collect_events(rx)).cost_usd,
+        None,
+        "an unpriced model must report None, not Some(0.0)"
+    );
+
+    // Priced: $3/M in, $15/M out. One million of each => 3.0 + 15.0.
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    let mut priced = yoagent::provider::ModelConfig::anthropic("mock", "Mock");
+    priced.cost = yoagent::provider::CostConfig {
+        input_per_million: 3.0,
+        output_per_million: 15.0,
+        cache_read_per_million: 0.0,
+        cache_write_per_million: 0.0,
+    };
+    let mut config = make_config(MockProvider::new(responses()));
+    config.model_config = Some(priced);
+    config.get_follow_up_messages = follow_up_once();
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+    let cost = agent_end_stats(&collect_events(rx))
+        .cost_usd
+        .expect("priced model must report a cost");
+    assert!((cost - 18.0).abs() < 1e-9, "cost {cost} != 18.0");
+}
+
+/// Hand out exactly one follow-up, so the loop takes two turns.
+fn follow_up_once() -> Option<Box<dyn Fn() -> Vec<AgentMessage> + Send + Sync>> {
+    let pending = std::sync::Arc::new(std::sync::Mutex::new(vec![AgentMessage::Llm(
+        Message::user("again"),
+    )]));
+    Some(Box::new(move || {
+        let mut q = pending.lock().unwrap();
+        if q.is_empty() {
+            vec![]
+        } else {
+            vec![q.remove(0)]
+        }
+    }))
+}
+
+/// `total_tokens` is not summed: providers disagree on it (Anthropic never sets
+/// it, Bedrock excludes cache), so a session-level sum would read as
+/// authoritative while being 0 for every Anthropic run.
+#[tokio::test]
+async fn total_tokens_is_not_summed_into_the_rollup() {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &make_config(MockProvider::new(vec![MockResponse::TextWithUsage(
+            "a".into(),
+            usage(5, 6, 7, 8),
+        )])),
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    let stats = agent_end_stats(&collect_events(rx));
+    assert_eq!(stats.usage.input, 5);
+    assert_eq!(
+        stats.usage.total_tokens, 0,
+        "total_tokens must stay 0; derive a total from the components"
+    );
+}
+
+/// A strategy that never changes anything must not be counted. This is the
+/// most likely implementation slip — counting *invocations* of `compact`
+/// rather than *effective* compactions — and it would make the number useless
+/// for anyone tuning a strategy.
+#[tokio::test]
+async fn a_no_op_compaction_is_not_counted() {
+    struct NoOp;
+    impl yoagent::context::CompactionStrategy for NoOp {
+        fn compact(
+            &self,
+            messages: Vec<AgentMessage>,
+            _config: &yoagent::context::ContextConfig,
+        ) -> Vec<AgentMessage> {
+            messages
+        }
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(vec![
+        MockResponse::TextWithUsage("a".into(), usage(10, 10, 0, 0)),
+        MockResponse::TextWithUsage("b".into(), usage(10, 10, 0, 0)),
+    ]));
+    // A tiny budget guarantees `compact` is called on every turn.
+    config.context_config = Some(yoagent::context::ContextConfig {
+        max_context_tokens: 10,
+        system_prompt_tokens: 0,
+        ..Default::default()
+    });
+    config.compaction_strategy = Some(std::sync::Arc::new(NoOp));
+    config.get_follow_up_messages = follow_up_once();
+
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert_eq!(
+        agent_end_stats(&collect_events(rx)).compactions,
+        0,
+        "compact() ran every turn but changed nothing — nothing to count"
+    );
+}
+
+/// The `||` clause the counting comment exists for: a strategy that rewrites
+/// content in place, leaving the message count identical. A length-only check
+/// silently misses it.
+#[tokio::test]
+async fn an_in_place_rewrite_is_counted_despite_an_unchanged_message_count() {
+    struct ShrinkInPlace;
+    impl yoagent::context::CompactionStrategy for ShrinkInPlace {
+        fn compact(
+            &self,
+            messages: Vec<AgentMessage>,
+            _config: &yoagent::context::ContextConfig,
+        ) -> Vec<AgentMessage> {
+            let before = messages.len();
+            let out: Vec<AgentMessage> = messages
+                .into_iter()
+                .map(|m| match m {
+                    AgentMessage::Llm(Message::User { timestamp, .. }) => {
+                        AgentMessage::Llm(Message::User {
+                            content: vec![Content::Text { text: "x".into() }],
+                            timestamp,
+                        })
+                    }
+                    other => other,
+                })
+                .collect();
+            assert_eq!(out.len(), before, "this strategy must not change length");
+            out
+        }
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(vec![MockResponse::TextWithUsage(
+        "a".into(),
+        usage(10, 10, 0, 0),
+    )]));
+    config.context_config = Some(yoagent::context::ContextConfig {
+        max_context_tokens: 10,
+        system_prompt_tokens: 0,
+        ..Default::default()
+    });
+    config.compaction_strategy = Some(std::sync::Arc::new(ShrinkInPlace));
+
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user(
+            "a considerably longer opening message than the replacement",
+        ))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert_eq!(
+        agent_end_stats(&collect_events(rx)).compactions,
+        1,
+        "token total moved while the count did not — the || clause must catch it"
+    );
 }

--- a/tests/gasp_test.rs
+++ b/tests/gasp_test.rs
@@ -487,7 +487,8 @@ async fn stop_reasons_map_to_distinct_outcomes() {
             )),
         })
         .unwrap();
-        tx.send(AgentEvent::AgentEnd { messages: vec![] }).unwrap();
+        tx.send(AgentEvent::agent_end(vec![], Default::default()))
+            .unwrap();
         drop(tx);
         handle.await.unwrap().unwrap().expect("recorded");
 

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -301,9 +301,7 @@ fn sample_tool_result() -> ToolResult {
 fn all_agent_events() -> Vec<AgentEvent> {
     vec![
         AgentEvent::AgentStart,
-        AgentEvent::AgentEnd {
-            messages: vec![sample_assistant()],
-        },
+        AgentEvent::agent_end(vec![sample_assistant()], SessionStats::default()),
         AgentEvent::TurnStart,
         AgentEvent::TurnEnd {
             message: sample_assistant(),


### PR DESCRIPTION
Closes #124.

Every per-turn number already existed — `Usage` on each assistant message,
`tokens_cached` on the `llm_stream` span, `cache_read` in the GASP record — but
nothing summed them. Answering *"what was this run's cache hit rate"* meant
replaying the event stream, so every cache-affecting change got judged by a
hand-built harness instead of a number the library reports. #123 and the #119
evaluation both had to do exactly that.

```rust
AgentEvent::AgentEnd { stats, .. } => {
    println!("{:.1}% cached over {} turns", stats.cache_hit_rate() * 100.0, stats.turns);
}
```

`SessionStats` carries summed `usage`, `turns`, `cost_usd` when rates are
configured, and `compactions`. Hit rate delegates to `Usage::cache_hit_rate` so
there is one definition rather than two that drift — and it counts
`cache_write` against you, because those are prompt tokens the provider
processed and billed. The GASP run-close record carries the same rollup by
**serializing the struct**, so there is no second hand-maintained wire shape to
drift from the first.

## What review found

Five agents ran against the first draft. Four findings changed the code:

| finding | why it mattered |
|---|---|
| **`stats` had no `#[serde(default)]`** | `{"type":"agentEnd","messages":[]}` → `missing field 'stats'`. `AgentEvent` is a frozen wire format and `Usage` already carries serde defaults for this exact reason — the draft broke the crate's own convention, and without defaults on the `SessionStats` fields too, every future field would repeat it. |
| **`total_tokens` was summed, and is not summable** | `anthropic.rs` sets it *only in a test fixture* — never in the stream path, so always 0. `bedrock.rs` computes `input + output`, excluding cache. The rest pass through a payload value including cached tokens. Summing laundered that into a session figure that reads as authoritative and is **zero for every Anthropic run**. |
| **the `set_model` rationale was fabricated** | `record_turn`'s doc claimed per-turn costing matters because a model can switch mid-session. It cannot: `run_loop` holds `&AgentLoopConfig`, `set_model` needs `&mut self`, and `SessionStats` is created fresh per run. The accrual is kept — right shape, future-proof — but the comment now says what is true. |
| **the hit-rate warning was backwards** | Counting only `input` shrinks the denominator and so *overstates* the rate; the doc said "understates". Same error #119 made and corrected, reintroduced in prose while the code stayed right. |

Plus: the compaction counter recomputed a full-history token walk already in
scope as `estimated`, and the tracker reset keyed off length alone while the
counter keyed off length-or-tokens — disagreeing on precisely the level-1
truncation case the comment calls out. Both now use one condition.

## Tests

`cost_usd`, `compactions` and serde compatibility had **zero** coverage.
Five added, including both compaction branches:

- a **no-op strategy must not count** — the likely slip is counting
  invocations of `compact` rather than effective compactions, which would make
  the number useless for anyone tuning a strategy
- an **in-place rewrite must count** despite unchanged message count — the
  `||` clause the counting comment exists for

## Boundaries documented, not fixed

**`SubAgentTool` spend is invisible.** It runs its own loop on a private
channel and its `AgentEnd` is dropped by the forwarder, so a delegating agent
under-reports — possibly by most of its spend. There is no usage back-channel
on `ToolContext`, so this is a feature rather than a line fix. Documented on
`cost_usd` and in the CHANGELOG rather than left to surface as a billing
surprise.

**Retried and cancelled turns contribute zero usage.** Properties of the
existing retry/cancel paths that this rollup *surfaces* rather than causes;
fixing either means changing what those paths return.

`compactions` is likewise not split into spliced-summary vs deterministic
fallback and carries no summarization spend — that lives on
`AgentEvent::ContextCompacted`, and `CompactionStrategy::compact` is
synchronous with no event channel, so the loop cannot see it. Folding a guess
in would be worse than the gap.

## Breaking changes

- `AgentEvent::AgentEnd` gained `stats`; the variant is `#[non_exhaustive]`.
  Match with `..`, construct via `AgentEvent::agent_end(messages, stats)`.
- `MockResponse` gained `TextWithUsage` and the attribute — `Text` reports
  `Usage::default()`, which cannot distinguish a rollup that sums from one that
  copies the last turn.

## Verification

- **530 tests pass, 0 failed** (525 before)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean
- doctest for the `SessionStats` example compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)