### PR TITLE
fix: make ToolContext actually non-breaking to extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Breaking: `ToolContext` is `#[non_exhaustive]`** and gained
+  `ToolContext::new` plus `with_cancel` / `with_on_update` / `with_on_progress`.
+
+  Its doc has always claimed that "adding fields to `ToolContext` is
+  non-breaking". That was false — the struct carried no attribute, so every
+  field addition broke downstream struct literals. Making it true cost 20
+  literal rewrites across this repo's own tests and examples, which is a fair
+  measure of what a future field would have cost everyone else. Tools *receive*
+  this type rather than construct it, so implementors are unaffected; only
+  code that builds one directly needs the constructor.
+
 - **Breaking: `AgentEvent::AgentEnd` gained a `stats` field** and the variant is
   now `#[non_exhaustive]`. Match with `..`, and construct via
   `AgentEvent::agent_end(messages, stats)` rather than a struct literal. The

--- a/examples/code_review.rs
+++ b/examples/code_review.rs
@@ -98,11 +98,8 @@ async fn main() {
     let make_ctx = |label: &str| -> (ToolContext, Arc<Mutex<String>>) {
         let label = label.to_string();
         let buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
-        let ctx = ToolContext {
-            tool_call_id: format!("tc-{}", label),
-            tool_name: label.clone(),
-            cancel: tokio_util::sync::CancellationToken::new(),
-            on_update: Some(Arc::new({
+        let ctx =
+            ToolContext::new(format!("tc-{}", label), label.clone()).with_on_update(Arc::new({
                 let label = label.clone();
                 let buf = buf.clone();
                 move |result: ToolResult| {
@@ -125,9 +122,7 @@ async fn main() {
                         }
                     }
                 }
-            })),
-            on_progress: None,
-        };
+            }));
         (ctx, buf)
     };
 

--- a/examples/rlm.rs
+++ b/examples/rlm.rs
@@ -105,34 +105,28 @@ async fn main() {
 
     // --- Parent: single call triggers the full recursive chain ---
     let buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
-    let ctx = ToolContext {
-        tool_call_id: "tc-rlm".into(),
-        tool_name: "lead_analyst".into(),
-        cancel: tokio_util::sync::CancellationToken::new(),
-        on_update: Some(Arc::new({
-            let buf = buf.clone();
-            move |result: ToolResult| {
-                for content in &result.content {
-                    if let Content::Text { text } = content {
-                        let mut b = buf.lock().unwrap();
-                        if text.starts_with("[sub-agent calling tool:") {
-                            if !b.is_empty() {
-                                eprintln!("[lead] {}", b.drain(..).collect::<String>());
-                            }
-                            eprintln!("[lead] {}", text);
-                            return;
+    let ctx = ToolContext::new("tc-rlm", "lead_analyst").with_on_update(Arc::new({
+        let buf = buf.clone();
+        move |result: ToolResult| {
+            for content in &result.content {
+                if let Content::Text { text } = content {
+                    let mut b = buf.lock().unwrap();
+                    if text.starts_with("[sub-agent calling tool:") {
+                        if !b.is_empty() {
+                            eprintln!("[lead] {}", b.drain(..).collect::<String>());
                         }
-                        b.push_str(text);
-                        while let Some(pos) = b.find('\n') {
-                            let line: String = b.drain(..=pos).collect();
-                            eprint!("[lead] {}", line);
-                        }
+                        eprintln!("[lead] {}", text);
+                        return;
+                    }
+                    b.push_str(text);
+                    while let Some(pos) = b.find('\n') {
+                        let line: String = b.drain(..=pos).collect();
+                        eprint!("[lead] {}", line);
                     }
                 }
             }
-        })),
-        on_progress: None,
-    };
+        }
+    }));
 
     let result = lead_analyst
         .execute(

--- a/examples/shared_state.rs
+++ b/examples/shared_state.rs
@@ -106,13 +106,7 @@ async fn main() {
     // --- Run all three in parallel ---
     println!("Dispatching 3 sub-agents in parallel...\n");
 
-    let ctx = |name: &str| ToolContext {
-        tool_call_id: format!("tc-{}", name),
-        tool_name: name.to_string(),
-        cancel: tokio_util::sync::CancellationToken::new(),
-        on_update: None,
-        on_progress: None,
-    };
+    let ctx = |name: &str| ToolContext::new(format!("tc-{}", name), name.to_string());
 
     let (r1, r2, r3) = tokio::join!(
         error_analyst.execute(

--- a/src/types.rs
+++ b/src/types.rs
@@ -585,7 +585,11 @@ pub type ProgressFn = Arc<dyn Fn(String) + Send + Sync>;
 /// Context passed to tool execution. Bundles all per-invocation state.
 ///
 /// Using a struct instead of individual parameters future-proofs the trait —
-/// adding fields to `ToolContext` is non-breaking.
+/// adding fields to `ToolContext` is non-breaking, which `#[non_exhaustive]`
+/// is what actually makes true. Tools receive this rather than build it, so
+/// the attribute costs implementors nothing; it only stops a struct literal in
+/// downstream test code from breaking on every new field.
+#[non_exhaustive]
 pub struct ToolContext {
     /// The ID of this tool call (for correlation).
     pub tool_call_id: String,
@@ -597,6 +601,42 @@ pub struct ToolContext {
     pub on_update: Option<ToolUpdateFn>,
     /// Optional callback for emitting user-facing progress messages.
     pub on_progress: Option<ProgressFn>,
+}
+
+impl ToolContext {
+    /// A context for one tool invocation, with no cancellation token and no
+    /// callbacks.
+    ///
+    /// This struct is `#[non_exhaustive]`, so downstream crates build it here
+    /// rather than with a struct literal. The loop constructs the real one;
+    /// this is for tests and for callers driving a tool directly.
+    pub fn new(tool_call_id: impl Into<String>, tool_name: impl Into<String>) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            cancel: tokio_util::sync::CancellationToken::new(),
+            on_update: None,
+            on_progress: None,
+        }
+    }
+
+    /// Use the given cancellation token instead of a fresh one.
+    pub fn with_cancel(mut self, cancel: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
+    /// Stream partial [`ToolResult`]s to this callback (UI/logging only).
+    pub fn with_on_update(mut self, on_update: ToolUpdateFn) -> Self {
+        self.on_update = Some(on_update);
+        self
+    }
+
+    /// Emit user-facing progress messages through this callback.
+    pub fn with_on_progress(mut self, on_progress: ProgressFn) -> Self {
+        self.on_progress = Some(on_progress);
+        self
+    }
 }
 
 impl Clone for ToolContext {

--- a/tests/openapi_test.rs
+++ b/tests/openapi_test.rs
@@ -88,13 +88,7 @@ const SPEC: &str = r#"{
 }"#;
 
 fn test_ctx() -> ToolContext {
-    ToolContext {
-        tool_call_id: "tc-1".into(),
-        tool_name: "test".into(),
-        cancel: tokio_util::sync::CancellationToken::new(),
-        on_update: None,
-        on_progress: None,
-    }
+    ToolContext::new("tc-1", "test")
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/shared_state_test.rs
+++ b/tests/shared_state_test.rs
@@ -1,7 +1,6 @@
 //! Tests for SharedState and its integration with SubAgentTool.
 
 use std::sync::Arc;
-use tokio_util::sync::CancellationToken;
 use yoagent::provider::mock::*;
 use yoagent::provider::MockProvider;
 use yoagent::provider::ModelConfig;
@@ -39,13 +38,7 @@ async fn test_sub_agent_reads_shared_state() {
     let result = sub_agent
         .execute(
             serde_json::json!({"task": "What happened in the build?"}),
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "analyzer".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "analyzer"),
         )
         .await
         .expect("sub-agent should succeed");
@@ -87,13 +80,7 @@ async fn test_sub_agent_writes_shared_state() {
     sub_agent
         .execute(
             serde_json::json!({"task": "Summarize"}),
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "writer".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "writer"),
         )
         .await
         .expect("sub-agent should succeed");
@@ -150,13 +137,7 @@ async fn test_parallel_sub_agents_share_state() {
         .with_system_prompt("You are agent B.")
         .with_shared_state(state.clone());
 
-    let ctx = || ToolContext {
-        tool_call_id: "tc".into(),
-        tool_name: "test".into(),
-        cancel: CancellationToken::new(),
-        on_update: None,
-        on_progress: None,
-    };
+    let ctx = || ToolContext::new("tc", "test");
 
     // Run in parallel
     let (ra, rb) = tokio::join!(
@@ -186,13 +167,7 @@ async fn test_sub_agent_without_shared_state_unchanged() {
     let result = sub_agent
         .execute(
             serde_json::json!({"task": "say hi"}),
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "plain".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "plain"),
         )
         .await
         .expect("should work without shared state");
@@ -231,13 +206,7 @@ async fn test_shared_state_summary_in_system_prompt() {
     let result = sub_agent
         .execute(
             serde_json::json!({"task": "list"}),
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "lister".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "lister"),
         )
         .await
         .unwrap();

--- a/tests/sub_agent_test.rs
+++ b/tests/sub_agent_test.rs
@@ -64,16 +64,7 @@ async fn test_sub_agent_basic() {
     let params = serde_json::json!({"task": "Tell me about Rust"});
 
     let result = sub_agent
-        .execute(
-            params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "researcher".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
-        )
+        .execute(params, ToolContext::new("tc-1", "researcher"))
         .await
         .expect("sub-agent should succeed");
 
@@ -150,16 +141,7 @@ async fn test_sub_agent_with_tools() {
     let params = serde_json::json!({"task": "Echo hello"});
 
     let result = sub_agent
-        .execute(
-            params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "echo_agent".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
-        )
+        .execute(params, ToolContext::new("tc-1", "echo_agent"))
         .await
         .expect("sub-agent should succeed");
 
@@ -190,13 +172,7 @@ async fn test_sub_agent_cancellation() {
     let result = sub_agent
         .execute(
             params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "cancelled_agent".into(),
-                cancel,
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "cancelled_agent").with_cancel(cancel),
         )
         .await
         .expect("should return a result even when cancelled");
@@ -242,16 +218,7 @@ async fn test_sub_agent_max_turns() {
     let params = serde_json::json!({"task": "Keep going"});
 
     let result = sub_agent
-        .execute(
-            params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "limited_agent".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
-        )
+        .execute(params, ToolContext::new("tc-1", "limited_agent"))
         .await
         .expect("sub-agent should succeed");
 
@@ -405,13 +372,7 @@ async fn test_sub_agent_event_forwarding() {
     let result = sub_agent
         .execute(
             params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "streaming_agent".into(),
-                cancel: CancellationToken::new(),
-                on_update: Some(on_update),
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "streaming_agent").with_on_update(on_update),
         )
         .await
         .expect("sub-agent should succeed");
@@ -450,16 +411,7 @@ async fn test_sub_agent_missing_task_parameter() {
     let params = serde_json::json!({}); // Missing "task"
 
     let result = sub_agent
-        .execute(
-            params,
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "test_agent".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
-        )
+        .execute(params, ToolContext::new("tc-1", "test_agent"))
         .await;
     assert!(result.is_err());
 
@@ -551,13 +503,7 @@ async fn capture_system_prompt(
     sub_agent
         .execute(
             serde_json::json!({"task": "do work"}),
-            ToolContext {
-                tool_call_id: "tc-1".into(),
-                tool_name: "sub".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-1", "sub"),
         )
         .await
         .expect("sub-agent should succeed");
@@ -761,13 +707,7 @@ impl yoagent::provider::StreamProvider for StreamConfigCapture {
 async fn run_sub_agent(tool: &SubAgentTool) {
     tool.execute(
         serde_json::json!({"task": "go"}),
-        ToolContext {
-            tool_call_id: "tc-cfg".into(),
-            tool_name: "cfg".into(),
-            cancel: CancellationToken::new(),
-            on_update: None,
-            on_progress: None,
-        },
+        ToolContext::new("tc-cfg", "cfg"),
     )
     .await
     .expect("sub-agent should succeed");
@@ -826,13 +766,7 @@ async fn test_sub_agent_from_provider_construction() {
     let result = tool
         .execute(
             serde_json::json!({"task": "go"}),
-            ToolContext {
-                tool_call_id: "tc-fp".into(),
-                tool_name: "researcher".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-fp", "researcher"),
         )
         .await
         .expect("sub-agent should succeed");
@@ -937,13 +871,7 @@ async fn test_sub_agent_tool_middleware_denies() {
     let result = tool
         .execute(
             serde_json::json!({"task": "go"}),
-            ToolContext {
-                tool_call_id: "tc-mw".into(),
-                tool_name: "gated".into(),
-                cancel: CancellationToken::new(),
-                on_update: None,
-                on_progress: None,
-            },
+            ToolContext::new("tc-mw", "gated"),
         )
         .await
         .expect("sub-agent completes despite denial");

--- a/tests/tools_test.rs
+++ b/tests/tools_test.rs
@@ -9,23 +9,11 @@ use yoagent::types::*;
 
 /// Helper to build a ToolContext for tests.
 fn ctx(name: &str) -> ToolContext {
-    ToolContext {
-        tool_call_id: "t1".into(),
-        tool_name: name.into(),
-        cancel: CancellationToken::new(),
-        on_update: None,
-        on_progress: None,
-    }
+    ToolContext::new("t1", name)
 }
 
 fn ctx_with_cancel(name: &str, cancel: CancellationToken) -> ToolContext {
-    ToolContext {
-        tool_call_id: "t1".into(),
-        tool_name: name.into(),
-        cancel,
-        on_update: None,
-        on_progress: None,
-    }
+    ToolContext::new("t1", name).with_cancel(cancel)
 }
 
 #[tokio::test]


### PR DESCRIPTION
Pre-release cleanup for 0.17.0.

`ToolContext`'s doc has claimed since it was introduced:

> Using a struct instead of individual parameters future-proofs the trait —
> adding fields to `ToolContext` is non-breaking.

**That was false.** The struct carried no `#[non_exhaustive]`, so every field
addition would break downstream struct literals. The comment described an
intent the code never enforced.

## The cost, measured

Making the claim true required rewriting **20 struct literals** across this
repo's own tests and examples. That is a fair estimate of what a future field
addition would have inflicted on every downstream user with no warning — and it
is exactly why this belongs in 0.17.0, alongside the breaking changes already
queued, rather than arriving as a surprise in 0.18.0.

## API

```rust
let ctx = ToolContext::new("tc-1", "my_tool")
    .with_cancel(token)
    .with_on_update(callback);
```

Tools **receive** a `ToolContext` rather than construct one, so `AgentTool`
implementors are unaffected. Only code that builds one directly — tests, and
callers driving a tool outside the loop — needs the constructor.

## Why now

This unblocks the sub-agent usage back-channel, one of the three follow-ups
documented in #124. A delegating agent's spend is currently invisible to
`SessionStats` because `SubAgentTool` runs its own loop on a private channel,
and closing that gap needs a field on `ToolContext`. With this merged, that
becomes a purely additive change shippable in a 0.17.x patch instead of
requiring another breaking release.

The same is true of the other two follow-ups:

| follow-up | after this PR |
|---|---|
| sub-agent spend back-channel | additive — new `ToolContext` field |
| compaction splice attribution | additive — defaulted trait method on `CompactionStrategy` |
| Azure / Responses / Bedrock cache directives | additive — request-body only |

So 0.17.0 can ship now without stranding any of them behind a future breaking
cycle.

## Verification

- **530 tests pass, 0 failed**
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)