### PR TITLE
release: 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.17.0
 
 > The fixes below also shipped on the **0.16.x maintenance line** — the gasp
 > extension-path and MSRV fixes in [0.16.3], the gasp id types in [0.16.4], and
 > the method-surface closure in [0.16.5] — cut from `v0.16.2` so consumers could
-> take them without the breaking changes queued here for 0.17.0.
+> take them without the breaking changes released here.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 # MSRV-aware dependency resolution (cargo 1.84+): prefer dependency versions
 # whose own rust-version fits ours. Without it CI re-resolves to whatever is


### PR DESCRIPTION
First release off `main` since **0.16.2**. The 0.16.x maintenance line
(`release/0.16.x`, currently 0.16.5) carried fixes to consumers who could not
take breaking changes; this is where those changes land.

Two files: `Cargo.toml` version bump, and the `## Unreleased` → `## 0.17.0`
heading rename. `Cargo.lock` is gitignored.

## Headline changes

**`LlmCompaction`** — an opt-in compaction strategy that summarizes instead of
dropping. `DefaultCompaction`'s lossy tiers discard early decisions and
constraints outright; this splices a prose handoff briefing where the dropped
span was. It buys retention quality and **costs tokens** — it does not reduce
prefix-cache breaks, and the docs say so with figures from a committed harness.

**`CacheStrategy` beyond Anthropic** — native OpenAI now receives
`prompt_cache_key`. That takes cache hints from 1 protocol to 2 of 7; Azure,
the OpenAI Responses path and Bedrock accept directives and remain unwired,
documented as our gap rather than their limitation.

**`SessionStats` on `AgentEnd`** — a run's cache hit rate, token totals, cost
and compaction count, summed by the loop. Previously every per-turn number
existed and nothing aggregated them, so cache-affecting changes got judged by
hand-built harnesses.

**Sonnet 5 was mispriced** — `ModelConfig::claude_sonnet_5` carried Sonnet
4.6's rates, overstating every `cost_usd` for that model by 50%.

## Breaking changes

`#[non_exhaustive]` added to `CacheConfig`, `CacheStrategy`, `OpenAiCompat`,
`MockResponse`, `ToolContext`, and the `AgentEvent::AgentEnd` variant — on top
of the five enums that took it earlier in this cycle. Construct via the
provided `new`/builder methods instead of struct literals; add `..` to affected
patterns and `_ =>` to affected matches.

`ToolContext` is the one worth reading twice. Its doc had claimed since
introduction that adding fields was non-breaking; that was false, and making it
true cost 20 struct-literal rewrites in this repo alone (#130).

## Why now rather than after the open follow-ups

Three known gaps are documented in the code and issues: sub-agent spend is
invisible to `SessionStats`, compaction splice-vs-fallback attribution is
unavailable to the loop, and three protocols accept cache directives yoagent
does not send. **All three are additive after this release** — the first needs
a `ToolContext` field (now non-breaking, thanks to #130), the second a
defaulted trait method on `CompactionStrategy`, the third request-body changes
only. None is stranded behind a future breaking cycle.

## Verification

- 530 tests pass; clippy clean under `-Dwarnings`; `cargo check` green at 0.17.0
- `main` is at `8d703a0` with PRs #119, #121, #122, #128, #129, #130 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)