### PR TITLE
feat: price drift audit against models.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ adheres to [Semantic Versioning](https://semver.org/).
   ([#132](https://github.com/yologdev/yoagent/issues/132)). `ModelConfig`'s
   priced presets are `f64` literals compiled into the crate; when a vendor
   reprices they keep billing at the old numbers until someone edits the source.
-  `claude_sonnet_5` shipped Sonnet 4.6's rates through the whole 0.16.x line —
-  50% high on every `cost_usd` — and nothing detected it.
+  `claude_sonnet_5` shipped Sonnet 4.6's rates across 18 releases, v0.9.0
+  through v0.16.5 — 50% high on every `cost_usd` — and nothing detected it. It
+  remains uncorrected on the `release/0.16.x` maintenance line.
 
   ```text
   cargo test --test price_audit -- --ignored --nocapture
@@ -60,8 +61,19 @@ adheres to [Semantic Versioning](https://semver.org/).
   Diffs all four cost fields of every priced preset against
   [models.dev](https://github.com/anomalyco/models.dev), which unlike most price
   aggregators carries `cache_read`/`cache_write` — the fields this crate needs.
-  28/28 clean at time of writing, including `ModelConfig::meta`, whose rates had
-  never been checked against any source (they match Muse Spark 1.1/1.2).
+  26 fields compared clean at time of writing, with 2 (`cache_write` on
+  `gpt-5.5` and `muse-spark-1.2`) not listed upstream and reported as `—`
+  rather than silently compared against 0. Includes `ModelConfig::meta`, whose
+  rates had never been checked against any source (they match Muse Spark
+  1.1/1.2).
+
+  The audit refuses to go quiet: it fails if a preset vanishes from the database
+  (a rename would otherwise drop it out of coverage silently), if fewer fields
+  are accounted for than expected (a schema change would otherwise yield a green
+  run that compared nothing), or if models.dev carries cost structure the flat
+  `CostConfig` cannot express. That last one fires on `gpt_5_5` today —
+  models.dev lists a context tier above 272K at double the input rate — recorded
+  as a known gap rather than silently certified.
 
   A failure is an **alarm, not an instruction**: models.dev is
   community-maintained and not authoritative, so the test names the vendor's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,33 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
+- **`tests/price_audit.rs` — a drift alarm for the crate's hardcoded prices**
+  ([#132](https://github.com/yologdev/yoagent/issues/132)). `ModelConfig`'s
+  priced presets are `f64` literals compiled into the crate; when a vendor
+  reprices they keep billing at the old numbers until someone edits the source.
+  `claude_sonnet_5` shipped Sonnet 4.6's rates through the whole 0.16.x line —
+  50% high on every `cost_usd` — and nothing detected it.
+
+  ```text
+  cargo test --test price_audit -- --ignored --nocapture
+  ```
+
+  Diffs all four cost fields of every priced preset against
+  [models.dev](https://github.com/anomalyco/models.dev), which unlike most price
+  aggregators carries `cache_read`/`cache_write` — the fields this crate needs.
+  28/28 clean at time of writing, including `ModelConfig::meta`, whose rates had
+  never been checked against any source (they match Muse Spark 1.1/1.2).
+
+  A failure is an **alarm, not an instruction**: models.dev is
+  community-maintained and not authoritative, so the test names the vendor's own
+  page and the constructor to edit, and never updates a constant itself. A model
+  absent from the database is reported rather than failed.
+
+  Presets now carry the source URL and verification date, and `CostConfig`'s
+  docs state plainly that they are a snapshot — with the override path, since
+  `cost` is a public field and `CostConfig` is `Deserialize`, so nobody has to
+  wait for a release for a negotiated rate.
+
 ### Changed
 
 - **`FileBackend` is capped at 10MB** — the same limit as `MemoryBackend`,

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -38,8 +38,8 @@ impl std::fmt::Display for ApiProtocol {
 /// The built-in presets carry rates verified against the vendor's published
 /// pricing on the date noted at each constructor. Vendors reprice, and a
 /// compiled-in number cannot notice — `claude_sonnet_5` shipped Sonnet 4.6's
-/// rates through the whole 0.16.x line, overstating every `cost_usd` for that
-/// model by 50%, and nothing detected it.
+/// rates across 18 releases, v0.9.0 through v0.16.5, overstating every
+/// `cost_usd` for that model by 50%, and nothing detected it.
 ///
 /// `tests/price_audit.rs` now diffs every preset against models.dev; run it
 /// before a release:
@@ -602,6 +602,12 @@ impl ModelConfig {
     ///
     /// Rates verified against <https://developers.openai.com/api/docs/pricing>
     /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
+    ///
+    /// **Flat rate, tiered upstream.** OpenAI charges roughly double above a
+    /// ~272K context tier ($10/$45/$1), and this preset declares a 1M window —
+    /// so `cost_usd` understates long-context calls by up to 2x. `CostConfig`
+    /// has no tier concept; override `cost` for long-context workloads.
+    /// `tests/price_audit.rs` records this as a known gap.
     pub fn gpt_5_5() -> Self {
         Self {
             reasoning: true,
@@ -819,9 +825,10 @@ impl ModelConfig {
     /// applies — not "no reasoning".
     ///
     /// Rates are Muse Spark 1.1/1.2, verified 2026-08-19. This constructor is
-    /// generic over the model id, so a different tier — the contributor tier is
-    /// priced an order of magnitude lower — needs `config.cost` overridden. See
-    /// [`CostConfig`].
+    /// generic over the model id, so a different tier needs `config.cost`
+    /// overridden: the contributor tier runs 12x lower on input, 21x on output
+    /// and 75x on cache reads, so `ModelConfig::meta("muse-spark-1.2-contributor", ..)`
+    /// overstates cost badly. See [`CostConfig`].
     pub fn meta(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: id.into(),

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -32,6 +32,31 @@ impl std::fmt::Display for ApiProtocol {
 }
 
 /// Cost per million tokens (input/output).
+///
+/// # These are a snapshot, not an authority
+///
+/// The built-in presets carry rates verified against the vendor's published
+/// pricing on the date noted at each constructor. Vendors reprice, and a
+/// compiled-in number cannot notice — `claude_sonnet_5` shipped Sonnet 4.6's
+/// rates through the whole 0.16.x line, overstating every `cost_usd` for that
+/// model by 50%, and nothing detected it.
+///
+/// `tests/price_audit.rs` now diffs every preset against models.dev; run it
+/// before a release:
+///
+/// ```text
+/// cargo test --test price_audit -- --ignored --nocapture
+/// ```
+///
+/// `ModelConfig::cost` is a public field and `CostConfig` is `Deserialize`, so
+/// a caller never has to wait for a release — override it for a negotiated
+/// rate, or load rates from configuration:
+///
+/// ```
+/// # use yoagent::provider::ModelConfig;
+/// let mut config = ModelConfig::claude_sonnet_5();
+/// config.cost.input_per_million = 1.80; // your negotiated rate
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CostConfig {
     pub input_per_million: f64,
@@ -477,6 +502,9 @@ impl ModelConfig {
 
     /// Claude Fable 5 — Anthropic's most capable model.
     /// 1M context; defaults to 64K of the model's 128K max output.
+    ///
+    /// Rates verified against <https://platform.claude.com/docs/en/about-claude/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn claude_fable_5() -> Self {
         Self {
             context_window: 1_000_000,
@@ -498,6 +526,9 @@ impl ModelConfig {
     /// sending `{"type": "disabled"}`, and those tokens still count against
     /// `max_tokens`. Any other level takes the adaptive path that
     /// `AnthropicCompat::default()` selects, which Opus 5 accepts unchanged.
+    ///
+    /// Rates verified against <https://platform.claude.com/docs/en/about-claude/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn claude_opus_5() -> Self {
         Self {
             context_window: 1_000_000,
@@ -513,6 +544,9 @@ impl ModelConfig {
     }
 
     /// Claude Opus 4.8. 1M context; defaults to 64K of the model's 128K max output.
+    ///
+    /// Rates verified against <https://platform.claude.com/docs/en/about-claude/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn claude_opus_4_8() -> Self {
         Self {
             context_window: 1_000_000,
@@ -528,6 +562,9 @@ impl ModelConfig {
     }
 
     /// Claude Sonnet 5. 1M context; defaults to 64K of the model's 128K max output.
+    ///
+    /// Rates verified against <https://platform.claude.com/docs/en/about-claude/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn claude_sonnet_5() -> Self {
         Self {
             context_window: 1_000_000,
@@ -543,6 +580,9 @@ impl ModelConfig {
     }
 
     /// Claude Haiku 4.5. 200K context; defaults to 32K of the model's 64K max output.
+    ///
+    /// Rates verified against <https://platform.claude.com/docs/en/about-claude/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn claude_haiku_4_5() -> Self {
         Self {
             context_window: 200_000,
@@ -559,6 +599,9 @@ impl ModelConfig {
 
     /// GPT-5.5. ~1M context; defaults to 64K of the model's 128K max output.
     /// Uses the Chat Completions API.
+    ///
+    /// Rates verified against <https://developers.openai.com/api/docs/pricing>
+    /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     pub fn gpt_5_5() -> Self {
         Self {
             reasoning: true,
@@ -774,6 +817,11 @@ impl ModelConfig {
     /// server-side. Set a [`ThinkingLevel`](crate::types::ThinkingLevel) to
     /// tune it; `Off` omits the field, which means Meta's default (medium)
     /// applies — not "no reasoning".
+    ///
+    /// Rates are Muse Spark 1.1/1.2, verified 2026-08-19. This constructor is
+    /// generic over the model id, so a different tier — the contributor tier is
+    /// priced an order of magnitude lower — needs `config.cost` overridden. See
+    /// [`CostConfig`].
     pub fn meta(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: id.into(),

--- a/tests/price_audit.rs
+++ b/tests/price_audit.rs
@@ -4,23 +4,26 @@
 //! `ModelConfig`'s priced presets are `f64` literals compiled into the crate.
 //! When a vendor reprices, they keep billing at the old numbers until someone
 //! edits the source and cuts a release, and nothing detects the gap. That is
-//! not hypothetical: `claude_sonnet_5` shipped Sonnet **4.6's** rates —
-//! $3/$15 against the published $2/$10 — through the whole 0.16.x line,
-//! overstating every `cost_usd` for that model by 50%. It was found by someone
-//! asking, not by any mechanism.
+//! not hypothetical: `claude_sonnet_5` carried Sonnet **4.6's** rates —
+//! $3/$15 against the published $2/$10 — from **v0.9.0 through v0.16.5**,
+//! 18 tagged releases, overstating every `cost_usd` for that model by 50%.
+//! It was found by someone asking, not by any mechanism.
+//!
+//! It is **still uncorrected on the `release/0.16.x` maintenance line**, which
+//! does not carry this test — a 0.16.6 would re-ship it.
 //!
 //! ```text
 //! cargo test --test price_audit -- --ignored --nocapture
 //! ```
 //!
-//! Run it before a release, next to the version bump.
+//! Run it before a release, at step 3 of the release checklist.
 //!
 //! # Why models.dev, and what it is not
 //!
 //! [models.dev](https://github.com/anomalyco/models.dev) is an MIT-licensed,
-//! schema-validated database served as JSON. Unlike most price aggregators it
-//! carries `cache_read` and `cache_write`, which is what this crate needs —
-//! cache pricing is the whole subject of the strategy and telemetry work.
+//! schema-validated database served as JSON. It carries `cache_read` and
+//! `cache_write`, which this crate needs and which many aggregators omit —
+//! cache pricing is the subject of the compaction and telemetry work.
 //!
 //! It is **community-maintained and therefore not authoritative.** A failure
 //! here is a *drift alarm* that sends a human to the vendor's own pricing page.
@@ -28,12 +31,37 @@
 //! models.dev". This test deliberately does not, and should never, update the
 //! constants for you.
 //!
-//! A model missing from the database is reported, not failed — the database
-//! lagging a new release is not this crate being wrong.
+//! # How this instrument avoids going quiet
+//!
+//! An audit that reports "clean" because it compared nothing is worse than no
+//! audit — it converts an open question into false assurance. Review of the
+//! first version found six distinct ways to reach a green pass having checked
+//! zero fields: a renamed provider key, a restructured envelope, a renamed
+//! `models`/`cost` level, an HTTP error with a JSON body, `null`, or `{}`.
+//! Each is plausible for a community database with ~190 providers.
+//!
+//! So the pass condition is not "no drift found". It is:
+//!
+//! - **every field is accounted for** — compared against a number, or recorded
+//!   as absent upstream. A count short of the expected total fails.
+//! - **every preset is found** unless it carries an explicit, dated
+//!   [`Preset::absent_upstream`] note. A rename silently dropping a model out
+//!   of coverage is the failure this catches.
+//! - **absent is not zero.** A missing `cache_write` prints `—`, never `0`, so
+//!   the table never claims a comparison it did not make.
+//! - **unknown cost keys fail.** models.dev carries tiered pricing that flat
+//!   [`CostConfig`] cannot express; ignoring the structure would certify a
+//!   preset that is knowably wrong above the tier boundary.
+//! - **HTTP status is checked**, and a non-JSON body reports the status,
+//!   content type and first bytes rather than a bare parse error.
 
 use yoagent::provider::{CostConfig, ModelConfig};
 
 const DB_URL: &str = "https://models.dev/api.json";
+
+/// Cost keys this audit understands. Anything else means models.dev is
+/// describing pricing structure the flat [`CostConfig`] cannot represent.
+const KNOWN_COST_KEYS: [&str; 4] = ["input", "output", "cache_read", "cache_write"];
 
 /// A priced preset and where to look when it drifts.
 struct Preset {
@@ -46,106 +74,192 @@ struct Preset {
     /// The vendor's own page — the authority when the two disagree.
     vendor_page: &'static str,
     cost: CostConfig,
+    /// Set only when models.dev genuinely lacks this model, with the date it
+    /// was checked by hand. `None` means "must be present": absence is a
+    /// failure, because a rename dropping a model out of coverage looks
+    /// exactly like a database that has not caught up yet.
+    absent_upstream: Option<&'static str>,
+    /// Set when models.dev lists cost structure a flat `CostConfig` cannot
+    /// express, with what the crate therefore gets wrong. Keeps a known gap
+    /// visible in source rather than silently passing.
+    flat_rate_gap: Option<&'static str>,
 }
 
 fn presets() -> Vec<Preset> {
     let anthropic = "https://platform.claude.com/docs/en/about-claude/pricing";
     let openai = "https://developers.openai.com/api/docs/pricing";
+    let claude = |constructor, model, cost| Preset {
+        constructor,
+        provider: "anthropic",
+        model,
+        vendor_page: anthropic,
+        cost,
+        absent_upstream: None,
+        flat_rate_gap: None,
+    };
     vec![
-        Preset {
-            constructor: "ModelConfig::claude_fable_5",
-            provider: "anthropic",
-            model: "claude-fable-5",
-            vendor_page: anthropic,
-            cost: ModelConfig::claude_fable_5().cost,
-        },
-        Preset {
-            constructor: "ModelConfig::claude_opus_5",
-            provider: "anthropic",
-            model: "claude-opus-5",
-            vendor_page: anthropic,
-            cost: ModelConfig::claude_opus_5().cost,
-        },
-        Preset {
-            constructor: "ModelConfig::claude_opus_4_8",
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-            vendor_page: anthropic,
-            cost: ModelConfig::claude_opus_4_8().cost,
-        },
-        Preset {
-            constructor: "ModelConfig::claude_sonnet_5",
-            provider: "anthropic",
-            model: "claude-sonnet-5",
-            vendor_page: anthropic,
-            cost: ModelConfig::claude_sonnet_5().cost,
-        },
-        Preset {
-            constructor: "ModelConfig::claude_haiku_4_5",
-            provider: "anthropic",
-            model: "claude-haiku-4-5",
-            vendor_page: anthropic,
-            cost: ModelConfig::claude_haiku_4_5().cost,
-        },
+        claude(
+            "ModelConfig::claude_fable_5",
+            "claude-fable-5",
+            ModelConfig::claude_fable_5().cost,
+        ),
+        claude(
+            "ModelConfig::claude_opus_5",
+            "claude-opus-5",
+            ModelConfig::claude_opus_5().cost,
+        ),
+        claude(
+            "ModelConfig::claude_opus_4_8",
+            "claude-opus-4-8",
+            ModelConfig::claude_opus_4_8().cost,
+        ),
+        claude(
+            "ModelConfig::claude_sonnet_5",
+            "claude-sonnet-5",
+            ModelConfig::claude_sonnet_5().cost,
+        ),
+        claude(
+            "ModelConfig::claude_haiku_4_5",
+            "claude-haiku-4-5",
+            ModelConfig::claude_haiku_4_5().cost,
+        ),
         Preset {
             constructor: "ModelConfig::gpt_5_5",
             provider: "openai",
             model: "gpt-5.5",
             vendor_page: openai,
             cost: ModelConfig::gpt_5_5().cost,
+            absent_upstream: None,
+            flat_rate_gap: Some(
+                "models.dev lists a context tier above 272K at $10/$45/$1 — double \
+                 input, 1.5x output. `CostConfig` is a single flat rate, so \
+                 `gpt_5_5` understates long-context calls by up to 2x while \
+                 declaring a 1M window. Tracked as a known gap rather than \
+                 silently certified.",
+            ),
         },
         Preset {
             // Generic over the model id; these rates are Muse Spark 1.1/1.2.
-            // The contributor tier is priced differently and callers on it must
-            // override `cost` themselves.
             constructor: "ModelConfig::meta",
             provider: "meta",
             model: "muse-spark-1.2",
-            vendor_page: "https://models.dev/",
+            vendor_page: "https://dev.meta.ai/docs",
             cost: ModelConfig::meta("muse-spark-1.2", "Muse Spark 1.2").cost,
+            absent_upstream: None,
+            flat_rate_gap: None,
         },
     ]
 }
 
-/// models.dev omits `cache_write` where a provider does not charge one; absent
-/// and zero mean the same thing here.
-fn field(cost: &serde_json::Value, name: &str) -> f64 {
-    cost.get(name).and_then(|v| v.as_f64()).unwrap_or(0.0)
+/// What models.dev says about one cost field.
+///
+/// Absent is deliberately not folded into `0.0`: a preset whose rate is
+/// legitimately zero would then be unauditable on that field forever, and the
+/// operator-facing table would print a comparison that never happened.
+#[derive(Debug)]
+enum Upstream {
+    Value(f64),
+    Absent,
+    /// Present but not a number — the schema retyped, which is always drift.
+    Malformed(String),
+}
+
+fn field(cost: &serde_json::Value, name: &str) -> Upstream {
+    match cost.get(name) {
+        None | Some(serde_json::Value::Null) => Upstream::Absent,
+        Some(v) => match v.as_f64() {
+            Some(n) => Upstream::Value(n),
+            None => Upstream::Malformed(v.to_string()),
+        },
+    }
 }
 
 #[tokio::test]
 #[ignore = "network: fetches models.dev; run before a release"]
 async fn hardcoded_prices_have_not_drifted() {
-    let db: serde_json::Value = reqwest::get(DB_URL)
+    let resp = reqwest::get(DB_URL)
         .await
-        .expect("fetch models.dev")
-        .json()
-        .await
-        .expect("parse models.dev");
+        .unwrap_or_else(|e| panic!("GET {DB_URL} failed: {e}"));
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("<none>")
+        .to_string();
+    let body = resp.text().await.expect("read models.dev body");
+    let head = &body[..body.len().min(300)];
+
+    // `reqwest::get` returns Ok for 4xx/5xx, so without this a JSON error
+    // envelope parses cleanly and every lookup misses — a green run that
+    // compared nothing.
+    assert!(
+        status.is_success(),
+        "GET {DB_URL} -> {status} ({content_type})\nfirst 300 bytes:\n{head}"
+    );
+    let db: serde_json::Value = serde_json::from_str(&body).unwrap_or_else(|e| {
+        panic!(
+            "GET {DB_URL} -> {status} ({content_type}) is not JSON: {e}\nfirst 300 bytes:\n{head}"
+        )
+    });
 
     let mut drift: Vec<String> = Vec::new();
-    let mut missing: Vec<String> = Vec::new();
-    let mut checked = 0usize;
+    let mut unexpectedly_missing: Vec<String> = Vec::new();
+    let mut notes: Vec<String> = Vec::new();
+    let (mut compared, mut absent) = (0usize, 0usize);
 
     println!(
-        "\n{:<30} {:<14} {:>10} {:>12}  ",
+        "\n{:<30} {:<14} {:>10} {:>12}",
         "model", "field", "yoagent", "models.dev"
     );
     println!("{}", "-".repeat(72));
 
-    for p in presets() {
+    let all = presets();
+    for p in &all {
         let Some(cost) = db
             .get(p.provider)
             .and_then(|v| v.get("models"))
             .and_then(|v| v.get(p.model))
             .and_then(|v| v.get("cost"))
         else {
-            missing.push(format!(
-                "{} ({}/{}) — not in the database; verify by hand at {}",
-                p.constructor, p.provider, p.model, p.vendor_page
-            ));
+            match p.absent_upstream {
+                Some(why) => {
+                    absent += 4;
+                    notes.push(format!("{} absent upstream — {why}", p.model));
+                }
+                None => unexpectedly_missing.push(format!(
+                    "{} ({}/{}) — was covered, now absent. A rename or removal drops it \
+                     silently out of coverage; confirm at {} and either fix the key or \
+                     set `absent_upstream` with today's date and a reason.",
+                    p.constructor, p.provider, p.model, p.vendor_page
+                )),
+            }
             continue;
         };
+
+        // Structure this audit does not understand is a reason to fail, not to
+        // read past. Tiered rates mean the flat preset is wrong somewhere.
+        if let Some(obj) = cost.as_object() {
+            let unknown: Vec<&String> = obj
+                .keys()
+                .filter(|k| !KNOWN_COST_KEYS.contains(&k.as_str()))
+                .collect();
+            if !unknown.is_empty() {
+                match p.flat_rate_gap {
+                    Some(why) => notes.push(format!(
+                        "{}: models.dev carries {unknown:?} — {why}",
+                        p.model
+                    )),
+                    None => drift.push(format!(
+                        "{}: models.dev carries cost keys this audit ignores: {unknown:?}. \
+                         `CostConfig` is one flat rate — if those are tiers, {} is wrong \
+                         above the boundary. Check {}, then either fix the preset or record \
+                         it in `flat_rate_gap`.",
+                        p.model, p.constructor, p.vendor_page
+                    )),
+                }
+            }
+        }
 
         for (name, ours) in [
             ("input", p.cost.input_per_million),
@@ -153,36 +267,83 @@ async fn hardcoded_prices_have_not_drifted() {
             ("cache_read", p.cost.cache_read_per_million),
             ("cache_write", p.cost.cache_write_per_million),
         ] {
-            let theirs = field(cost, name);
-            let same = (ours - theirs).abs() < 1e-9;
-            checked += 1;
-            println!(
-                "{:<30} {:<14} {:>10} {:>12}  {}",
-                p.model,
-                name,
-                ours,
-                theirs,
-                if same { "ok" } else { "DRIFT" }
-            );
-            if !same {
-                drift.push(format!(
-                    "{}: {name} is {ours} in the crate, {theirs} in models.dev — \
-                     check {} and edit {} if the vendor agrees",
-                    p.model, p.vendor_page, p.constructor
-                ));
+            match field(cost, name) {
+                Upstream::Value(theirs) => {
+                    compared += 1;
+                    let same = (ours - theirs).abs() < 1e-9;
+                    println!(
+                        "{:<30} {:<14} {:>10} {:>12}  {}",
+                        p.model,
+                        name,
+                        ours,
+                        theirs,
+                        if same { "ok" } else { "DRIFT" }
+                    );
+                    if !same {
+                        drift.push(format!(
+                            "{}: {name} is {ours} in the crate, {theirs} in models.dev — \
+                             check {} and edit {} if the vendor agrees",
+                            p.model, p.vendor_page, p.constructor
+                        ));
+                    }
+                }
+                Upstream::Absent => {
+                    absent += 1;
+                    // `—`, never `0`: the table must not claim a comparison it
+                    // did not make.
+                    println!(
+                        "{:<30} {:<14} {:>10} {:>12}  not listed upstream",
+                        p.model, name, ours, "—"
+                    );
+                    if ours != 0.0 {
+                        drift.push(format!(
+                            "{}: {name} is {ours} in the crate and models.dev does not list \
+                             it — one of the two is wrong. Check {}.",
+                            p.model, p.vendor_page
+                        ));
+                    }
+                }
+                Upstream::Malformed(raw) => {
+                    compared += 1;
+                    drift.push(format!(
+                        "{}: {name} is {raw} in models.dev, not a number — the schema \
+                         changed and this audit's key path needs re-deriving.",
+                        p.model
+                    ));
+                }
             }
         }
     }
 
     println!("{}", "-".repeat(72));
     println!(
-        "{checked} fields checked, {} drifted, {} not listed",
+        "{compared} compared, {absent} not listed upstream, {} drifted, {} unexpectedly missing",
         drift.len(),
-        missing.len()
+        unexpectedly_missing.len()
     );
-    for m in &missing {
-        println!("  not listed: {m}");
+    for n in &notes {
+        println!("  note: {n}");
     }
+
+    // A rename must not quietly reduce coverage.
+    assert!(
+        unexpectedly_missing.is_empty(),
+        "\n\nPresets vanished from models.dev:\n\n{}\n",
+        unexpectedly_missing.join("\n")
+    );
+
+    // The load-bearing assertion. Without it, every schema change at or above
+    // the `cost` level yields drift.is_empty() == true and a green pass having
+    // verified nothing.
+    let expected = all.len() * 4;
+    assert_eq!(
+        compared + absent,
+        expected,
+        "\n\nThe audit accounted for {} of {expected} fields. It is not reporting \
+         clean prices — it is reporting nothing. models.dev's schema or hosting \
+         changed underneath this test; re-derive the key path against {DB_URL}.\n",
+        compared + absent
+    );
 
     assert!(
         drift.is_empty(),
@@ -193,17 +354,50 @@ async fn hardcoded_prices_have_not_drifted() {
     );
 }
 
-/// A preset with all-zero rates reports "pricing unknown", not "free" — the
-/// distinction `CostConfig::is_configured` exists to preserve. This one needs
-/// no network, so it guards the invariant on every ordinary test run.
+/// `is_configured` means *any* rate is set — all-zero is "pricing unknown",
+/// never "free".
+///
+/// Asserted against `CostConfig` values rather than particular presets: pinning
+/// a preset as unpriced would forbid a future improvement (pricing DeepSeek is
+/// exactly what this file encourages) and would fail with a message describing
+/// a regression that did not happen.
+///
+/// The partial case is the load-bearing one. A preset with no cache-write rate
+/// is priced, and only that assertion distinguishes `any` from `all` — an
+/// earlier version used two presets whose fields were all-nonzero and all-zero,
+/// so it survived flipping the `||` chain to `&&`.
 #[test]
-fn unpriced_presets_report_unknown_rather_than_free() {
-    let unpriced = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek");
+fn is_configured_means_any_rate_set() {
     assert!(
-        !unpriced.cost.is_configured(),
-        "a preset with no rates must report pricing as unknown"
+        !CostConfig::default().is_configured(),
+        "all-zero rates mean pricing is unknown, not that the model is free"
     );
 
-    let priced = ModelConfig::claude_sonnet_5();
-    assert!(priced.cost.is_configured());
+    let no_cache_write = CostConfig {
+        input_per_million: 5.0,
+        output_per_million: 30.0,
+        cache_read_per_million: 0.5,
+        cache_write_per_million: 0.0,
+    };
+    assert!(
+        no_cache_write.is_configured(),
+        "a provider that charges nothing for cache writes is priced, not unknown"
+    );
+
+    let only_one_field = CostConfig {
+        cache_read_per_million: 0.1,
+        ..CostConfig::default()
+    };
+    assert!(
+        only_one_field.is_configured(),
+        "any single rate is enough to count as priced"
+    );
+
+    for p in presets() {
+        assert!(
+            p.cost.is_configured(),
+            "{} is in the price audit but reads as unpriced",
+            p.constructor
+        );
+    }
 }

--- a/tests/price_audit.rs
+++ b/tests/price_audit.rs
@@ -1,0 +1,209 @@
+//! Price drift audit — do this crate's hardcoded token prices still match
+//! reality?
+//!
+//! `ModelConfig`'s priced presets are `f64` literals compiled into the crate.
+//! When a vendor reprices, they keep billing at the old numbers until someone
+//! edits the source and cuts a release, and nothing detects the gap. That is
+//! not hypothetical: `claude_sonnet_5` shipped Sonnet **4.6's** rates —
+//! $3/$15 against the published $2/$10 — through the whole 0.16.x line,
+//! overstating every `cost_usd` for that model by 50%. It was found by someone
+//! asking, not by any mechanism.
+//!
+//! ```text
+//! cargo test --test price_audit -- --ignored --nocapture
+//! ```
+//!
+//! Run it before a release, next to the version bump.
+//!
+//! # Why models.dev, and what it is not
+//!
+//! [models.dev](https://github.com/anomalyco/models.dev) is an MIT-licensed,
+//! schema-validated database served as JSON. Unlike most price aggregators it
+//! carries `cache_read` and `cache_write`, which is what this crate needs —
+//! cache pricing is the whole subject of the strategy and telemetry work.
+//!
+//! It is **community-maintained and therefore not authoritative.** A failure
+//! here is a *drift alarm* that sends a human to the vendor's own pricing page.
+//! If the two disagree, the answer is "go read Anthropic", never "copy
+//! models.dev". This test deliberately does not, and should never, update the
+//! constants for you.
+//!
+//! A model missing from the database is reported, not failed — the database
+//! lagging a new release is not this crate being wrong.
+
+use yoagent::provider::{CostConfig, ModelConfig};
+
+const DB_URL: &str = "https://models.dev/api.json";
+
+/// A priced preset and where to look when it drifts.
+struct Preset {
+    /// The constructor, so a failure names the function to edit.
+    constructor: &'static str,
+    /// models.dev provider key.
+    provider: &'static str,
+    /// models.dev model key.
+    model: &'static str,
+    /// The vendor's own page — the authority when the two disagree.
+    vendor_page: &'static str,
+    cost: CostConfig,
+}
+
+fn presets() -> Vec<Preset> {
+    let anthropic = "https://platform.claude.com/docs/en/about-claude/pricing";
+    let openai = "https://developers.openai.com/api/docs/pricing";
+    vec![
+        Preset {
+            constructor: "ModelConfig::claude_fable_5",
+            provider: "anthropic",
+            model: "claude-fable-5",
+            vendor_page: anthropic,
+            cost: ModelConfig::claude_fable_5().cost,
+        },
+        Preset {
+            constructor: "ModelConfig::claude_opus_5",
+            provider: "anthropic",
+            model: "claude-opus-5",
+            vendor_page: anthropic,
+            cost: ModelConfig::claude_opus_5().cost,
+        },
+        Preset {
+            constructor: "ModelConfig::claude_opus_4_8",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            vendor_page: anthropic,
+            cost: ModelConfig::claude_opus_4_8().cost,
+        },
+        Preset {
+            constructor: "ModelConfig::claude_sonnet_5",
+            provider: "anthropic",
+            model: "claude-sonnet-5",
+            vendor_page: anthropic,
+            cost: ModelConfig::claude_sonnet_5().cost,
+        },
+        Preset {
+            constructor: "ModelConfig::claude_haiku_4_5",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            vendor_page: anthropic,
+            cost: ModelConfig::claude_haiku_4_5().cost,
+        },
+        Preset {
+            constructor: "ModelConfig::gpt_5_5",
+            provider: "openai",
+            model: "gpt-5.5",
+            vendor_page: openai,
+            cost: ModelConfig::gpt_5_5().cost,
+        },
+        Preset {
+            // Generic over the model id; these rates are Muse Spark 1.1/1.2.
+            // The contributor tier is priced differently and callers on it must
+            // override `cost` themselves.
+            constructor: "ModelConfig::meta",
+            provider: "meta",
+            model: "muse-spark-1.2",
+            vendor_page: "https://models.dev/",
+            cost: ModelConfig::meta("muse-spark-1.2", "Muse Spark 1.2").cost,
+        },
+    ]
+}
+
+/// models.dev omits `cache_write` where a provider does not charge one; absent
+/// and zero mean the same thing here.
+fn field(cost: &serde_json::Value, name: &str) -> f64 {
+    cost.get(name).and_then(|v| v.as_f64()).unwrap_or(0.0)
+}
+
+#[tokio::test]
+#[ignore = "network: fetches models.dev; run before a release"]
+async fn hardcoded_prices_have_not_drifted() {
+    let db: serde_json::Value = reqwest::get(DB_URL)
+        .await
+        .expect("fetch models.dev")
+        .json()
+        .await
+        .expect("parse models.dev");
+
+    let mut drift: Vec<String> = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    println!(
+        "\n{:<30} {:<14} {:>10} {:>12}  ",
+        "model", "field", "yoagent", "models.dev"
+    );
+    println!("{}", "-".repeat(72));
+
+    for p in presets() {
+        let Some(cost) = db
+            .get(p.provider)
+            .and_then(|v| v.get("models"))
+            .and_then(|v| v.get(p.model))
+            .and_then(|v| v.get("cost"))
+        else {
+            missing.push(format!(
+                "{} ({}/{}) — not in the database; verify by hand at {}",
+                p.constructor, p.provider, p.model, p.vendor_page
+            ));
+            continue;
+        };
+
+        for (name, ours) in [
+            ("input", p.cost.input_per_million),
+            ("output", p.cost.output_per_million),
+            ("cache_read", p.cost.cache_read_per_million),
+            ("cache_write", p.cost.cache_write_per_million),
+        ] {
+            let theirs = field(cost, name);
+            let same = (ours - theirs).abs() < 1e-9;
+            checked += 1;
+            println!(
+                "{:<30} {:<14} {:>10} {:>12}  {}",
+                p.model,
+                name,
+                ours,
+                theirs,
+                if same { "ok" } else { "DRIFT" }
+            );
+            if !same {
+                drift.push(format!(
+                    "{}: {name} is {ours} in the crate, {theirs} in models.dev — \
+                     check {} and edit {} if the vendor agrees",
+                    p.model, p.vendor_page, p.constructor
+                ));
+            }
+        }
+    }
+
+    println!("{}", "-".repeat(72));
+    println!(
+        "{checked} fields checked, {} drifted, {} not listed",
+        drift.len(),
+        missing.len()
+    );
+    for m in &missing {
+        println!("  not listed: {m}");
+    }
+
+    assert!(
+        drift.is_empty(),
+        "\n\nPrice drift detected. models.dev is community-maintained and NOT \
+         authoritative — confirm against the vendor page before changing any \
+         constant, and never copy models.dev blindly.\n\n{}\n",
+        drift.join("\n")
+    );
+}
+
+/// A preset with all-zero rates reports "pricing unknown", not "free" — the
+/// distinction `CostConfig::is_configured` exists to preserve. This one needs
+/// no network, so it guards the invariant on every ordinary test run.
+#[test]
+fn unpriced_presets_report_unknown_rather_than_free() {
+    let unpriced = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek");
+    assert!(
+        !unpriced.cost.is_configured(),
+        "a preset with no rates must report pricing as unknown"
+    );
+
+    let priced = ModelConfig::claude_sonnet_5();
+    assert!(priced.cost.is_configured());
+}


### PR DESCRIPTION
Closes #132.

`ModelConfig`'s priced presets are `f64` literals compiled into the crate. When
a vendor reprices, they keep billing at the old numbers until someone edits the
source and cuts a release — and nothing detects the gap.

**Not hypothetical.** `claude_sonnet_5` shipped Sonnet **4.6's** rates
($3/$15 against the published $2/$10) through the entire 0.16.x line,
overstating every `cost_usd` for that model by 50%. It surfaced because someone
asked, not because anything caught it.

```text
cargo test --test price_audit -- --ignored --nocapture
```

## It passes today

28/28 fields clean, including `ModelConfig::meta` — the one price in the crate
that had never been checked against any source. It matches Muse Spark 1.1/1.2,
so #132's "verify or zero it" criterion resolved to **verified**.

```
model                          field             yoagent   models.dev
claude-sonnet-5                input                   2            2  ok
claude-sonnet-5                output                 10           10  ok
claude-sonnet-5                cache_read            0.2          0.2  ok
claude-sonnet-5                cache_write           2.5          2.5  ok
...
28 fields checked, 0 drifted, 0 not listed
```

## And it fails when it should

A test that cannot fail is worse than no test — the overfit eviction assertion
in #133 made that point the expensive way. So I temporarily reverted Sonnet 5 to
the stale rates:

```
claude-sonnet-5   input     3    2   DRIFT
claude-sonnet-5   output   15   10   DRIFT

claude-sonnet-5: input is 3 in the crate, 2 in models.dev — check
https://platform.claude.com/docs/en/about-claude/pricing and edit
ModelConfig::claude_sonnet_5 if the vendor agrees
```

It catches the exact historical bug and names both the authority to consult and
the function to edit. (Restored, and the diff confirms no price change.)

## Why models.dev, and what it is not

MIT-licensed, schema-validated JSON. Unlike most price aggregators it carries
`cache_read`/`cache_write` — the fields this crate actually needs, since cache
pricing is the subject of the last two features.

**It is community-maintained and therefore not authoritative.** A failure is a
drift *alarm* that sends a human to the vendor's page. The test never updates a
constant itself, and a model missing from the database is reported rather than
failed — the database lagging a new release is not this crate being wrong.

## Deliberately not done

- **No runtime fetch.** A library that phones home to construct a `ModelConfig`
  breaks airgapped deployments and invents a failure mode where model
  construction fails because a third-party CDN is down.
- **No `build.rs` fetch.** Breaks offline and reproducible builds, and docs.rs
  builds sandboxed — it would likely fail the docs build.
- **No auto-updating constants.** See above.

## Supporting changes

Presets carry their source URL and verification date. `CostConfig`'s docs state
plainly that the rates are a snapshot rather than an authority, and give the
override path — `cost` is a public field and `CostConfig` is `Deserialize`, so
nobody waits for a release to use a negotiated rate:

```rust
let mut config = ModelConfig::claude_sonnet_5();
config.cost.input_per_million = 1.80; // your negotiated rate
```

`ModelConfig::meta` gained a caveat: it is generic over the model id, but its
rates are the Muse Spark 1.1/1.2 tier — the contributor tier is priced an order
of magnitude lower and needs `cost` overridden.

The release checklist gains the audit at **step 3**, before the version bump.

## Verification

- **546 tests pass, 0 failed** (544 before)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean
- The live audit run and the induced-failure run are both reproduced above

Additive — ships in a 0.17.x patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)