### PR TITLE
feat: loop detection in ExecutionLimits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,41 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
+- **Loop detection in `ExecutionLimits`**
+  ([#126](https://github.com/yologdev/yoagent/issues/126)). The cheapest
+  catastrophic failure mode — a model calling one tool with the same arguments
+  forever — tripped none of the three existing limits early. They all fire
+  eventually, but only after burning the full turn, token and wall-clock budget,
+  so the run costs its maximum to discover it achieved nothing.
+
+  `max_identical_tool_calls: Option<usize>`, default `Some(3)`, `None` to
+  disable. Two escalations, mirroring the house pattern of steering before
+  aborting:
+
+  1. **First trip** injects a steering message and continues. A model repeating
+     a call is often retrying something transient, and aborting immediately
+     would regress that legitimate case.
+  2. **A later trip on the same signature** stops the run.
+
+  Both emit the new `AgentEvent::LoopDetected { tool_name, repetitions, aborted }`,
+  so a UI can show the intervention and GASP can record why a run ended — an
+  audit wants loop aborts distinguishable from turn-limit stops.
+
+  Signatures compare `serde_json::Value`, not serialized text: two calls
+  differing only in key order are the same call, and string comparison would
+  miss the loop. Counting covers duplicates *within* one batch as well as across
+  turns, because `ToolExecutionStrategy` defaults to `Parallel` and a model can
+  emit the same call three times in a single message. Any different call resets
+  the streak.
+
+  The check runs **before** tool execution, so a stuck model does not also pay
+  for the tool run it was never going to learn from.
+
+- **Breaking: `ExecutionLimits` gained `max_identical_tool_calls`.** The struct
+  is not `#[non_exhaustive]`, so downstream struct-literal construction needs
+  the new field or `..Default::default()`. Behaviour changes only for
+  pathological sessions, but it *is* on by default.
+
 - **`tests/price_audit.rs` — a drift alarm for the crate's hardcoded prices**
   ([#132](https://github.com/yologdev/yoagent/issues/132)). `ModelConfig`'s
   priced presets are `f64` literals compiled into the crate; when a vendor

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -577,6 +577,87 @@ async fn run_loop(
                 _ => vec![],
             };
 
+            // Repetition check runs *before* execution, so a stuck model does
+            // not also pay for the tool run it was never going to learn from.
+            if has_tool_calls_early(&tool_calls) {
+                if let Some(ref mut tracker) = tracker {
+                    let sigs: Vec<(String, serde_json::Value)> = tool_calls
+                        .iter()
+                        .map(|(_, name, args)| (name.clone(), args.clone()))
+                        .collect();
+                    match tracker.record_tool_calls(&sigs) {
+                        context::LoopVerdict::Continue => {}
+                        context::LoopVerdict::Steer {
+                            tool_name,
+                            repetitions,
+                        } => {
+                            warn!(
+                                "loop detection: {tool_name} called {repetitions}x with                                  identical arguments; steering"
+                            );
+                            tx.send(AgentEvent::LoopDetected {
+                                tool_name: tool_name.clone(),
+                                repetitions,
+                                aborted: false,
+                            })
+                            .ok();
+                            // A nudge, not a stop: a model repeating a call is
+                            // often retrying something transient, and it
+                            // usually recovers once told the result will not
+                            // change.
+                            let nudge = AgentMessage::Llm(Message::User {
+                                content: vec![Content::Text {
+                                    text: format!(
+                                        "[You have called {tool_name} {repetitions} times with                                          identical arguments. The result will not change —                                          change approach, or say why the repetition is needed.]"
+                                    ),
+                                }],
+                                timestamp: now_ms(),
+                            });
+                            tx.send(AgentEvent::MessageStart {
+                                message: nudge.clone(),
+                            })
+                            .ok();
+                            tx.send(AgentEvent::MessageEnd {
+                                message: nudge.clone(),
+                            })
+                            .ok();
+                            context.messages.push(nudge.clone());
+                            new_messages.push(nudge);
+                        }
+                        context::LoopVerdict::Abort {
+                            tool_name,
+                            repetitions,
+                        } => {
+                            warn!("loop detection: {tool_name} repeated after steering; stopping");
+                            tx.send(AgentEvent::LoopDetected {
+                                tool_name: tool_name.clone(),
+                                repetitions,
+                                aborted: true,
+                            })
+                            .ok();
+                            let stop = AgentMessage::Llm(Message::User {
+                                content: vec![Content::Text {
+                                    text: format!(
+                                        "[Agent stopped: {tool_name} was called repeatedly with                                          identical arguments after being asked to change                                          approach.]"
+                                    ),
+                                }],
+                                timestamp: now_ms(),
+                            });
+                            tx.send(AgentEvent::MessageStart {
+                                message: stop.clone(),
+                            })
+                            .ok();
+                            tx.send(AgentEvent::MessageEnd {
+                                message: stop.clone(),
+                            })
+                            .ok();
+                            context.messages.push(stop.clone());
+                            new_messages.push(stop);
+                            return stats;
+                        }
+                    }
+                }
+            }
+
             let has_tool_calls = !tool_calls.is_empty();
             let mut tool_results: Vec<Message> = Vec::new();
 
@@ -723,6 +804,11 @@ async fn run_loop(
     }
 
     stats
+}
+
+/// Whether this turn produced any tool call at all.
+fn has_tool_calls_early(calls: &[(String, String, serde_json::Value)]) -> bool {
+    !calls.is_empty()
 }
 
 /// Stream an assistant response from the LLM.

--- a/src/context.rs
+++ b/src/context.rs
@@ -881,6 +881,15 @@ pub struct ExecutionLimits {
     pub max_total_tokens: usize,
     /// Maximum wall-clock time
     pub max_duration: std::time::Duration,
+    /// Consecutive identical tool calls tolerated before intervening.
+    ///
+    /// The cheapest catastrophic failure mode is a model calling one tool with
+    /// the same arguments forever. The other three limits all fire eventually,
+    /// but only after burning the full turn, token and wall-clock budget — so
+    /// the run costs its maximum to discover it achieved nothing.
+    ///
+    /// `None` disables the check. Default `Some(3)`.
+    pub max_identical_tool_calls: Option<usize>,
 }
 
 impl Default for ExecutionLimits {
@@ -889,8 +898,28 @@ impl Default for ExecutionLimits {
             max_turns: 50,
             max_total_tokens: 1_000_000,
             max_duration: std::time::Duration::from_secs(600),
+            max_identical_tool_calls: Some(3),
         }
     }
+}
+
+/// What the loop should do about a repeated tool call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoopVerdict {
+    /// Nothing repetitive, or below the threshold.
+    Continue,
+    /// First trip: steer and keep going. A model that is stuck usually
+    /// recovers when told so, and aborting here would regress the legitimate
+    /// case of retrying a tool that failed transiently.
+    Steer {
+        tool_name: String,
+        repetitions: usize,
+    },
+    /// The same signature tripped again after being steered about. Stop.
+    Abort {
+        tool_name: String,
+        repetitions: usize,
+    },
 }
 
 /// Tracks execution state against limits
@@ -899,6 +928,17 @@ pub struct ExecutionTracker {
     pub turns: usize,
     pub tokens_used: usize,
     pub started_at: std::time::Instant,
+    /// The tool signature seen most recently, and how many times in a row.
+    ///
+    /// A signature is `(name, arguments)` compared as `serde_json::Value`, not
+    /// as serialized text — two calls that differ only in key order are the
+    /// same call, and string comparison would miss the loop.
+    last_signature: Option<(String, serde_json::Value)>,
+    consecutive: usize,
+    /// Signatures already steered about. A second trip on one of these aborts
+    /// rather than steering again, so a model that ignores the nudge does not
+    /// loop forever between nudges.
+    steered: Vec<(String, serde_json::Value)>,
 }
 
 impl ExecutionTracker {
@@ -908,7 +948,58 @@ impl ExecutionTracker {
             turns: 0,
             tokens_used: 0,
             started_at: std::time::Instant::now(),
+            last_signature: None,
+            consecutive: 0,
+            steered: Vec::new(),
         }
+    }
+
+    /// Fold one turn's tool calls into the repetition counter.
+    ///
+    /// Counts within a batch as well as across turns: `ToolExecutionStrategy`
+    /// defaults to `Parallel`, so a model can emit the same call three times in
+    /// one message and never take a second turn.
+    pub fn record_tool_calls(&mut self, calls: &[(String, serde_json::Value)]) -> LoopVerdict {
+        let Some(threshold) = self.limits.max_identical_tool_calls else {
+            return LoopVerdict::Continue;
+        };
+        if threshold == 0 {
+            return LoopVerdict::Continue;
+        }
+
+        let mut verdict = LoopVerdict::Continue;
+        for (name, args) in calls {
+            let sig = (name.clone(), args.clone());
+            match &self.last_signature {
+                Some(prev) if *prev == sig => self.consecutive += 1,
+                _ => {
+                    // Any different call breaks the streak — a model working
+                    // through distinct steps is not looping.
+                    self.last_signature = Some(sig.clone());
+                    self.consecutive = 1;
+                }
+            }
+
+            if self.consecutive >= threshold && verdict == LoopVerdict::Continue {
+                let repetitions = self.consecutive;
+                if self.steered.contains(&sig) {
+                    verdict = LoopVerdict::Abort {
+                        tool_name: name.clone(),
+                        repetitions,
+                    };
+                } else {
+                    self.steered.push(sig);
+                    // Reset so the abort needs another full run of repeats,
+                    // rather than firing on the very next call.
+                    self.consecutive = 0;
+                    verdict = LoopVerdict::Steer {
+                        tool_name: name.clone(),
+                        repetitions,
+                    };
+                }
+            }
+        }
+        verdict
     }
 
     pub fn record_turn(&mut self, tokens: usize) {
@@ -1478,6 +1569,7 @@ mod tests {
             max_turns: 3,
             max_total_tokens: 1000,
             max_duration: std::time::Duration::from_secs(60),
+            ..Default::default()
         };
 
         let mut tracker = ExecutionTracker::new(limits);

--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -425,6 +425,7 @@ impl AgentTool for SubAgentTool {
                 // Generous token/duration limits — turn limit is the primary guard
                 max_total_tokens: 1_000_000,
                 max_duration: std::time::Duration::from_secs(300),
+                ..Default::default()
             }),
             cache_config: self.cache_config.clone(),
             tool_output_sink: self.shared_state.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -799,6 +799,18 @@ pub enum AgentEvent {
     /// tell which one ran and what it cost. The built-in
     /// [`DefaultCompaction`](crate::context::DefaultCompaction) does not emit
     /// this; it has no event channel and never issues a request.
+    /// A tool was called repeatedly with identical arguments.
+    ///
+    /// Emitted on both escalations: the first trip steers the model and
+    /// continues, a later trip on the same signature stops the run. `aborted`
+    /// distinguishes them, so a caller can tell a nudge from a stop and an
+    /// audit can record why a run ended.
+    #[non_exhaustive]
+    LoopDetected {
+        tool_name: String,
+        repetitions: usize,
+        aborted: bool,
+    },
     ContextCompacted {
         /// Which compaction path produced this result.
         method: CompactionMethod,
@@ -823,6 +835,18 @@ impl AgentEvent {
     /// crates (and tests) build it here rather than with a struct literal.
     pub fn agent_end(messages: Vec<AgentMessage>, stats: SessionStats) -> Self {
         Self::AgentEnd { messages, stats }
+    }
+
+    /// Construct an [`AgentEvent::LoopDetected`].
+    ///
+    /// `aborted` separates the two escalations: `false` is a steer the model
+    /// can recover from, `true` means the run stopped.
+    pub fn loop_detected(tool_name: impl Into<String>, repetitions: usize, aborted: bool) -> Self {
+        Self::LoopDetected {
+            tool_name: tool_name.into(),
+            repetitions,
+            aborted,
+        }
     }
 }
 
@@ -1176,6 +1200,7 @@ mod wire_tag_freeze {
             AgentEvent::ToolExecutionEnd { .. } => "toolExecutionEnd",
             AgentEvent::ProgressMessage { .. } => "progressMessage",
             AgentEvent::InputRejected { .. } => "inputRejected",
+            AgentEvent::LoopDetected { .. } => "loopDetected",
             AgentEvent::ContextCompacted { .. } => "contextCompacted",
         }
     }

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -771,6 +771,7 @@ async fn test_execution_limit_counts_cached_tokens() {
             max_turns: 50,
             max_total_tokens: 100,
             max_duration: std::time::Duration::from_secs(60),
+            ..Default::default()
         }),
         cache_config: CacheConfig::default(),
         tool_output_sink: None,
@@ -2292,6 +2293,7 @@ fn calibration_config(
             max_turns: 2,
             max_total_tokens: 1_000_000,
             max_duration: std::time::Duration::from_secs(60),
+            ..Default::default()
         }),
         cache_config: CacheConfig::default(),
         tool_output_sink: None,
@@ -3314,4 +3316,168 @@ async fn with_shared_state_is_idempotent() {
     // The run completes; a duplicate tool name would have been a build-time
     // duplicate in the tool list handed to the provider.
     assert!(!agent.messages().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Loop detection (issue #126)
+// ---------------------------------------------------------------------------
+
+fn loop_events(events: &[AgentEvent]) -> Vec<(String, usize, bool)> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::LoopDetected {
+                tool_name,
+                repetitions,
+                aborted,
+                ..
+            } => Some((tool_name.clone(), *repetitions, *aborted)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn repeat_call(n: usize, args: serde_json::Value) -> Vec<MockResponse> {
+    (0..n)
+        .map(|_| {
+            MockResponse::ToolCalls(vec![MockToolCall {
+                provider_metadata: None,
+                name: "silent_tool".into(),
+                arguments: args.clone(),
+            }])
+        })
+        .collect()
+}
+
+async fn run_with_limits(
+    responses: Vec<MockResponse>,
+    limits: yoagent::context::ExecutionLimits,
+) -> Vec<AgentEvent> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(SilentTool)],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(responses));
+    config.execution_limits = Some(limits);
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+    collect_events(rx)
+}
+
+/// Three identical calls steer; continued repetition aborts. The steer comes
+/// first on purpose — a model repeating a call is often retrying something
+/// transient, and aborting immediately would regress that.
+#[tokio::test]
+async fn repeated_identical_calls_steer_then_abort() {
+    let events = run_with_limits(
+        repeat_call(12, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits {
+            max_identical_tool_calls: Some(3),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let detected = loop_events(&events);
+    assert!(
+        detected.iter().any(|(_, _, aborted)| !aborted),
+        "the first trip must steer, got {detected:?}"
+    );
+    assert!(
+        detected.iter().any(|(_, _, aborted)| *aborted),
+        "continued repetition must abort, got {detected:?}"
+    );
+
+    // Steer strictly precedes abort.
+    let first_abort = detected.iter().position(|(_, _, a)| *a).unwrap();
+    let first_steer = detected.iter().position(|(_, _, a)| !*a).unwrap();
+    assert!(
+        first_steer < first_abort,
+        "steer must come first: {detected:?}"
+    );
+}
+
+/// Distinct arguments are not a loop. This is the false positive that would
+/// make the feature worse than useless — an agent working through a list of
+/// files calls one tool repeatedly and legitimately.
+#[tokio::test]
+async fn distinct_arguments_never_trip() {
+    let responses: Vec<MockResponse> = (0..12)
+        .map(|i| {
+            MockResponse::ToolCalls(vec![MockToolCall {
+                provider_metadata: None,
+                name: "silent_tool".into(),
+                arguments: serde_json::json!({ "file": format!("f{i}.rs") }),
+            }])
+        })
+        .collect();
+
+    let events = run_with_limits(
+        responses,
+        yoagent::context::ExecutionLimits {
+            max_identical_tool_calls: Some(3),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        loop_events(&events).is_empty(),
+        "distinct arguments are progress, not repetition"
+    );
+}
+
+/// A different call between repeats breaks the streak.
+#[tokio::test]
+async fn an_interleaved_different_call_resets_the_counter() {
+    let mut responses = Vec::new();
+    for i in 0..12 {
+        responses.push(MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "silent_tool".into(),
+            // same, same, different, repeating — never 3 in a row
+            arguments: if i % 3 == 2 {
+                serde_json::json!({"q": "other"})
+            } else {
+                serde_json::json!({"q": "same"})
+            },
+        }]));
+    }
+
+    let events = run_with_limits(
+        responses,
+        yoagent::context::ExecutionLimits {
+            max_identical_tool_calls: Some(3),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        loop_events(&events).is_empty(),
+        "a streak broken before the threshold is not a loop"
+    );
+}
+
+/// `None` disables the check entirely.
+#[tokio::test]
+async fn detection_can_be_switched_off() {
+    let events = run_with_limits(
+        repeat_call(12, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits {
+            max_identical_tool_calls: None,
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        loop_events(&events).is_empty(),
+        "None must disable detection"
+    );
 }

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -169,6 +169,7 @@ fn test_execution_limits_roundtrip() {
         max_turns: 25,
         max_total_tokens: 500_000,
         max_duration: std::time::Duration::from_secs(300),
+        ..Default::default()
     };
     let json = serde_json::to_string(&limits).expect("serialize");
     let back: ExecutionLimits = serde_json::from_str(&json).expect("deserialize");
@@ -365,6 +366,7 @@ fn all_agent_events() -> Vec<AgentEvent> {
                 Some(0.0451),
             )),
         },
+        AgentEvent::loop_detected("bash", 3, false),
     ]
 }
 
@@ -450,6 +452,7 @@ fn expected_event_tag(event: &AgentEvent) -> &'static str {
         AgentEvent::ProgressMessage { .. } => "progressMessage",
         AgentEvent::InputRejected { .. } => "inputRejected",
         AgentEvent::ContextCompacted { .. } => "contextCompacted",
+        AgentEvent::LoopDetected { .. } => "loopDetected",
         _ => "unknown",
     }
 }
@@ -465,7 +468,7 @@ fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
 }
 
 /// Number of arms in `expected_event_tag` — bump together with the match.
-const EVENT_VARIANT_COUNT: usize = 13;
+const EVENT_VARIANT_COUNT: usize = 14;
 
 #[test]
 fn test_agent_event_type_tags_are_frozen() {


### PR DESCRIPTION
Closes #126.

The cheapest catastrophic failure mode — a model calling one tool with the same
arguments forever — tripped none of the three existing limits early. Turns,
tokens and wall-clock all fire *eventually*, but only after the run has burned
its entire budget to discover it achieved nothing.

```rust
ExecutionLimits {
    max_identical_tool_calls: Some(3),  // default; None disables
    ..Default::default()
}
```

## Two escalations, steer before abort

1. **First trip** — inject a steering message and continue.
2. **A later trip on the same signature** — stop the run.

Steering first is deliberate. A model repeating a call is often retrying
something transient, and a hard abort would regress that legitimate case. After
steering, the counter resets, so an abort needs another full run of repeats
rather than firing on the very next call.

Both emit `AgentEvent::LoopDetected { tool_name, repetitions, aborted }`, so a
UI can show the intervention and GASP can record *why* a run ended — an audit
wants a loop abort distinguishable from a turn-limit stop, not inferred from an
injected message.

## Two details it turns on

**Signatures compare `serde_json::Value`, not serialized text.** Two calls
differing only in key order are the same call; string comparison would miss the
loop entirely.

**Counting covers duplicates within one batch**, not just across turns.
`ToolExecutionStrategy` defaults to `Parallel`, so a model can emit the same
call three times in a single message and never take a second turn.

The check runs **before** tool execution, so a stuck model does not also pay for
the tool run it was never going to learn from.

## Tests

| test | property |
|---|---|
| `repeated_identical_calls_steer_then_abort` | steer precedes abort, both fire |
| `distinct_arguments_never_trip` | an agent working a list of files is progress, not repetition |
| `an_interleaved_different_call_resets_the_counter` | a broken streak is not a loop |
| `detection_can_be_switched_off` | `None` disables |

The two false-positive tests matter more than the detection one. A detector
that fires on legitimate repetition is worse than no detector.

## Noticed while wiring this up

`EVENT_VARIANT_COUNT` in `tests/serialization_test.rs` did **not** fail when a
14th `AgentEvent` variant appeared, despite an assertion message claiming it
guards exactly that. It compares two hand-maintained lists, so a new enum
variant slips past; the real compile-time guard is `wire_tag_freeze` in
`src/types.rs`. This PR adds the new variant's tag, sample and round-trip
coverage, but the count guard reads stronger than it is — worth an issue.

## Breaking

`ExecutionLimits` gained a field and is not `#[non_exhaustive]`, so downstream
struct literals need it or `..Default::default()`. On by default, so behaviour
changes for pathological sessions.

## Verification

- **550 tests pass, 0 failed** (546 before)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)