### PR TITLE
docs: record why summarization is standalone, not in-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
+- **Recorded why `LlmCompaction` summarizes standalone rather than in-session**
+  ([#127](https://github.com/yologdev/yoagent/issues/127)). Appending the
+  summarization instruction to the live session makes the history a prefix-cache
+  hit — an obvious-looking saving that measures badly, because the briefing is
+  then billed at the *loop* model's output rate. Per compaction: Sonnet 5 gains
+  3%, Opus 5 loses 2.4x, Fable 5 loses 4.8x. The idea was motivated by reusing
+  the expensive model's cache and the expensive model is where it loses.
+
+  It wins only when the loop model *is* the summarizer (DeepSeek in-session runs
+  3.2x cheaper than DeepSeek standalone), which is the configuration cheap-model
+  routing exists to avoid. And a background request racing the loop's own turn
+  can miss the cache entirely, paying full input on the whole history — 2.6x the
+  standalone cost on Sonnet. Best case a few percent, failure case a 2.6x
+  overrun. Documented as a no-go in the `llm_compaction` module docs.
+
 - **Loop detection in `ExecutionLimits`**
   ([#126](https://github.com/yologdev/yoagent/issues/126)). The cheapest
   catastrophic failure mode — a model calling one tool with the same arguments

--- a/src/llm_compaction.rs
+++ b/src/llm_compaction.rs
@@ -32,6 +32,43 @@
 //! [`AgentEvent::ContextCompacted`], which reports the request's own usage next
 //! to the tokens it saved.
 //!
+//! # Why the request is standalone, not appended to the live session
+//!
+//! An obvious-looking optimisation is to append the summarization instruction
+//! to the *live* session instead: the history is then a prefix-cache hit, so
+//! the span costs cached-input rates rather than fresh input. Measured against
+//! real pricing, it is a bad trade almost everywhere, and the reason is
+//! counterintuitive enough to be worth recording (yologdev/yoagent#127).
+//!
+//! In-session forces the briefing to be billed at the **loop model's** output
+//! rate. Output runs 5-10x input, so the cache saving on the span is swamped
+//! by the output penalty — and the more expensive the loop model, the worse it
+//! gets. Per compaction, at a ~12K history / ~8K span / ~1K briefing:
+//!
+//! | loop model | standalone on Haiku | appended in-session |
+//! |---|---|---|
+//! | Sonnet 5 | $0.0130 | $0.0126 |
+//! | Opus 5 | $0.0130 | $0.0315 |
+//! | Fable 5 | $0.0130 | $0.0630 |
+//!
+//! So the idea is backwards: it was motivated by "reuse the expensive model's
+//! cache", and the expensive model is exactly where it loses. It only wins when
+//! the loop model *is* the summarizer — DeepSeek in-session runs 3.2x cheaper
+//! than DeepSeek standalone — which is the configuration this strategy already
+//! steers away from, since routing summarization at a cheap model is the
+//! documented shape.
+//!
+//! The downside is worse than the upside. A background request that races the
+//! loop's own turn can arrive before the cache write lands and miss entirely,
+//! paying full input on the *whole history* rather than fresh input on the
+//! span: 2.6x the standalone cost on Sonnet. The best case is a few percent,
+//! the failure case is a 2.6x overrun, and the race is not something this
+//! crate controls.
+//!
+//! Recorded as **no-go**. Revisit if a provider appears whose output rates are
+//! flat across model tiers, or if a same-model summarizer becomes the common
+//! configuration rather than the fallback.
+//!
 //! **Does not buy: fewer prefix-cache breaks.** Both strategies rewrite history
 //! only when the budget is crossed, and neither rewrites in between, so the
 //! number of rewrites over a session is a wash: **6 vs 6** over 120 turns at a


### PR DESCRIPTION
Answers #127, which asked for **a go/no-go with the arithmetic written down**,
explicitly not an implementation. Docs only — no behaviour change.

**Answer: no-go.** The reason is backwards from the premise that motivated it.

## The comparison

Appending the summarization instruction to the live session makes the history a
prefix-cache hit, so the span costs cached-input rather than fresh input. But it
forces the briefing to be billed at the **loop model's** output rate, and output
runs 5–10x input.

Per compaction, at ~12K history / ~8K span / ~1K briefing (the shape from the
#119 live evaluation):

| loop model | standalone on Haiku | appended in-session | |
|---|---|---|---|
| Sonnet 5 | $0.0130 | $0.0126 | +3% |
| Opus 5 | $0.0130 | $0.0315 | **2.4x worse** |
| Fable 5 | $0.0130 | $0.0630 | **4.8x worse** |
| DeepSeek v4 Flash (own summarizer) | $0.00484 | $0.00153 | 3.2x better |

Decomposed for Sonnet 5:

```
A: span input     0.00800   briefing output 0.00500
B: cached history 0.00240   briefing output 0.01000
   input saved by B: +0.00560
   output penalty  : -0.00500   <- pays the LOOP model's output rate
```

The idea was *"reuse the expensive model's cache"*, and the expensive model is
exactly where it loses. It wins only when the loop model **is** the summarizer,
because then the output term is identical on both sides — which is the
configuration cheap-model routing exists to avoid.

## The downside exceeds the upside

#127 asked to verify the ordering hazard rather than assume it. It is real and
asymmetric. A background request racing the loop's own turn can arrive before
the cache write lands and miss entirely, paying full input on the **whole
history** rather than fresh input on the span:

| loop model | B (cache hit) | B (cache miss) | A standalone |
|---|---|---|---|
| Sonnet 5 | $0.01260 | $0.03420 | $0.01300 |
| DeepSeek v4 Flash | $0.00153 | $0.00664 | $0.00484 |

Best case a few percent, failure case a 2.6x overrun — and the race is not
something this crate controls. The summarization request and the loop's next
turn are independent HTTP calls against a cache whose write timing is the
provider's business.

It would also duplicate the background state machine that was **twice a bug**
before review caught it (the fingerprint anchored on `compact`'s input rather
than its return value; the whole-history splice that deleted the briefing while
still reporting `Summarized`). A second copy is a second place to get both
wrong, in exchange for those few percent.

## What lands

A section in the `llm_compaction` module doc with the table and the reasoning,
so the idea is not re-litigated from scratch in six months — plus the two
conditions that would justify revisiting:

- a provider whose output rates are flat across model tiers, removing the
  penalty that dominates the comparison
- same-model summarization becoming the common configuration rather than the
  fallback, since the DeepSeek row is a genuine 3.2x

#124's session aggregates are what made this measurable rather than theoretical
— the soft prerequisite noted when #127 was filed.

## Verification

- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- 17 doctests pass
- `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)