### PR TITLE
feat: per-block stash keys, and make the sub-agent sink reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,36 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
+- **Truncation stash: one key per content block, and `SubAgentTool` can now
+  reach it at all** ([#134](https://github.com/yologdev/yoagent/issues/134)).
+
+  A tool result carrying several text blocks got one marker per block, all
+  naming the **same** key, while the stash held the blocks joined by `\n` with
+  any image between them silently dropped. So a fetch returned every block
+  concatenated — never the block whose marker the model had just followed — and
+  the value called "full output" was missing content the transcript still
+  showed. Keys are now block-qualified and each marker names exactly the block it sits
+  in — the suffix is the block's position in the content vector, so
+  text/image/text yields `…-b0` and `…-b2`, not `-b0`/`-b1`.
+
+  Making that path reachable exposed a second problem it had been hiding: the
+  sub-agent's system prompt embeds a `SharedState` summary, so a second
+  invocation would have seen the first run's `tool-out-*` keys — a *different*
+  system prompt each time, breaking prefix caching on every sub-agent turn and
+  filling the most cache-sensitive text in the request with pointers to
+  kilobyte-sized blobs nobody asked about. The cost is a cold prefix on the
+  first turn of every subsequent delegation, not on every turn — the prompt is
+  built once per invocation. `SharedState::prompt_summary` excludes them; the
+  `shared_state` tool's `list` still shows them, so they stay discoverable at
+  runtime where changing text costs nothing.
+
+  Separately, the sink wired into `SubAgentTool` in #133 was **dead code**.
+  Sub-agents set `context_config: None`, and the loop gates truncation and
+  stashing together on that being `Some` — so sub-agents never truncated tool
+  output and therefore never stashed. `SubAgentTool::with_context_config` makes
+  both reachable. `max_turns` remains the guard on a sub-agent's *length*; this
+  is about the size of any single tool result it takes in.
+
 - **Recorded why `LlmCompaction` summarizes standalone rather than in-session**
   ([#127](https://github.com/yologdev/yoagent/issues/127)). Appending the
   summarization instruction to the live session makes the history a prefix-cache

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -691,9 +691,9 @@ async fn run_loop(
                     let original: AgentMessage = result.clone().into();
                     let mut am = original.clone();
                     if let Some(ctx_config) = append_cap {
-                        // First pass, unkeyed: tells us both what the context
-                        // will hold and whether a marker exists to name a key.
-                        let (plain, has_marker) =
+                        // First pass, unkeyed: tells us what the context will
+                        // hold and which blocks carry a marker to name a key.
+                        let (plain, marked) =
                             context::truncate_tool_output_keyed(original.clone(), ctx_config, None);
                         am = plain;
 
@@ -703,36 +703,107 @@ async fn run_loop(
                         // discarded the middle, so there would be nothing left
                         // to store.
                         //
-                        // `has_marker` is the gate, not "did the text change":
-                        // a budget too small for a marker still truncates, and
+                        // `marked` is the gate, not "did the text change": a
+                        // budget too small for a marker still truncates, and
                         // stashing then would leave an entry no marker names
                         // and nothing can reach.
-                        if let (Some(sink), true) = (&config.tool_output_sink, has_marker) {
+                        if let (Some(sink), false) = (&config.tool_output_sink, marked.is_empty()) {
                             if let Message::ToolResult { tool_call_id, .. } = result {
-                                let full = context::message_text(&original);
-                                let key = context::tool_output_key(tool_call_id, &full);
-                                match sink.set(&key, full).await {
-                                    Ok(()) => {
-                                        // Re-truncate from the original with
-                                        // the key inline, so the marker names
-                                        // it only once the value is stored.
-                                        am = context::truncate_tool_output_keyed(
-                                            original.clone(),
-                                            ctx_config,
-                                            Some(&key),
-                                        )
-                                        .0;
-                                    }
-                                    Err(e) => {
-                                        // The unkeyed marker already in `am` is
-                                        // the pre-feature behaviour: still
-                                        // truncated, but promising nothing it
-                                        // cannot deliver.
-                                        warn!(
-                                            "could not stash full output for {tool_call_id}: {e}; \
-                                             the truncation marker will not offer retrieval"
+                                let blocks = context::block_texts(&original);
+                                // One key per marked block. A single shared key
+                                // made every marker resolve to all blocks
+                                // concatenated, silently dropping any image
+                                // between them, so what the model fetched was
+                                // never the block whose marker it followed.
+                                // Via the shared helper, so the hash input
+                                // cannot drift from what `message_text`
+                                // documents and silently move every key.
+                                let base = context::tool_output_key(
+                                    tool_call_id,
+                                    &context::message_text(&original),
+                                );
+                                let mut all_stored = true;
+                                let mut written: Vec<String> = Vec::new();
+                                for idx in &marked {
+                                    let Some((_, text)) = blocks.iter().find(|(i, _)| i == idx)
+                                    else {
+                                        // Unreachable — `marked` and `blocks`
+                                        // both enumerate the same `original`.
+                                        // Fail closed regardless: continuing
+                                        // leaves `all_stored` true and emits a
+                                        // marker for a block never stored,
+                                        // which is the defect this feature
+                                        // exists to prevent.
+                                        debug_assert!(
+                                            false,
+                                            "marked block {idx} absent from block_texts"
                                         );
+                                        all_stored = false;
+                                        break;
+                                    };
+                                    let key = context::block_key(&base, *idx);
+                                    match sink.set(&key, text.clone()).await {
+                                        Ok(()) => written.push(key),
+                                        Err(e) => {
+                                            all_stored = false;
+                                            warn!(
+                                                tool_call_id = %tool_call_id,
+                                                block = idx,
+                                                bytes = text.len(),
+                                                "could not stash tool output: {e}; no marker in \
+                                                 this result will offer retrieval"
+                                            );
+                                            break;
+                                        }
                                     }
+                                }
+
+                                // `Ok(())` per write is not proof the set
+                                // survived. `FileBackend` evicts to fit and
+                                // exempts only the key it just wrote, so a
+                                // later sibling can evict an earlier one —
+                                // and its (mtime, filename) ordering makes
+                                // `-b0` lose to `-b2` deterministically. Naming
+                                // a key that was deleted microseconds ago is
+                                // exactly the marker-points-at-nothing failure
+                                // the backend's own guard was added to stop.
+                                if all_stored {
+                                    for key in &written {
+                                        if sink.get(key).await.is_none() {
+                                            all_stored = false;
+                                            warn!(
+                                                tool_call_id = %tool_call_id,
+                                                key = %key,
+                                                stored = written.len(),
+                                                "a stashed block did not survive storing its \
+                                                 siblings — the backend cap cannot hold this \
+                                                 result; no marker will offer retrieval"
+                                            );
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                // Roll back whatever is left, keyed or not.
+                                // Half a result in the store is unreachable
+                                // bytes that still count against the cap, and
+                                // on `FileBackend` they evict the caller's own
+                                // artifacts to make room for debris.
+                                if !all_stored {
+                                    for key in &written {
+                                        sink.remove(key).await;
+                                    }
+                                }
+                                if all_stored {
+                                    // Re-truncate from the original with the
+                                    // base key, so each marker names its own
+                                    // block only once every block is stored.
+                                    am = context::truncate_tool_output_keyed(
+                                        original.clone(),
+                                        ctx_config,
+                                        Some(&base),
+                                    )
+                                    .0;
                                 }
                             }
                         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -454,23 +454,31 @@ fn level1_truncate_tool_outputs(
         .collect()
 }
 
-/// All text content of a message, concatenated. Used to stash the full,
-/// pre-truncation output.
+/// All `Content::Text` of a message, joined with newlines.
+///
+/// The hash input for [`tool_output_key`] — not a stored value. Per-block
+/// stashing means no single entry holds this string.
 pub fn message_text(msg: &AgentMessage) -> String {
-    match msg {
-        AgentMessage::Llm(Message::ToolResult { content, .. }) => content
-            .iter()
-            .filter_map(|c| match c {
-                Content::Text { text } => Some(text.as_str()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        _ => String::new(),
-    }
+    block_texts(msg)
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
-/// The key a truncated tool result is stashed under.
+/// Prefix marking a key as machine-generated truncation stash rather than a
+/// variable a caller or model chose to store.
+///
+/// Used to keep these out of the system-prompt summary: that text is
+/// prefix-cached, and an entry appearing there on every stash would change the
+/// prompt each turn.
+pub const TOOL_OUTPUT_KEY_PREFIX: &str = "tool-out-";
+
+/// The **base** key for a truncated tool result.
+///
+/// Nothing is stored under this key: per-block keys derive from it via
+/// [`block_key`]. The hash input is every text block joined, so the base is
+/// stable for the whole result while each block gets its own entry.
 ///
 /// Combines the tool call id with a hash of the full output. The id alone is
 /// not enough: `google.rs` and `google_vertex.rs` synthesize ids as a
@@ -490,28 +498,67 @@ pub fn tool_output_key(tool_call_id: &str, full_output: &str) -> String {
         hash ^= u64::from(*byte);
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    format!("tool-out-{tool_call_id}-{hash:016x}")
+    format!("{TOOL_OUTPUT_KEY_PREFIX}{tool_call_id}-{hash:016x}")
 }
 
-/// Truncate, optionally naming a stash key inside the marker.
+/// The stash key for one content block of a tool result.
 ///
-/// Public so a caller implementing their own stash sink can reproduce exactly
-/// what the loop does: truncate with `None` to learn whether a marker exists,
-/// stash, then truncate again with `Some(key)`.
+/// Block-qualified because a result can carry several text blocks, each
+/// truncated independently and each getting its own marker. Sharing one key
+/// across them made every marker resolve to all the blocks concatenated —
+/// never the one the model had just been told to fetch.
+pub fn block_key(base: &str, block: usize) -> String {
+    format!("{base}-b{block}")
+}
+
+/// The text of each `Content::Text` block, with its index.
 ///
-/// Returns the message and whether a marker naming `key` was actually emitted.
+/// Indices are positions in the **full content vector** — the same enumeration
+/// [`truncate_tool_output_keyed`] uses — so the indices it reports in `marked`
+/// address these entries directly.
+///
+/// They are deliberately *not* a count of text blocks. A text-only ordinal
+/// would read more naturally and would silently disagree with the marker keys
+/// whenever non-text content sits between two text blocks: `[Text, Image,
+/// Text]` yields indices 0 and 2 here and must yield `-b0` and `-b2` there.
+pub fn block_texts(msg: &AgentMessage) -> Vec<(usize, String)> {
+    match msg {
+        AgentMessage::Llm(Message::ToolResult { content, .. }) => content
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| match c {
+                Content::Text { text } => Some((i, text.clone())),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Truncate, optionally naming a per-block stash key inside each marker.
+///
+/// Returns the message and the indices of blocks that actually got a marker.
 ///
 /// The key is threaded into marker *generation* rather than substituted
 /// afterwards. Rewriting the rendered text would hit every occurrence of the
 /// marker's shape — including one that came from the tool's own output, which
 /// is ordinary for a coding agent reading a log or a session transcript — and
-/// would silently do nothing in the case below where truncation emits no marker
-/// at all. Generating it means the key is present exactly when a marker is.
+/// would silently do nothing in the case where truncation emits no marker at
+/// all. Generating it means the key is present exactly when a marker is.
+///
+/// Each marker names *its own block's* key, so what the model fetches is the
+/// block whose marker it followed — not the whole result flattened, which is
+/// what a single shared key produced and which silently dropped any non-text
+/// content sitting between the blocks.
+///
+/// Public so a caller implementing their own stash sink can reproduce exactly
+/// what the loop does: truncate with `None` to learn which blocks carry a
+/// marker, stash those, then truncate again with the base key.
 pub fn truncate_tool_output_keyed(
     msg: AgentMessage,
     config: &ContextConfig,
-    key: Option<&str>,
-) -> (AgentMessage, bool) {
+    base_key: Option<&str>,
+) -> (AgentMessage, Vec<usize>) {
     match msg {
         AgentMessage::Llm(Message::ToolResult {
             tool_call_id,
@@ -521,13 +568,18 @@ pub fn truncate_tool_output_keyed(
             timestamp,
         }) => {
             let max_lines = config.max_lines_for(&tool_name);
-            let mut emitted = false;
+            let mut marked = Vec::new();
             let truncated_content: Vec<Content> = content
                 .into_iter()
-                .map(|c| match c {
+                .enumerate()
+                .map(|(i, c)| match c {
                     Content::Text { text } => {
-                        let (out, marked) = truncate_text_head_tail(&text, max_lines, key);
-                        emitted |= marked;
+                        let key = base_key.map(|b| block_key(b, i));
+                        let (out, emitted) =
+                            truncate_text_head_tail(&text, max_lines, key.as_deref());
+                        if emitted {
+                            marked.push(i);
+                        }
                         Content::Text { text: out }
                     }
                     other => other,
@@ -542,10 +594,10 @@ pub fn truncate_tool_output_keyed(
                     is_error,
                     timestamp,
                 }),
-                emitted,
+                marked,
             )
         }
-        other => (other, false),
+        other => (other, Vec::new()),
     }
 }
 

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -573,6 +573,33 @@ impl SharedState {
         }
     }
 
+    /// Summary for a system prompt: like [`summary`](Self::summary) but
+    /// excluding machine-generated truncation stashes.
+    ///
+    /// The system prompt is the most prefix-cache-sensitive text in a request.
+    /// A stash entry appearing here would change the prompt on every
+    /// truncation, breaking the cache on every subsequent turn and filling it
+    /// with kilobyte-sized keys nobody asked about. The model can still
+    /// discover them at runtime via the `shared_state` tool's `list`, which
+    /// uses the complete [`summary`](Self::summary).
+    pub async fn prompt_summary(&self) -> String {
+        let mut entries: Vec<(String, usize)> = Vec::new();
+        for key in self.keys().await {
+            // A scoped write lands as `scope␟tool-out-…`, so a prefix test on
+            // the whole key misses every stash a scoped sub-agent made — and it
+            // is the *unscoped* parent whose prompt would then carry them.
+            // Compare the part after the last scope separator.
+            let bare = key.rsplit(SCOPE_SEP).next().unwrap_or(&key);
+            if bare.starts_with(crate::context::TOOL_OUTPUT_KEY_PREFIX) {
+                continue;
+            }
+            let len = self.get(&key).await.map(|v| v.len()).unwrap_or(0);
+            entries.push((key, len));
+        }
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        format_summary(entries.iter().map(|(k, n)| (k.as_str(), *n)))
+    }
+
     /// Human-readable summary of stored variables (key names + byte sizes).
     /// Suitable for injecting into a system prompt.
     ///

--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -61,6 +61,7 @@ pub struct SubAgentTool {
     retry_config: crate::retry::RetryConfig,
     max_turns: usize,
     shared_state: Option<SharedState>,
+    context_config: Option<crate::context::ContextConfig>,
     turn_delay: Option<std::time::Duration>,
     model_config: Option<ModelConfig>,
     tool_middleware: Vec<Arc<dyn ToolMiddleware>>,
@@ -99,6 +100,7 @@ impl SubAgentTool {
             retry_config: crate::retry::RetryConfig::default(),
             max_turns: DEFAULT_MAX_TURNS,
             shared_state: None,
+            context_config: None,
             turn_delay: None,
             model_config: None,
             tool_middleware: Vec::new(),
@@ -243,6 +245,31 @@ impl SubAgentTool {
         self
     }
 
+    /// Give the sub-agent its own context management.
+    ///
+    /// Sub-agents ran without one, so `truncate_tool_output_on_append` never
+    /// fired for them and a sub-agent's oversized tool output entered its
+    /// context whole — and, once #133 wired a stash sink here, that sink was
+    /// unreachable because the loop gates truncation and stashing together on
+    /// this being `Some`.
+    ///
+    /// This enables the **whole** context pipeline for the child loop, not just
+    /// truncation: compaction summarizes and drops old turns once the sub-agent
+    /// exceeds `max_context_tokens`. `max_turns` remains the guard on a
+    /// sub-agent's *length*; this adds guards on any single tool result and on
+    /// total history.
+    ///
+    /// The gate is this being `Some` **and** `truncate_tool_output_on_append`,
+    /// which defaults to true — passing a config with it false still yields no
+    /// truncation and no stash. Note also that the budget is line-based, so a
+    /// single-line result (minified JSON, base64) passes through whole.
+    ///
+    /// Not inherited by nested sub-agents; each needs its own call.
+    pub fn with_context_config(mut self, config: crate::context::ContextConfig) -> Self {
+        self.context_config = Some(config);
+        self
+    }
+
     pub fn with_max_turns(mut self, max: usize) -> Self {
         self.max_turns = max;
         self
@@ -382,7 +409,7 @@ impl AgentTool for SubAgentTool {
         // Inject SharedStateTool when shared state is configured
         if let Some(ref state) = self.shared_state {
             tools.push(Box::new(SharedStateTool::new(state.clone())));
-            let summary = state.summary().await;
+            let summary = state.prompt_summary().await;
             system_prompt.push_str(&format!(
                 "\n\n## Shared State\nYou have access to a shared variable store via the `shared_state` tool.\nAvailable: {}",
                 summary
@@ -418,7 +445,7 @@ impl AgentTool for SubAgentTool {
             transform_context: None,
             get_steering_messages: None,
             get_follow_up_messages: None,
-            context_config: None,
+            context_config: self.context_config.clone(),
             compaction_strategy: None,
             execution_limits: Some(ExecutionLimits {
                 max_turns: self.max_turns,

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -3481,3 +3481,303 @@ async fn detection_can_be_switched_off() {
         "None must disable detection"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Multimodal + scoped stash (issue #134)
+// ---------------------------------------------------------------------------
+
+/// A tool result carrying text, an image, and more text.
+struct MultimodalTool;
+
+#[async_trait::async_trait]
+impl AgentTool for MultimodalTool {
+    fn name(&self) -> &str {
+        "multimodal"
+    }
+    fn label(&self) -> &str {
+        "Multimodal"
+    }
+    fn description(&self) -> &str {
+        "emits text, an image, and more text"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(
+        &self,
+        _p: serde_json::Value,
+        _c: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let long = |tag: &str| {
+            (0..300)
+                .map(|i| format!("{tag} {i}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        Ok(ToolResult {
+            content: vec![
+                Content::Text {
+                    text: long("alpha"),
+                },
+                Content::Image {
+                    data: "AAAA".into(),
+                    mime_type: "image/png".into(),
+                },
+                Content::Text {
+                    text: long("omega"),
+                },
+            ],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+fn markers_in(messages: &[AgentMessage]) -> Vec<String> {
+    messages
+        .iter()
+        .flat_map(|m| match m {
+            AgentMessage::Llm(Message::ToolResult { content, .. }) => content
+                .iter()
+                .filter_map(|c| match c {
+                    Content::Text { text } => text
+                        .split_once("shared_state get \"")
+                        .and_then(|(_, r)| r.split_once('"').map(|(k, _)| k.to_string())),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            _ => vec![],
+        })
+        .collect()
+}
+
+/// Each marker must resolve to *its own* block. Sharing one key across blocks
+/// made every fetch return all blocks concatenated, with the image between
+/// them silently dropped — so what the model got back was never the block whose
+/// marker it followed.
+#[tokio::test]
+async fn each_text_block_gets_its_own_key_and_resolves_to_itself() {
+    let state = yoagent::shared_state::SharedState::new();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(MultimodalTool)],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "multimodal".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("done".into()),
+    ]));
+    config.context_config = Some(yoagent::context::ContextConfig {
+        tool_output_max_lines: 20,
+        ..Default::default()
+    });
+    config.tool_output_sink = Some(state.clone());
+
+    let messages = agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    let keys = markers_in(&messages);
+    assert_eq!(
+        keys.len(),
+        2,
+        "one marker per truncated text block: {keys:?}"
+    );
+    assert_ne!(keys[0], keys[1], "blocks must not share a key: {keys:?}");
+
+    // Each key resolves to exactly the block whose marker named it.
+    let first = state.get(&keys[0]).await.expect("first key resolves");
+    let second = state.get(&keys[1]).await.expect("second key resolves");
+    assert!(
+        first.contains("alpha 150") && !first.contains("omega"),
+        "the first marker's key must return only the first block"
+    );
+    assert!(
+        second.contains("omega 150") && !second.contains("alpha"),
+        "the second marker's key must return only the second block"
+    );
+
+    // The image survives in the transcript untouched — truncation never
+    // rewrote it, and the stash never claimed to hold it.
+    let has_image = messages.iter().any(|m| match m {
+        AgentMessage::Llm(Message::ToolResult { content, .. }) => {
+            content.iter().any(|c| matches!(c, Content::Image { .. }))
+        }
+        _ => false,
+    });
+    assert!(has_image, "non-text content must pass through untouched");
+}
+
+/// Only the second text block is long enough to truncate, so `marked` is
+/// `[2]` while `blocks` holds entries at 0 and 2. Every other multi-block test
+/// truncates *all* blocks, which makes `marked`'s values and `blocks`'
+/// positions coincide — hiding the natural refactor
+/// (`marked.iter().enumerate()` indexing `blocks[n]`) that would store one
+/// block's text under another block's key.
+#[tokio::test]
+async fn a_partially_truncated_result_keys_the_right_block() {
+    struct ShortThenLong;
+    #[async_trait::async_trait]
+    impl AgentTool for ShortThenLong {
+        fn name(&self) -> &str {
+            "short_then_long"
+        }
+        fn label(&self) -> &str {
+            "Mixed"
+        }
+        fn description(&self) -> &str {
+            "a short block, an image, then a long one"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(
+            &self,
+            _p: serde_json::Value,
+            _c: ToolContext,
+        ) -> Result<ToolResult, ToolError> {
+            Ok(ToolResult {
+                content: vec![
+                    Content::Text {
+                        text: "short and safe".into(),
+                    },
+                    Content::Image {
+                        data: "AAAA".into(),
+                        mime_type: "image/png".into(),
+                    },
+                    Content::Text {
+                        text: (0..300)
+                            .map(|i| format!("omega {i}"))
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    },
+                ],
+                details: serde_json::Value::Null,
+            })
+        }
+    }
+
+    let state = yoagent::shared_state::SharedState::new();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(ShortThenLong)],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "short_then_long".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("done".into()),
+    ]));
+    config.context_config = Some(yoagent::context::ContextConfig {
+        tool_output_max_lines: 20,
+        ..Default::default()
+    });
+    config.tool_output_sink = Some(state.clone());
+
+    let messages = agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    let keys = markers_in(&messages);
+    assert_eq!(keys.len(), 1, "only the long block truncates: {keys:?}");
+    assert!(
+        keys[0].ends_with("-b2"),
+        "the key must name the long block's own position (2), not its ordinal \
+         among text blocks (1): {}",
+        keys[0]
+    );
+    let full = state.get(&keys[0]).await.expect("the key resolves");
+    assert!(
+        full.contains("omega 150") && !full.contains("short and safe"),
+        "the key must return the block whose marker named it"
+    );
+}
+
+/// Image-only results are correctly benign: nothing truncates, so nothing is
+/// stashed and no marker appears. Pinned so a future change to the stash gate
+/// cannot regress it into storing an empty string under a live key.
+#[tokio::test]
+async fn an_image_only_result_stashes_nothing() {
+    struct ImageOnly;
+    #[async_trait::async_trait]
+    impl AgentTool for ImageOnly {
+        fn name(&self) -> &str {
+            "image_only"
+        }
+        fn label(&self) -> &str {
+            "Image"
+        }
+        fn description(&self) -> &str {
+            "an image and nothing else"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(
+            &self,
+            _p: serde_json::Value,
+            _c: ToolContext,
+        ) -> Result<ToolResult, ToolError> {
+            Ok(ToolResult {
+                content: vec![Content::Image {
+                    data: "AAAA".into(),
+                    mime_type: "image/png".into(),
+                }],
+                details: serde_json::Value::Null,
+            })
+        }
+    }
+
+    let state = yoagent::shared_state::SharedState::new();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(ImageOnly)],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "image_only".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("done".into()),
+    ]));
+    config.context_config = Some(yoagent::context::ContextConfig {
+        tool_output_max_lines: 20,
+        ..Default::default()
+    });
+    config.tool_output_sink = Some(state.clone());
+
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert!(
+        state.keys().await.is_empty(),
+        "nothing was elided, so nothing may be stored"
+    );
+}

--- a/tests/shared_state_test.rs
+++ b/tests/shared_state_test.rs
@@ -415,13 +415,13 @@ fn a_budget_too_small_for_a_marker_reports_no_marker() {
             tool_output_max_lines: max_lines,
             ..Default::default()
         };
-        let (msg, emitted) = yoagent::context::truncate_tool_output_keyed(
+        let (msg, marked) = yoagent::context::truncate_tool_output_keyed(
             big_tool_result("tc-1", 100),
             &config,
             Some("tool-out-tc-1-deadbeef"),
         );
         assert!(
-            !emitted,
+            marked.is_empty(),
             "max_lines={max_lines} has no room for a marker, so none was emitted"
         );
         assert!(

--- a/tests/sub_agent_test.rs
+++ b/tests/sub_agent_test.rs
@@ -888,3 +888,218 @@ async fn test_sub_agent_tool_middleware_denies() {
     };
     assert!(text.contains("finished"));
 }
+
+// ---------------------------------------------------------------------------
+// Scoped stash: the sink and the tool must agree on scope (issue #134)
+// ---------------------------------------------------------------------------
+
+struct BigOutputTool;
+
+#[async_trait::async_trait]
+impl AgentTool for BigOutputTool {
+    fn name(&self) -> &str {
+        "big_output"
+    }
+    fn label(&self) -> &str {
+        "Big"
+    }
+    fn description(&self) -> &str {
+        "emits many lines"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(
+        &self,
+        _p: serde_json::Value,
+        _c: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        Ok(ToolResult {
+            content: vec![Content::Text {
+                text: (0..400)
+                    .map(|i| format!("line {i}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+/// A scoped sub-agent stashes under `scope␟key` while its marker names the bare
+/// key. That resolves only because the `shared_state` tool it is given carries
+/// the *same* scoped handle — an agreement that currently holds by construction
+/// and was asserted nowhere. A change to either side would break retrieval
+/// silently.
+#[tokio::test]
+async fn a_scoped_sub_agent_stash_resolves_through_its_own_scoped_tool() {
+    let parent_view = SharedState::new();
+
+    let sub_provider = MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "big_output".into(),
+            arguments: serde_json::json!({}),
+        }]),
+        MockResponse::Text("done".into()),
+    ]);
+
+    let sub_agent = SubAgentTool::from_provider(
+        "worker",
+        std::sync::Arc::new(sub_provider),
+        ModelConfig::mock(),
+    )
+    .with_tools(vec![std::sync::Arc::new(BigOutputTool)])
+    .with_scoped_shared_state(parent_view.clone(), "worker-1")
+    .with_context_config(yoagent::context::ContextConfig {
+        tool_output_max_lines: 20,
+        ..Default::default()
+    });
+
+    sub_agent
+        .execute(
+            serde_json::json!({"task": "produce output"}),
+            ToolContext::new("tc-1", "worker"),
+        )
+        .await
+        .expect("sub-agent should succeed");
+
+    // The parent's unscoped view sees the entry under the scope prefix, so the
+    // stash really did go through the scoped handle.
+    let parent_keys = parent_view.keys().await;
+    assert_eq!(
+        parent_keys.len(),
+        1,
+        "the sub-agent's truncated output must be stashed, got {parent_keys:?}"
+    );
+    assert!(
+        parent_keys[0].contains("worker-1"),
+        "the entry must carry the sub-agent's scope, got {parent_keys:?}"
+    );
+
+    // And the sub-agent's own scoped view resolves it by the bare key the
+    // marker names — which is the invariant that was never pinned.
+    let scoped = parent_view.scoped("worker-1");
+    let scoped_keys = scoped.keys().await;
+    assert_eq!(
+        scoped_keys.len(),
+        1,
+        "the scoped view must see exactly its own entry, got {scoped_keys:?}"
+    );
+    let full = scoped
+        .get(&scoped_keys[0])
+        .await
+        .expect("the scoped key the marker names must resolve");
+    assert!(
+        full.contains("line 200"),
+        "retrieval must return the elided middle"
+    );
+}
+
+/// A provider that records the system prompt it was handed.
+struct PromptRecorder {
+    prompts: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    inner: MockProvider,
+}
+
+#[async_trait::async_trait]
+impl yoagent::provider::StreamProvider for PromptRecorder {
+    async fn stream(
+        &self,
+        config: yoagent::provider::StreamConfig,
+        tx: tokio::sync::mpsc::UnboundedSender<yoagent::provider::StreamEvent>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<Message, yoagent::provider::ProviderError> {
+        self.prompts
+            .lock()
+            .unwrap()
+            .push(config.system_prompt.clone());
+        self.inner.stream(config, tx, cancel).await
+    }
+}
+
+/// Stashed tool output must not leak into the sub-agent's system prompt.
+///
+/// This asserts on the prompt the provider actually receives. An earlier
+/// version called `prompt_summary()` directly and never inspected a prompt —
+/// reverting `sub_agent.rs` to the leaking `summary()` left it green, so the
+/// test named for the regression could not see it.
+///
+/// The prompt embeds a `SharedState` summary computed once per invocation, so
+/// a second run would otherwise carry the first run's machine-generated
+/// `tool-out-*` keys — a different system prompt per delegation, meaning no
+/// sub-agent call can reuse the previous one's cached prefix.
+#[tokio::test]
+async fn stashed_output_does_not_leak_into_the_sub_agent_system_prompt() {
+    let store = SharedState::new();
+    let prompts = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    let run = |label: &'static str| {
+        let store = store.clone();
+        let prompts = prompts.clone();
+        async move {
+            SubAgentTool::from_provider(
+                "worker",
+                std::sync::Arc::new(PromptRecorder {
+                    prompts,
+                    inner: MockProvider::new(vec![
+                        MockResponse::ToolCalls(vec![MockToolCall {
+                            provider_metadata: None,
+                            name: "big_output".into(),
+                            arguments: serde_json::json!({}),
+                        }]),
+                        MockResponse::Text("done".into()),
+                    ]),
+                }),
+                ModelConfig::mock(),
+            )
+            .with_tools(vec![std::sync::Arc::new(BigOutputTool)])
+            .with_system_prompt("You are a worker.")
+            .with_shared_state(store)
+            .with_context_config(yoagent::context::ContextConfig {
+                tool_output_max_lines: 20,
+                ..Default::default()
+            })
+            .execute(
+                serde_json::json!({ "task": label }),
+                ToolContext::new("tc-1", "worker"),
+            )
+            .await
+            .expect("run")
+        }
+    };
+
+    run("first").await;
+    assert!(
+        !store.keys().await.is_empty(),
+        "precondition: the first run must have stashed something"
+    );
+    run("second").await;
+
+    let seen = prompts.lock().unwrap().clone();
+    assert!(
+        seen.len() >= 2,
+        "both invocations must have reached the provider"
+    );
+    for (i, prompt) in seen.iter().enumerate() {
+        assert!(
+            !prompt.contains("tool-out-"),
+            "prompt {i} carries a stash key: {prompt}"
+        );
+    }
+
+    // The load-bearing property: the prompt is byte-identical across
+    // invocations, so a delegation can reuse the previous one's cached prefix.
+    let first_of_run_one = &seen[0];
+    let first_of_run_two = seen.last().unwrap();
+    assert_eq!(
+        first_of_run_one, first_of_run_two,
+        "the system prompt must not change between invocations"
+    );
+
+    // A user-set variable still belongs in the prompt summary, and stashes are
+    // still discoverable at runtime through the tool's own listing.
+    store.set("findings", "user data".into()).await.unwrap();
+    assert!(store.prompt_summary().await.contains("findings"));
+    assert!(store.summary().await.contains("tool-out-"));
+}


### PR DESCRIPTION
Closes #134.

Two gaps left open in #133, plus three defects review found while fixing them.

## One key per content block

A tool result with several text blocks got one marker per block, all naming the
**same** key, while the stash held the blocks joined with `\n` and any image
between them dropped. A fetch returned every block concatenated — never the
block whose marker the model had just followed — and the value called "full
output" was missing content the transcript still showed.

Keys are now suffixed with the block's **position in the content vector**, so
text/image/text yields `-b0` and `-b2` (not `-b0`/`-b1` — that distinction is
now pinned by a test).

## The sub-agent sink was dead code

`SubAgentTool` set `context_config: None`, and the loop gates truncation and
stashing together on that being `Some`. So sub-agents never truncated tool
output, and the sink wired up in #133 was **never reached**. The missing test
wasn't just missing coverage — it was hiding that the feature was inert.

`with_context_config` makes both work. It enables the whole context pipeline,
compaction included, which the doc now says rather than implying it only caps
tool results.

Making that path live exposed a regression it had been hiding: the sub-agent's
system prompt embeds a `SharedState` summary, so a second invocation would carry
the first run's `tool-out-*` keys — a different prompt per delegation, meaning no
sub-agent call could reuse the previous one's cached prefix.
`SharedState::prompt_summary` excludes the stash namespace; the `shared_state`
tool's own listing still shows it, so stashes stay discoverable at runtime where
changing text costs nothing.

## What review found

**Sibling blocks evicted each other while reporting success.**
`FileBackend::evict_to_fit` exempts only the key it just wrote, so storing `-b2`
can evict `-b0` — and its `(mtime, filename)` ordering makes `-b0` lose
deterministically. `all_stored` stayed true and a marker named a key deleted
microseconds earlier. That is exactly the failure the backend's own guard was
added to stop, reintroduced by the multi-block change. Every stashed key is now
re-read before any marker names it, with rollback when the set didn't survive.

**The leak test did not test the leak.** It called `prompt_summary()` directly
and never inspected a prompt — reverting the fix left the whole suite green. It
now captures what the provider receives and asserts the prompt is byte-identical
across two invocations. Verified it fails on that mutation:

```
prompt 2 carries a stash key: You are a worker.
```

**`prompt_summary`'s filter did not survive scoping.** Scoped writes land as
`scope␟tool-out-…`, which fails a prefix test — so an unscoped parent would leak
its scoped sub-agents' stashes into its own prompt.

## Doc corrections

`block_texts` claimed full-vector indices are "stable regardless of what non-text
content sits between blocks" — the **inverse** of the truth, since interleaving
an image is precisely what shifts them. As a stated justification it would have
led a maintainer to the wrong implementation.

`prompt_summary` was inserted between `summary`'s doc block and `summary`,
leaving it undocumented — the same slip as `truncate_tool_output` in #133.

`message_text` was dead code with a false doc while the loop duplicated it
inline. It now backs the loop's hash input so the two cannot drift.

## Tests

Three new, including the one that closes the sharpest gap: every prior
multi-block test truncated *all* blocks, so `marked`'s values and `blocks`'
positions coincided — hiding the natural refactor that would store one block's
text under another's key. `a_partially_truncated_result_keys_the_right_block`
uses short/image/long so they differ.

## Verification

- **555 tests pass, 0 failed** (554 before)
- `cargo clippy --all-targets --features gasp` clean under `-Dwarnings`
- `cargo fmt -- --check` clean

Additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)