### PR TITLE
feat: model context tiers in CostConfig; every preset stays flat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,23 +46,54 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
-- **`CostConfig`'s flat-rate limitation is documented where it bites**
-  ([#138](https://github.com/yologdev/yoagent/issues/138)). `cost_usd` applies
+- **`CostConfig` models context tiers; no preset uses one**
+  ([#138](https://github.com/yologdev/yoagent/issues/138)). `cost_usd` applied
   one rate per token category regardless of request size, while some vendors
-  price long-context requests higher.
+  price long-context requests higher. It now takes an optional
+  `CostConfig::context_tier`, and selects rates by the request's **prompt**
+  tokens (`input + cache_read + cache_write`) so a long reply to a short prompt
+  stays on the base rate.
 
-  Checking every priced preset: six of seven are flat on both models.dev and the
-  vendor's own page. The seventh, `gpt_5_5`, is claimed tiered by models.dev
-  (above 272K at $10/$45/$1) — but OpenAI's pricing page lists it only in rows
-  annotated `<272K context length`, with no >272K row anywhere. The tier is
-  plausible, since the annotation implies *something* changes at that boundary,
-  but it is uncorroborated and its rates are models.dev's alone.
+  ```rust,ignore
+  let cost = CostConfig::new(5.0, 30.0, 0.5, 0.0)
+      .with_context_tier(ContextTier::new(272_000, 10.0, 45.0, 1.0));
+  ```
 
-  So the preset stays flat rather than encoding rates no vendor page confirms —
-  which is what #132's own doctrine requires: models.dev is a drift alarm, never
-  a source of truth. The claim, its source, and its unverified status are now on
-  the constructor; `CostConfig`'s docs say tiers are not modelled and point
-  callers running long-context workloads at setting `cost` themselves.
+  **Every shipped preset stays flat**, `gpt_5_5` included — and getting there
+  took three passes, each reversing the last. models.dev records a 272K tier for
+  gpt-5.5 at $10/$45/$1. Reading OpenAI's pricing page said no such row existed.
+  A closer read said it did, as columns rather than rows. Parsing the page's
+  actual markup resolved it: the `>272K input tokens` column group is real, but
+  **gpt-5.5 has no row in it** — the $10/$1/$45 triple belongs to
+  `gpt-5.6-sol`, a model whose short-context rates are identical to gpt-5.5's.
+  The one gpt-5.5 row that does appear in a long-context table,
+  `gpt-5.5-cyber`, has `-` in all four long-context cells.
+
+  What settled it was checking models.dev's tier data where a vendor states the
+  answer unambiguously: 34 Claude entries carry tiers, including
+  `claude-4.6-sonnet` and `claude-opus-4.6` — models Anthropic's own page says
+  bill the full 1M window at standard rates. Its tier data is demonstrably wrong
+  where it is checkable, so a models.dev tier alone is not grounds to double
+  what callers are charged. #132's doctrine, applied: drift alarm, never
+  authority.
+
+  `tests/price_audit.rs` now asserts the disputed rates rather than merely
+  naming the keys, so a revision upstream fails the audit and the decision gets
+  re-made against new evidence instead of silently inheriting this one.
+
+  One caveat for whoever tiers a preset later: prompt size is derived as
+  `input + cache_read + cache_write`, which holds only where the provider
+  subtracts cached tokens out of `input`. `bedrock.rs` populates neither cache
+  field, so a heavily-cached prompt reads small there and would select the cheap
+  tier.
+
+  **Breaking: `CostConfig` is now `#[non_exhaustive]`** and gained a fifth
+  field, so out-of-crate struct-literal construction no longer compiles. Use
+  `CostConfig::new(input, output, cache_read, cache_write)`, optionally with
+  `.with_context_tier(..)`; `..Default::default()` no longer rescues a literal.
+  Field *reads* and mutation through a binding are unaffected. This is the last
+  cheap moment to close it — every future rate category (per-image, per-second
+  audio, a second tier) would otherwise be another breaking release.
 
 - **Truncation stash: one key per content block, and `SubAgentTool` can now
   reach it at all** ([#134](https://github.com/yologdev/yoagent/issues/134)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,24 @@ adheres to [Semantic Versioning](https://semver.org/).
   restarts every turn — id alone would let turn 1's frozen marker resolve to
   turn 5's content.
 
+- **`CostConfig`'s flat-rate limitation is documented where it bites**
+  ([#138](https://github.com/yologdev/yoagent/issues/138)). `cost_usd` applies
+  one rate per token category regardless of request size, while some vendors
+  price long-context requests higher.
+
+  Checking every priced preset: six of seven are flat on both models.dev and the
+  vendor's own page. The seventh, `gpt_5_5`, is claimed tiered by models.dev
+  (above 272K at $10/$45/$1) — but OpenAI's pricing page lists it only in rows
+  annotated `<272K context length`, with no >272K row anywhere. The tier is
+  plausible, since the annotation implies *something* changes at that boundary,
+  but it is uncorroborated and its rates are models.dev's alone.
+
+  So the preset stays flat rather than encoding rates no vendor page confirms —
+  which is what #132's own doctrine requires: models.dev is a drift alarm, never
+  a source of truth. The claim, its source, and its unverified status are now on
+  the constructor; `CostConfig`'s docs say tiers are not modelled and point
+  callers running long-context workloads at setting `cost` themselves.
+
 - **Truncation stash: one key per content block, and `SubAgentTool` can now
   reach it at all** ([#134](https://github.com/yologdev/yoagent/issues/134)).
 

--- a/examples/llm_compaction_live.rs
+++ b/examples/llm_compaction_live.rs
@@ -123,12 +123,7 @@ fn priced(id: &str) -> ModelConfig {
 /// DeepSeek has no write category — populating its cache is free.
 fn deepseek_priced(id: &str, input: f64, output: f64, cache_read: f64) -> ModelConfig {
     let mut config = ModelConfig::deepseek(id, id);
-    config.cost = CostConfig {
-        input_per_million: input,
-        output_per_million: output,
-        cache_read_per_million: cache_read,
-        cache_write_per_million: 0.0,
-    };
+    config.cost = CostConfig::new(input, output, cache_read, 0.0);
     config
 }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -17,7 +17,7 @@ pub use bedrock::BedrockProvider;
 pub use google::GoogleProvider;
 pub use google_vertex::GoogleVertexProvider;
 pub use mock::MockProvider;
-pub use model::{AnthropicCompat, ApiProtocol, CostConfig, ModelConfig, OpenAiCompat};
+pub use model::{AnthropicCompat, ApiProtocol, ContextTier, CostConfig, ModelConfig, OpenAiCompat};
 pub use openai_compat::OpenAiCompatProvider;
 pub use openai_responses::OpenAiResponsesProvider;
 pub(crate) use registry::resolve_api_key_or_warn;

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -41,13 +41,22 @@ impl std::fmt::Display for ApiProtocol {
 /// rates across 18 releases, v0.9.0 through v0.16.5, overstating every
 /// `cost_usd` for that model by 50%, and nothing detected it.
 ///
-/// # Rates are flat; tiers are not modelled
+/// # Context tiers
 ///
-/// `cost_usd` applies one rate per token category regardless of request size.
-/// Some vendors price long-context requests higher. Of the presets here, six of
-/// seven are flat per models.dev *and* the vendor's own page; the seventh
-/// (`gpt_5_5`) has an unverified tier claim recorded at its constructor. If you
-/// run long-context workloads where the bill matters, set `cost` yourself.
+/// Some vendors charge more above a prompt-size threshold. Set
+/// [`context_tier`](Self::context_tier) and `cost_usd` selects by the request's
+/// prompt tokens (`input + cache_read + cache_write`).
+///
+/// **No preset here sets one** (checked 2026-08-20). Anthropic states that 4.6+
+/// models bill the full 1M window at standard rates, and Meta's page says there
+/// is no long-context premium; Haiku 4.5 is flat because its window is 200K.
+/// `gpt_5_5` is the one contested case — see its docs for why it stays flat.
+///
+/// Note the derivation: prompt size is `input + cache_read + cache_write`, which
+/// holds only where the provider subtracts cached tokens out of `input`.
+/// `bedrock.rs` populates neither cache field, so a heavily-cached prompt reads
+/// small there and would select the cheap tier. Fix that before tiering a model
+/// Bedrock serves.
 ///
 /// `tests/price_audit.rs` now diffs every preset against models.dev; run it
 /// before a release:
@@ -66,7 +75,35 @@ impl std::fmt::Display for ApiProtocol {
 /// config.cost.input_per_million = 1.80; // your negotiated rate
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CostConfig {
+    pub input_per_million: f64,
+    pub output_per_million: f64,
+    #[serde(default)]
+    pub cache_read_per_million: f64,
+    #[serde(default)]
+    pub cache_write_per_million: f64,
+    /// Rates that replace the above once a request's prompt exceeds a
+    /// threshold. `None` means one flat rate at every size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tier: Option<ContextTier>,
+}
+
+/// Higher rates charged above a context threshold.
+///
+/// OpenAI prices gpt-5.5 at $5/$30 below ~272K prompt tokens and $10/$45 above
+/// it — published as *columns* on the same pricing row, which is easy to miss
+/// if you go looking for a second row. A flat `CostConfig` under-bills those
+/// requests by 2x on input, and this crate's whole compaction subsystem exists
+/// to run agents at high context, so the case is central rather than exotic.
+///
+/// The threshold is compared against the request's **prompt** tokens —
+/// `input + cache_read + cache_write` — not the total including output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ContextTier {
+    /// Prompt tokens above which the tier rates apply.
+    pub above_prompt_tokens: u64,
     pub input_per_million: f64,
     pub output_per_million: f64,
     #[serde(default)]
@@ -75,7 +112,51 @@ pub struct CostConfig {
     pub cache_write_per_million: f64,
 }
 
+impl ContextTier {
+    /// A tier with no separate cache-write rate, which is the common shape.
+    pub fn new(
+        above_prompt_tokens: u64,
+        input_per_million: f64,
+        output_per_million: f64,
+        cache_read_per_million: f64,
+    ) -> Self {
+        Self {
+            above_prompt_tokens,
+            input_per_million,
+            output_per_million,
+            cache_read_per_million,
+            cache_write_per_million: 0.0,
+        }
+    }
+}
+
 impl CostConfig {
+    /// Flat rates, one price per token category at every request size.
+    ///
+    /// `CostConfig` is `#[non_exhaustive]`, so downstream crates build it here
+    /// rather than with a struct literal. Add a tier with
+    /// [`with_context_tier`](Self::with_context_tier).
+    pub fn new(
+        input_per_million: f64,
+        output_per_million: f64,
+        cache_read_per_million: f64,
+        cache_write_per_million: f64,
+    ) -> Self {
+        Self {
+            input_per_million,
+            output_per_million,
+            cache_read_per_million,
+            cache_write_per_million,
+            context_tier: None,
+        }
+    }
+
+    /// Charge higher rates above a prompt-size threshold.
+    pub fn with_context_tier(mut self, tier: ContextTier) -> Self {
+        self.context_tier = Some(tier);
+        self
+    }
+
     /// Whether any rate is set. All-zero rates mean pricing is unknown
     /// (custom/local models), not that the model is free.
     pub fn is_configured(&self) -> bool {
@@ -90,10 +171,27 @@ impl CostConfig {
     /// Consumed by [`crate::Agent::session_cost_usd`]; also usable directly
     /// in `after_turn` callbacks for per-turn cost tracking.
     pub fn cost_usd(&self, usage: &crate::types::Usage) -> f64 {
-        (usage.input as f64 * self.input_per_million
-            + usage.output as f64 * self.output_per_million
-            + usage.cache_read as f64 * self.cache_read_per_million
-            + usage.cache_write as f64 * self.cache_write_per_million)
+        // Prompt size, which is what a context tier is priced against — every
+        // caller passes one request's usage, so no extra parameter is needed.
+        let prompt = usage.input + usage.cache_read + usage.cache_write;
+        let (input, output, cache_read, cache_write) = match &self.context_tier {
+            Some(t) if prompt > t.above_prompt_tokens => (
+                t.input_per_million,
+                t.output_per_million,
+                t.cache_read_per_million,
+                t.cache_write_per_million,
+            ),
+            _ => (
+                self.input_per_million,
+                self.output_per_million,
+                self.cache_read_per_million,
+                self.cache_write_per_million,
+            ),
+        };
+        (usage.input as f64 * input
+            + usage.output as f64 * output
+            + usage.cache_read as f64 * cache_read
+            + usage.cache_write as f64 * cache_write)
             / 1_000_000.0
     }
 }
@@ -105,6 +203,7 @@ impl Default for CostConfig {
             output_per_million: 0.0,
             cache_read_per_million: 0.0,
             cache_write_per_million: 0.0,
+            context_tier: None,
         }
     }
 }
@@ -522,6 +621,7 @@ impl ModelConfig {
                 output_per_million: 50.0,
                 cache_read_per_million: 1.0,
                 cache_write_per_million: 12.5,
+                ..Default::default()
             },
             ..Self::anthropic("claude-fable-5", "Claude Fable 5")
         }
@@ -546,6 +646,7 @@ impl ModelConfig {
                 output_per_million: 25.0,
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 6.25,
+                ..Default::default()
             },
             ..Self::anthropic("claude-opus-5", "Claude Opus 5")
         }
@@ -564,6 +665,7 @@ impl ModelConfig {
                 output_per_million: 25.0,
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 6.25,
+                ..Default::default()
             },
             ..Self::anthropic("claude-opus-4-8", "Claude Opus 4.8")
         }
@@ -582,6 +684,7 @@ impl ModelConfig {
                 output_per_million: 10.0,
                 cache_read_per_million: 0.2,
                 cache_write_per_million: 2.5,
+                ..Default::default()
             },
             ..Self::anthropic("claude-sonnet-5", "Claude Sonnet 5")
         }
@@ -600,6 +703,7 @@ impl ModelConfig {
                 output_per_million: 5.0,
                 cache_read_per_million: 0.1,
                 cache_write_per_million: 1.25,
+                ..Default::default()
             },
             ..Self::anthropic("claude-haiku-4-5", "Claude Haiku 4.5")
         }
@@ -611,19 +715,34 @@ impl ModelConfig {
     /// Rates verified against <https://developers.openai.com/api/docs/pricing>
     /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     ///
-    /// **Flat rate; a long-context tier may exist and is unverified.**
     ///
-    /// models.dev lists a context tier above 272K at $10/$45/$1 — double input,
-    /// 1.5x output. OpenAI's own pricing page shows only rows annotated
-    /// "<272K context length" at $5/$30, with no >272K row: consistent with a
-    /// tier existing (why annotate otherwise?) but not confirming one, and
-    /// giving no rates.
+    /// **Deliberately flat, over a contested tier claim.** models.dev records a
+    /// 272K tier for this model at $10/$45 with $1.00 cache reads. The preset
+    /// does not, because the evidence does not survive checking:
     ///
-    /// So this preset stays flat rather than encoding rates no vendor page
-    /// corroborates. If a tier does apply, `cost_usd` understates calls above
-    /// ~272K; override `cost` for long-context workloads where the bill
-    /// matters. `CostConfig` has no tier concept — see its docs and
-    /// yologdev/yoagent#138 for what would change that.
+    /// - OpenAI's pricing page does publish a `>272K input tokens` schedule,
+    ///   as a second column group beside `≤272K`. But gpt-5.5 has no row in
+    ///   that table. Across all four Flagship tiers it appears only as
+    ///   `gpt-5.5 (<272K context length)` — Standard $5/$0.50/$30, Batch and
+    ///   Flex $2.50/$15, Fast $12.50/$75 — with no long-context cell.
+    /// - The one gpt-5.5 row that *is* in a long-context table,
+    ///   `gpt-5.5-cyber`, has all four long-context cells set to `-`, and the
+    ///   page hides that row by default.
+    /// - $10/$1/$45 does appear on the page verbatim — as `gpt-5.6-sol`'s
+    ///   long-context rates. Its short-context rates are identical to
+    ///   gpt-5.5's, which is a plausible route for the number to have been
+    ///   copied onto the wrong model.
+    /// - models.dev's own entry contradicts itself: `tiers[0].tier.size` is
+    ///   272000 while the sibling key carrying the same rates is named
+    ///   `context_over_200k`.
+    ///
+    /// Tiering this preset on that would have doubled the input rate every
+    /// caller is charged above 272K prompt tokens. If OpenAI publishes a
+    /// gpt-5.5 long-context row, the machinery is ready —
+    /// [`CostConfig::with_context_tier`]. Until then, flat.
+    ///
+    /// Rates verified against <https://developers.openai.com/api/docs/pricing>
+    /// on 2026-08-20, both column groups read. See [`CostConfig`].
     pub fn gpt_5_5() -> Self {
         Self {
             reasoning: true,
@@ -634,6 +753,7 @@ impl ModelConfig {
                 output_per_million: 30.0,
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 0.0,
+                context_tier: None,
             },
             ..Self::openai("gpt-5.5", "GPT-5.5")
         }
@@ -860,6 +980,7 @@ impl ModelConfig {
                 output_per_million: 4.25,
                 cache_read_per_million: 0.15,
                 cache_write_per_million: 0.0,
+                ..Default::default()
             },
             headers: HashMap::new(),
             anthropic: None,
@@ -1054,6 +1175,7 @@ mod tests {
             output_per_million: 15.0,
             cache_read_per_million: 0.3,
             cache_write_per_million: 3.75,
+            ..Default::default()
         };
         let usage = crate::types::Usage {
             input: 1_000_000,

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -41,6 +41,14 @@ impl std::fmt::Display for ApiProtocol {
 /// rates across 18 releases, v0.9.0 through v0.16.5, overstating every
 /// `cost_usd` for that model by 50%, and nothing detected it.
 ///
+/// # Rates are flat; tiers are not modelled
+///
+/// `cost_usd` applies one rate per token category regardless of request size.
+/// Some vendors price long-context requests higher. Of the presets here, six of
+/// seven are flat per models.dev *and* the vendor's own page; the seventh
+/// (`gpt_5_5`) has an unverified tier claim recorded at its constructor. If you
+/// run long-context workloads where the bill matters, set `cost` yourself.
+///
 /// `tests/price_audit.rs` now diffs every preset against models.dev; run it
 /// before a release:
 ///
@@ -603,11 +611,19 @@ impl ModelConfig {
     /// Rates verified against <https://developers.openai.com/api/docs/pricing>
     /// on 2026-08-19. See [`CostConfig`] — they are a snapshot, not an authority.
     ///
-    /// **Flat rate, tiered upstream.** OpenAI charges roughly double above a
-    /// ~272K context tier ($10/$45/$1), and this preset declares a 1M window —
-    /// so `cost_usd` understates long-context calls by up to 2x. `CostConfig`
-    /// has no tier concept; override `cost` for long-context workloads.
-    /// `tests/price_audit.rs` records this as a known gap.
+    /// **Flat rate; a long-context tier may exist and is unverified.**
+    ///
+    /// models.dev lists a context tier above 272K at $10/$45/$1 — double input,
+    /// 1.5x output. OpenAI's own pricing page shows only rows annotated
+    /// "<272K context length" at $5/$30, with no >272K row: consistent with a
+    /// tier existing (why annotate otherwise?) but not confirming one, and
+    /// giving no rates.
+    ///
+    /// So this preset stays flat rather than encoding rates no vendor page
+    /// corroborates. If a tier does apply, `cost_usd` understates calls above
+    /// ~272K; override `cost` for long-context workloads where the bill
+    /// matters. `CostConfig` has no tier concept — see its docs and
+    /// yologdev/yoagent#138 for what would change that.
     pub fn gpt_5_5() -> Self {
         Self {
             reasoning: true,

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -2742,12 +2742,7 @@ async fn cost_accrues_when_rates_are_configured_and_stays_none_otherwise() {
         system_prompt: String::new(),
     };
     let mut priced = yoagent::provider::ModelConfig::anthropic("mock", "Mock");
-    priced.cost = yoagent::provider::CostConfig {
-        input_per_million: 3.0,
-        output_per_million: 15.0,
-        cache_read_per_million: 0.0,
-        cache_write_per_million: 0.0,
-    };
+    priced.cost = yoagent::provider::CostConfig::new(3.0, 15.0, 0.0, 0.0);
     let mut config = make_config(MockProvider::new(responses()));
     config.model_config = Some(priced);
     config.get_follow_up_messages = follow_up_once();

--- a/tests/price_audit.rs
+++ b/tests/price_audit.rs
@@ -80,9 +80,30 @@ struct Preset {
     /// exactly like a database that has not caught up yet.
     absent_upstream: Option<&'static str>,
     /// Set when models.dev lists cost structure a flat `CostConfig` cannot
-    /// express, with what the crate therefore gets wrong. Keeps a known gap
-    /// visible in source rather than silently passing.
-    flat_rate_gap: Option<&'static str>,
+    /// express. Records *exactly* what was acknowledged, so the note cannot
+    /// become a blanket amnesty for whatever appears later.
+    flat_rate_gap: Option<FlatRateGap>,
+}
+
+/// A recorded, verified gap between what models.dev carries and what a flat
+/// `CostConfig` can express.
+///
+/// Prose alone made this a waiver: the audit checked only that a note existed,
+/// so a *new* unknown key — a second tier, an audio rate, a reasoning rate —
+/// folded silently into the old note and the preset stayed green forever. The
+/// reverse went unnoticed too: if the upstream claim vanished, or its key was
+/// renamed (indistinguishable from removal), nothing said the recorded decision
+/// had gone stale.
+///
+/// So the acknowledgement names the keys and the rates it was made against, and
+/// both directions are assertions.
+struct FlatRateGap {
+    /// Cost keys this gap covers. Any *other* unknown key is drift.
+    keys: &'static [&'static str],
+    /// Upstream rates the decision was reasoned against, as
+    /// `(json_pointer, value)`. A revision makes the recorded reasoning stale.
+    rates: &'static [(&'static str, f64)],
+    why: &'static str,
 }
 
 fn presets() -> Vec<Preset> {
@@ -130,21 +151,41 @@ fn presets() -> Vec<Preset> {
             vendor_page: openai,
             cost: ModelConfig::gpt_5_5().cost,
             absent_upstream: None,
-            flat_rate_gap: Some(
-                "models.dev lists a context tier above 272K at $10/$45/$1. \
-                 OpenAI's pricing page shows only `<272K` rows and no >272K \
-                 row, so the tier is plausible but uncorroborated and its rates \
-                 unverified. `CostConfig` is a single flat rate; the preset \
-                 stays flat rather than encode rates no vendor page confirms. \
-                 See yologdev/yoagent#138.",
-            ),
+            flat_rate_gap: Some(FlatRateGap {
+                keys: &["tiers", "context_over_200k"],
+                rates: &[
+                    ("/context_over_200k/input", 10.0),
+                    ("/context_over_200k/output", 45.0),
+                    ("/context_over_200k/cache_read", 1.0),
+                    ("/tiers/0/input", 10.0),
+                    ("/tiers/0/output", 45.0),
+                    ("/tiers/0/cache_read", 1.0),
+                    ("/tiers/0/tier/size", 272000.0),
+                ],
+                why: "models.dev says gpt-5.5 is tiered at 272K; the preset is \
+                      deliberately flat and `ModelConfig::gpt_5_5` documents why. \
+                      Short version: OpenAI publishes a >272K schedule but gpt-5.5 \
+                      has no row in it, the one gpt-5.5 row that appears in a \
+                      long-context table has `-` in every long-context cell, and \
+                      $10/$1/$45 is verbatim `gpt-5.6-sol`'s long-context rates \
+                      on a model with identical short-context rates. models.dev \
+                      also contradicts itself here — `tiers[0].tier.size` is \
+                      272000 beside a key named `context_over_200k`. \
+                      \
+                      The `rates` above are asserted, so this stays honest in both \
+                      directions: if upstream revises the numbers or drops the \
+                      claim, this fails and the decision gets re-made against new \
+                      evidence rather than silently inheriting an old one. \
+                      `CostConfig::with_context_tier` is ready if OpenAI publishes \
+                      a gpt-5.5 long-context row.",
+            }),
         },
         Preset {
             // Generic over the model id; these rates are Muse Spark 1.1/1.2.
             constructor: "ModelConfig::meta",
             provider: "meta",
             model: "muse-spark-1.2",
-            vendor_page: "https://dev.meta.ai/docs",
+            vendor_page: "https://dev.meta.ai/docs/pricing-rate-limits",
             cost: ModelConfig::meta("muse-spark-1.2", "Muse Spark 1.2").cost,
             absent_upstream: None,
             flat_rate_gap: None,
@@ -241,24 +282,69 @@ async fn hardcoded_prices_have_not_drifted() {
         // Structure this audit does not understand is a reason to fail, not to
         // read past. Tiered rates mean the flat preset is wrong somewhere.
         if let Some(obj) = cost.as_object() {
-            let unknown: Vec<&String> = obj
+            let unknown: Vec<String> = obj
                 .keys()
                 .filter(|k| !KNOWN_COST_KEYS.contains(&k.as_str()))
+                .cloned()
                 .collect();
-            if !unknown.is_empty() {
-                match p.flat_rate_gap {
-                    Some(why) => notes.push(format!(
-                        "{}: models.dev carries {unknown:?} — {why}",
-                        p.model
-                    )),
-                    None => drift.push(format!(
-                        "{}: models.dev carries cost keys this audit ignores: {unknown:?}. \
-                         `CostConfig` is one flat rate — if those are tiers, {} is wrong \
-                         above the boundary. Check {}, then either fix the preset or record \
-                         it in `flat_rate_gap`.",
-                        p.model, p.constructor, p.vendor_page
-                    )),
+
+            match &p.flat_rate_gap {
+                Some(gap) => {
+                    // Anything beyond what was acknowledged is new structure,
+                    // not covered by an old decision. Without this the note is
+                    // a blanket amnesty: a second tier or an audio rate would
+                    // fold into it and the preset would stay green forever.
+                    let unacknowledged: Vec<&String> = unknown
+                        .iter()
+                        .filter(|k| !gap.keys.contains(&k.as_str()))
+                        .collect();
+                    if !unacknowledged.is_empty() {
+                        drift.push(format!(
+                            "{}: models.dev carries cost keys beyond the recorded gap: \
+                             {unacknowledged:?}. The note covers {:?} only. Check {} and \
+                             either fix {} or widen the acknowledgement.",
+                            p.model, gap.keys, p.vendor_page, p.constructor
+                        ));
+                    }
+
+                    // The reverse is just as important. If the claim vanishes —
+                    // or a key is renamed, which is indistinguishable from
+                    // removal — the recorded decision has gone stale and
+                    // nothing would otherwise say so.
+                    let missing: Vec<&&str> =
+                        gap.keys.iter().filter(|k| !obj.contains_key(**k)).collect();
+                    if !missing.is_empty() {
+                        drift.push(format!(
+                            "{}: the recorded gap names {missing:?}, which models.dev no \
+                             longer carries. Either upstream dropped the claim — re-check \
+                             {} and delete the note — or a key was renamed and this preset \
+                             is now silently uncovered.",
+                            p.model, p.vendor_page
+                        ));
+                    }
+
+                    // And the rates the decision was reasoned against.
+                    for (pointer, expected) in gap.rates {
+                        match cost.pointer(pointer).and_then(|v| v.as_f64()) {
+                            Some(actual) if (actual - expected).abs() < 1e-9 => {}
+                            other => drift.push(format!(
+                                "{}: recorded gap expects {pointer} == {expected}, models.dev \
+                                 now says {other:?}. The decision in {} was reasoned against \
+                                 the old figure; re-check {}.",
+                                p.model, p.constructor, p.vendor_page
+                            )),
+                        }
+                    }
+                    notes.push(format!("{}: {}", p.model, gap.why));
                 }
+                None if !unknown.is_empty() => drift.push(format!(
+                    "{}: models.dev carries cost keys this audit ignores: {unknown:?}. \
+                     `CostConfig` is one flat rate — if those are tiers, {} is wrong \
+                     above the boundary. Check {}, then either fix the preset or record \
+                     it in `flat_rate_gap`.",
+                    p.model, p.constructor, p.vendor_page
+                )),
+                None => {}
             }
         }
 
@@ -374,21 +460,13 @@ fn is_configured_means_any_rate_set() {
         "all-zero rates mean pricing is unknown, not that the model is free"
     );
 
-    let no_cache_write = CostConfig {
-        input_per_million: 5.0,
-        output_per_million: 30.0,
-        cache_read_per_million: 0.5,
-        cache_write_per_million: 0.0,
-    };
+    let no_cache_write = CostConfig::new(5.0, 30.0, 0.5, 0.0);
     assert!(
         no_cache_write.is_configured(),
         "a provider that charges nothing for cache writes is priced, not unknown"
     );
 
-    let only_one_field = CostConfig {
-        cache_read_per_million: 0.1,
-        ..CostConfig::default()
-    };
+    let only_one_field = CostConfig::new(0.0, 0.0, 0.1, 0.0);
     assert!(
         only_one_field.is_configured(),
         "any single rate is enough to count as priced"
@@ -401,4 +479,70 @@ fn is_configured_means_any_rate_set() {
             p.constructor
         );
     }
+}
+
+/// A request above the tier boundary must cost the tier rate.
+///
+/// Built from a literal, not a preset: no shipped preset is tiered today, and
+/// this must keep testing the mechanism if that stays true. The boundary is
+/// compared against *prompt* tokens — `input + cache_read + cache_write` — so a
+/// long reply to a short prompt stays on the base rate.
+#[test]
+fn cost_usd_applies_the_context_tier_by_prompt_size() {
+    use yoagent::provider::{ContextTier, CostConfig};
+    use yoagent::types::Usage;
+
+    let cfg = CostConfig::new(5.0, 30.0, 0.5, 0.0)
+        .with_context_tier(ContextTier::new(272_000, 10.0, 45.0, 1.0));
+
+    let usage = |input: u64, output: u64| Usage {
+        input,
+        output,
+        cache_read: 0,
+        cache_write: 0,
+        total_tokens: input + output,
+    };
+
+    // Below: base rates. 100k in, 1k out => 100k*$5/M + 1k*$30/M.
+    let below = cfg.cost_usd(&usage(100_000, 1_000));
+    assert!(
+        (below - (0.5 + 0.03)).abs() < 1e-9,
+        "below the boundary must use base rates, got {below}"
+    );
+
+    // Above: tier rates. 300k in, 1k out => 300k*$10/M + 1k*$45/M.
+    let above = cfg.cost_usd(&usage(300_000, 1_000));
+    assert!(
+        (above - (3.0 + 0.045)).abs() < 1e-9,
+        "above the boundary must use tier rates, got {above}"
+    );
+
+    // Exactly at the boundary is *below* — the field is `above_prompt_tokens`.
+    let at = cfg.cost_usd(&usage(272_000, 0));
+    assert!(
+        (at - 1.36).abs() < 1e-9,
+        "the boundary itself must stay on the base rate, got {at}"
+    );
+
+    // Cached tokens count toward prompt size: 272k cache reads and 1 fresh
+    // token is a 272_001-token prompt, so the tier applies.
+    let cached = cfg.cost_usd(&Usage {
+        input: 1,
+        output: 0,
+        cache_read: 272_000,
+        cache_write: 0,
+        total_tokens: 272_001,
+    });
+    assert!(
+        (cached - (272_000.0 + 10.0) / 1_000_000.0).abs() < 1e-9,
+        "cache reads must count toward the boundary and bill at the tier's \
+         cache rate, got {cached}"
+    );
+
+    // Output does not push a short prompt over the line.
+    let long_reply = cfg.cost_usd(&usage(1_000, 400_000));
+    assert!(
+        (long_reply - (0.005 + 12.0)).abs() < 1e-9,
+        "the tier keys on prompt size, not total, got {long_reply}"
+    );
 }

--- a/tests/price_audit.rs
+++ b/tests/price_audit.rs
@@ -131,11 +131,12 @@ fn presets() -> Vec<Preset> {
             cost: ModelConfig::gpt_5_5().cost,
             absent_upstream: None,
             flat_rate_gap: Some(
-                "models.dev lists a context tier above 272K at $10/$45/$1 — double \
-                 input, 1.5x output. `CostConfig` is a single flat rate, so \
-                 `gpt_5_5` understates long-context calls by up to 2x while \
-                 declaring a 1M window. Tracked as a known gap rather than \
-                 silently certified.",
+                "models.dev lists a context tier above 272K at $10/$45/$1. \
+                 OpenAI's pricing page shows only `<272K` rows and no >272K \
+                 row, so the tier is plausible but uncorroborated and its rates \
+                 unverified. `CostConfig` is a single flat rate; the preset \
+                 stays flat rather than encode rates no vendor page confirms. \
+                 See yologdev/yoagent#138.",
             ),
         },
         Preset {


### PR DESCRIPTION
Closes #138.

`cost_usd` applied one rate per token category regardless of request size, while
some vendors price long-context requests higher. It now takes an optional
`CostConfig::context_tier` and selects rates by the request's **prompt** tokens
(`input + cache_read + cache_write`), so a long reply to a short prompt stays on
the base rate.

```rust
let cost = CostConfig::new(5.0, 30.0, 0.5, 0.0)
    .with_context_tier(ContextTier::new(272_000, 10.0, 45.0, 1.0));
```

## Every shipped preset stays flat

`gpt_5_5` was the candidate. It took three passes to settle, each reversing the
last, so the reasoning is recorded on the constructor rather than left in review
history:

- models.dev records a 272K tier for gpt-5.5 at $10/$45 with $1.00 cache reads.
- OpenAI's pricing page **does** publish a `>272K input tokens` schedule — as a
  second column group beside `≤272K`, which is easy to miss and which I first
  reported as absent.
- But **gpt-5.5 has no row in it.** Across all four Flagship tiers it appears
  only as `gpt-5.5 (<272K context length)` — Standard $5/$0.50/$30, Batch and
  Flex $2.50/$15, Fast $12.50/$75.
- `$10/$1/$45` does appear on the page verbatim — as **`gpt-5.6-sol`'s**
  long-context rates, a model whose short-context rates are identical to
  gpt-5.5's. A plausible route for the number to reach the wrong entry.
- The one gpt-5.5 row that appears in a long-context table, `gpt-5.5-cyber`, has
  `-` in all four long-context cells (and the page hides that row by default).
- models.dev contradicts itself here: `tiers[0].tier.size` is `272000` beside a
  sibling key named `context_over_200k` carrying the same rates.

What actually settled it was checking models.dev's tier data somewhere a vendor
states the answer unambiguously. **34 Claude entries carry tiers**, including
`claude-4.6-sonnet` and `claude-opus-4.6` — models Anthropic's own page says
bill the full 1M window at standard rates. Its tier data is demonstrably wrong
where it is checkable, so a models.dev tier alone is not grounds to double what
every caller is charged above 272K. #132's doctrine, applied: drift alarm, never
authority.

## Audit

`tests/price_audit.rs` now **asserts** the disputed rates as JSON-pointer
comparisons rather than merely naming the keys as unhandled. If OpenAI publishes
a gpt-5.5 long-context row, or models.dev revises or drops the claim, the audit
fails and the decision gets re-made against new evidence instead of silently
inheriting this one.

`cost_usd_applies_the_context_tier_by_prompt_size` builds its tier from a
literal, not a preset, so it keeps testing the mechanism while no preset is
tiered. Mutation-checked: flipping `>` to `>=` in `cost_usd` fails the boundary
assertion.

Also corrected here: the Meta preset's `vendor_page` pointed at a docs index
with no prices; it now points at the pricing page, which states outright that
there is no long-context premium.

## Caveat for whoever tiers a preset later

Prompt size is derived as `input + cache_read + cache_write`, which holds only
where the provider subtracts cached tokens out of `input` (anthropic,
openai_compat, google, google_vertex). `bedrock.rs` populates neither cache
field, so a heavily-cached prompt reads small there and would select the cheap
tier.

## Breaking

`CostConfig` is now `#[non_exhaustive]` and gained a fifth field, so
out-of-crate struct-literal construction no longer compiles — use
`CostConfig::new(..)`. `..Default::default()` does not rescue it. Field reads
and mutation through a binding are unaffected. Two literals in this repo needed
updating, one of them in an example that only builds under `--all-features`.
`ContextTier` is exported from `yoagent::provider` (it was reachable as a public
field's type but unnameable).

## Verification

`cargo test --all-features`: 598 passed, 0 failed. `cargo clippy --all-targets
--all-features` clean. Live audit (`--include-ignored`) passes against
models.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)