### PR TITLE
ci: build the default feature set, and document the commands CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,35 @@ jobs:
       - name: Build
         run: cargo build --all-features
 
+  # Every job above builds `--all-features`, but `openapi` and `gasp` are both
+  # off by default — so the feature set a `cargo add yoagent` user actually gets
+  # was never compiled here. A `#[cfg(feature = ...)]` mistake that leaves an
+  # import or a type reachable only with a feature on would pass all-features CI
+  # and break on crates.io. One OS is enough: feature gating is not OS-specific.
+  feature-combos:
+    name: Features (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            flags: ""
+          - name: openapi
+            flags: "--features openapi"
+          - name: gasp
+            flags: "--features gasp"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy
+        run: cargo clippy --all-targets ${{ matrix.flags }}
+      - name: Test
+        run: cargo test ${{ matrix.flags }}
+
   # Built-in tools shell out to unix commands, so Windows only checks compilation.
   windows-check:
     name: Check (windows)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Development Commands
 
 ```bash
-cargo build                          # Build the library
-cargo test                           # Run all unit tests
-cargo test <test_name>               # Run a single test by name
-cargo test --test agent_test         # Run a specific test file
+cargo test --all-features            # Run all tests — what CI runs
+cargo clippy --all-targets --all-features   # Lint — what CI runs (-Dwarnings)
 cargo fmt                            # Auto-format code
 cargo fmt -- --check                 # Check formatting (CI uses this)
-cargo clippy --all-targets           # Lint (CI runs with -Dwarnings)
+
+cargo test <test_name>               # Run a single test by name
+cargo test --test agent_test         # Run a specific test file
 cargo run --example cli              # Run the interactive CLI example
 cargo run --example basic            # Run the minimal example
 ```
+
+**Pass `--all-features` when checking your work.** `openapi` and `gasp` are off
+by default, and some targets exist only behind them: `gasp_emit` and
+`llm_compaction_live` are both `required-features = ["gasp"]`, so plain
+`cargo clippy --all-targets` skips them entirely and reports clean on code CI
+will reject. This is not hypothetical — a breaking change to `CostConfig`
+passed local clippy while `llm_compaction_live` no longer compiled.
 
 CI (`RUSTFLAGS="-Dwarnings"`) treats all clippy warnings as errors. Integration tests in `tests/integration_anthropic.rs` require a live API key and are skipped by default.
 


### PR DESCRIPTION
Fallout from #141, in both directions.

## CI never built what users install

`openapi` and `gasp` are both off by default, and every existing job runs
`--all-features` — so the feature set a `cargo add yoagent` user actually gets
was **never compiled in CI**. A `#[cfg(feature = ...)]` mistake that leaves an
import or type reachable only with a feature enabled passes all-features CI and
breaks on crates.io.

Verified rather than assumed. Referencing a gasp-only export unconditionally
from `lib.rs`:

| | clippy errors |
|---|---|
| `cargo clippy --all-targets --all-features` (current CI) | **0** |
| `cargo clippy --all-targets` (new job) | **3** |

Adds a `feature-combos` job over default / openapi / gasp. One OS — feature
gating isn't OS-specific, so the second runner buys nothing. All three are green
today, so this locks in current behaviour rather than opening a backlog:

| combo | tests | clippy |
|---|---|---|
| default | 533 passed, 0 failed | clean |
| `openapi` | 575 passed, 0 failed | clean |
| `gasp` | 556 passed, 0 failed | clean |

## CLAUDE.md pointed the other way

It documented `cargo test` and `cargo clippy --all-targets`, neither with
`--all-features`. Following it diverges from CI in the opposite direction:
`gasp_emit` and `llm_compaction_live` are both `required-features = ["gasp"]`,
so a bare `cargo clippy --all-targets` **skips them entirely** and reports clean
on code CI will reject.

Not hypothetical — that is exactly how #141's breaking `CostConfig` change
passed local clippy while `llm_compaction_live` no longer compiled. The
documented commands now match CI, with the reason attached so the next person
doesn't re-simplify them.

No library change; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)