### PR TITLE
fix: make the AgentEvent wire freeze catch a new variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **The `AgentEvent` wire freeze now catches a new variant**
-  ([#137](https://github.com/yologdev/yoagent/issues/137)). `EVENT_VARIANT_COUNT`
-  claimed to fail when a variant was added without a serialization sample. It
-  could not: both sides of its comparison — the sample list and the count — are
-  hand-written, and a new variant appears in neither. #136 added a 14th variant
-  and the suite stayed 27/27 green, with the new variant's tag and round-trip
-  exactly as untested as the message described.
+  ([#137](https://github.com/yologdev/yoagent/issues/137)). `EVENT_VARIANT_COUNT`'s
+  message claimed it failed when a variant was added without a serialization
+  sample. It could not fire for that: the integration test's match carries a
+  `_ => "unknown"` arm, forced by `#[non_exhaustive]`, so adding a variant
+  requires no edit to that file at all — the count and the sample list are both
+  hand-written and a new variant appears in neither. #136 added a 14th variant
+  and the suite stayed green, but only because the author added the sample by
+  hand and said so in the commit message; nothing would have complained
+  otherwise.
 
   `wire_tag_freeze` in `src/types.rs` now declares the frozen tag **and** a
   sample for every variant from one list, via a `wire_freeze!` macro that emits
@@ -27,26 +30,42 @@ adheres to [Semantic Versioning](https://semver.org/).
 
   Adding a variant is a non-exhaustive-match compile error, and the only way to
   fix it is to add a line here — which supplies the sample in the same breath.
-  The two lists cannot drift because they are one list. A duplicated pattern is
-  an `unreachable_pattern` error under `-Dwarnings`, and a mistyped sample does
-  not compile.
+  The specifier is `pat_param`, not `pat`, and that is load-bearing: `pat` would
+  accept an or-pattern, letting someone answer the compile error by widening an
+  unrelated arm (`TurnStart | NewVariant => "turnStart"`) and leave the new
+  variant with no coverage at all.
 
-  Coverage went from one variant to all of them. The old test serialized
-  `AgentStart` only, so 13 of the 14 tag strings were asserted nowhere — a typo
-  like `"turnEndd"` compiled and passed. Each sample is now checked for its
-  frozen tag, camelCase payload keys, and a JSON round-trip, with a distinctness
-  check catching a sample paired with the wrong pattern.
+  Each sample is checked for its frozen tag, a JSON round-trip, and camelCase
+  keys **recursively** — a snake_case key at `agentEnd.messages[0].usage`
+  reaches clients as surely as a top-level one. Samples are deliberately
+  populated rather than defaulted: a round-trip cannot notice a field that
+  `#[serde(skip)]` drops if the value it reconstructs is the default anyway.
+
+  Scope, stated plainly because this entry is about a guard that overclaimed:
+  this freezes tags, per-variant sample coverage, and round-tripping. It does
+  **not** freeze payload shape — a `#[serde(rename)]` on a field still passes.
+  Field names are pinned only where `tests/serialization_test.rs` asserts them
+  by literal.
 
   Verified by mutation, since a guard that cannot fire is the bug being fixed:
   adding a 15th variant is a compile error (the integration test stays green on
-  the same mutation), a tag typo fails, a mis-paired sample fails, and dropping
-  `rename_all_fields` fails on `tool_results`.
+  the same mutation), an or-pattern bypass is a macro parse error, a tag typo
+  fails, dropping `Usage`'s `totalTokens` rename fails on the nested key, and
+  `#[serde(skip)]` on `AgentEnd.stats` now fails the round-trip.
 
-  Also fixed in `tests/serialization_test.rs`: `test_context_compacted_wire_shape_is_frozen`
-  indexed the sample list **positionally** (`all_agent_events()[12]`), so
-  inserting a variant earlier would have silently retargeted it at a different
-  event; it now looks the variant up. The misleading guard and its false doc
-  claim are gone.
+  Two related fixes. `ToolResult` reaches the wire as `toolExecutionEnd.result`
+  but carried no `rename_all = "camelCase"`, unlike its siblings — a no-op for
+  today's single-word fields, and a silent snake_case leak for the first
+  multi-word one. And `ContextCompacted`'s doc block had been concatenated onto
+  `LoopDetected` since #136, leaving `ContextCompacted` undocumented.
+
+  In `tests/serialization_test.rs`: `test_context_compacted_wire_shape_is_frozen`
+  indexed the sample list positionally (`all_agent_events()[12]`), so inserting
+  a variant earlier broke it with a confusing `contextCompacted` tag mismatch
+  rather than an edit to this test; it now looks the variant up. The count guard
+  is kept under an accurate name and message — it never caught an *added*
+  variant, but it does catch a sample being *deleted*, which silently drops that
+  variant's payload coverage.
 
 - **Truncated tool output is retrievable instead of lost**
   ([#125](https://github.com/yologdev/yoagent/issues/125)). `truncate_tool_output`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **The `AgentEvent` wire freeze now catches a new variant**
+  ([#137](https://github.com/yologdev/yoagent/issues/137)). `EVENT_VARIANT_COUNT`
+  claimed to fail when a variant was added without a serialization sample. It
+  could not: both sides of its comparison — the sample list and the count — are
+  hand-written, and a new variant appears in neither. #136 added a 14th variant
+  and the suite stayed 27/27 green, with the new variant's tag and round-trip
+  exactly as untested as the message described.
+
+  `wire_tag_freeze` in `src/types.rs` now declares the frozen tag **and** a
+  sample for every variant from one list, via a `wire_freeze!` macro that emits
+  both the wildcard-free match and the sample vector:
+
+  ```rust,ignore
+  AgentEvent::LoopDetected { .. } => "loopDetected"
+      = AgentEvent::loop_detected("bash", 3, false),
+  ```
+
+  Adding a variant is a non-exhaustive-match compile error, and the only way to
+  fix it is to add a line here — which supplies the sample in the same breath.
+  The two lists cannot drift because they are one list. A duplicated pattern is
+  an `unreachable_pattern` error under `-Dwarnings`, and a mistyped sample does
+  not compile.
+
+  Coverage went from one variant to all of them. The old test serialized
+  `AgentStart` only, so 13 of the 14 tag strings were asserted nowhere — a typo
+  like `"turnEndd"` compiled and passed. Each sample is now checked for its
+  frozen tag, camelCase payload keys, and a JSON round-trip, with a distinctness
+  check catching a sample paired with the wrong pattern.
+
+  Verified by mutation, since a guard that cannot fire is the bug being fixed:
+  adding a 15th variant is a compile error (the integration test stays green on
+  the same mutation), a tag typo fails, a mis-paired sample fails, and dropping
+  `rename_all_fields` fails on `tool_results`.
+
+  Also fixed in `tests/serialization_test.rs`: `test_context_compacted_wire_shape_is_frozen`
+  indexed the sample list **positionally** (`all_agent_events()[12]`), so
+  inserting a variant earlier would have silently retargeted it at a different
+  event; it now looks the variant up. The misleading guard and its false doc
+  claim are gone.
+
 - **Truncated tool output is retrievable instead of lost**
   ([#125](https://github.com/yologdev/yoagent/issues/125)). `truncate_tool_output`
   head-tail-truncates on append and the middle was gone irrecoverably — the full

--- a/src/types.rs
+++ b/src/types.rs
@@ -692,6 +692,7 @@ pub trait AgentTool: Send + Sync {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolResult {
     pub content: Vec<Content>,
     #[serde(default)]
@@ -792,13 +793,6 @@ pub enum AgentEvent {
     InputRejected {
         reason: String,
     },
-    /// History was compacted before a turn.
-    ///
-    /// Emitted by [`LlmCompaction`](crate::LlmCompaction) on both of its paths
-    /// — the spliced summary and the deterministic fallback — so a consumer can
-    /// tell which one ran and what it cost. The built-in
-    /// [`DefaultCompaction`](crate::context::DefaultCompaction) does not emit
-    /// this; it has no event channel and never issues a request.
     /// A tool was called repeatedly with identical arguments.
     ///
     /// Emitted on both escalations: the first trip steers the model and
@@ -811,6 +805,13 @@ pub enum AgentEvent {
         repetitions: usize,
         aborted: bool,
     },
+    /// History was compacted before a turn.
+    ///
+    /// Emitted by [`LlmCompaction`](crate::LlmCompaction) on both of its paths
+    /// — the spliced summary and the deterministic fallback — so a consumer can
+    /// tell which one ran and what it cost. The built-in
+    /// [`DefaultCompaction`](crate::context::DefaultCompaction) does not emit
+    /// this; it has no event channel and never issues a request.
     ContextCompacted {
         /// Which compaction path produced this result.
         method: CompactionMethod,
@@ -1173,10 +1174,15 @@ impl fmt::Display for StopReason {
 /// Freezes the serde wire contract for `AgentEvent` and `StreamDelta`.
 ///
 /// Both enums are documented as a stable wire format for websocket fanout
-/// servers, TypeScript clients and JSONL pipes, so a changed tag, a changed
-/// payload shape, or a variant that quietly serializes however serde happens
-/// to derive it are all breaking changes for consumers who never rebuild
-/// against this crate.
+/// servers, TypeScript clients and JSONL pipes, so a changed tag or a variant
+/// that quietly serializes however serde happens to derive it are breaking
+/// changes for consumers who never rebuild against this crate.
+///
+/// **Scope.** This freezes the `"type"` tag of every variant, that every
+/// variant has a sample, and that each sample round-trips. It does **not**
+/// freeze payload shape: a `#[serde(rename)]` on a field, a field added or
+/// removed, or a changed field type all pass here. Field names are pinned
+/// only where `tests/serialization_test.rs` asserts them by literal.
 ///
 /// This lives in the defining crate on purpose. Both enums are
 /// `#[non_exhaustive]`, so an integration test *cannot* match them
@@ -1196,59 +1202,94 @@ mod wire_tag_freeze {
     /// notice a *new* variant, because a new variant appears in neither. Here
     /// the generated match has no wildcard, so adding a variant fails to
     /// compile — and the only way to fix that is to add a line below, which
-    /// supplies the sample in the same breath. The two lists cannot drift
-    /// because they are one list.
+    /// supplies the sample in the same breath.
     ///
-    /// Three further mistakes are caught by the compiler rather than by luck:
-    /// a duplicated pattern makes the later arm `unreachable_pattern` (an
-    /// error under CI's `-Dwarnings`), a sample of the wrong type does not
-    /// compile, and a missing arm is a non-exhaustive match.
+    /// Three mistakes are caught by the compiler rather than by luck: a
+    /// duplicated pattern makes the later arm `unreachable_patterns` (an error
+    /// under CI's `-Dwarnings`), a sample of the wrong type does not compile,
+    /// and a missing arm is a non-exhaustive match.
     ///
-    /// What the *tests* below add, which no macro can: that the declared tag
-    /// is the one serde actually emits, that each sample survives a
-    /// round-trip, and that a sample on the wrong line is caught (via the
-    /// distinctness check).
+    /// The specifier is `pat_param`, not `pat`, and that is load-bearing: `pat`
+    /// would accept an or-pattern, letting someone answer the compile error by
+    /// widening an unrelated arm (`TurnStart | NewVariant => "turnStart"`)
+    /// instead of adding a line — leaving the new variant with no sample and no
+    /// coverage, which is exactly the hole this macro exists to close. No arm
+    /// can legitimately need one, since two variants cannot share a tag.
     macro_rules! wire_freeze {
-        ($ty:ty, $tag_of:ident, $samples:ident, $($pat:pat => $tag:literal = $sample:expr),+ $(,)?) => {
+        ($ty:ty, $tag_of:ident, $samples:ident, $($pat:pat_param => $tag:literal = $sample:expr),+ $(,)?) => {
             /// The frozen `"type"` tag per variant. Changing one breaks every
             /// deployed wire client — do not edit casually.
             fn $tag_of(v: &$ty) -> &'static str {
                 match v { $($pat => $tag,)+ }
             }
 
-            /// One sample per variant, positionally paired with the tags above.
+            /// One sample per variant, in declaration order. The tests re-derive
+            /// each tag from its sample rather than trusting that order — see
+            /// [`assert_frozen`].
             fn $samples() -> Vec<$ty> { vec![$($sample,)+] }
         };
     }
 
+    /// A populated assistant message. Every field is deliberately non-default:
+    /// a round-trip cannot detect a field that `#[serde(skip)]` drops if the
+    /// value it reconstructs is the default anyway.
     fn msg() -> AgentMessage {
         AgentMessage::Llm(Message::Assistant {
             content: vec![Content::Text { text: "hi".into() }],
-            stop_reason: StopReason::Stop,
-            model: "mock".into(),
+            stop_reason: StopReason::ToolUse,
+            model: "mock-1".into(),
             provider: "mock".into(),
-            usage: Usage::default(),
+            usage: Usage {
+                input: 11,
+                output: 22,
+                cache_read: 33,
+                cache_write: 44,
+                total_tokens: 110,
+            },
             timestamp: 7,
-            error_message: None,
+            error_message: Some("boom".into()),
         })
     }
 
     fn tool_result() -> ToolResult {
         ToolResult {
             content: vec![Content::Text { text: "ok".into() }],
-            details: serde_json::Value::Null,
+            details: serde_json::json!({"exitCode": 0}),
+        }
+    }
+
+    fn tool_result_message() -> Message {
+        Message::ToolResult {
+            tool_call_id: "tc-1".into(),
+            tool_name: "bash".into(),
+            content: vec![Content::Text { text: "ok".into() }],
+            is_error: false,
+            timestamp: 9,
         }
     }
 
     wire_freeze! {
         AgentEvent, expected_event_tag, event_samples,
         AgentEvent::AgentStart => "agentStart" = AgentEvent::AgentStart,
-        AgentEvent::AgentEnd { .. } => "agentEnd"
-            = AgentEvent::agent_end(vec![msg()], SessionStats::default()),
+        AgentEvent::AgentEnd { .. } => "agentEnd" = AgentEvent::agent_end(
+            vec![msg()],
+            SessionStats {
+                usage: Usage {
+                    input: 5,
+                    output: 6,
+                    cache_read: 7,
+                    cache_write: 8,
+                    total_tokens: 26,
+                },
+                turns: 3,
+                cost_usd: Some(0.02),
+                compactions: 1,
+            },
+        ),
         AgentEvent::TurnStart => "turnStart" = AgentEvent::TurnStart,
         AgentEvent::TurnEnd { .. } => "turnEnd" = AgentEvent::TurnEnd {
             message: msg(),
-            tool_results: vec![],
+            tool_results: vec![tool_result_message()],
         },
         AgentEvent::MessageStart { .. } => "messageStart"
             = AgentEvent::MessageStart { message: msg() },
@@ -1294,7 +1335,17 @@ mod wire_tag_freeze {
                 messages_after: 13,
                 tokens_before: 96_500,
                 tokens_after: 41_200,
-                summary: None,
+                summary: Some(SummaryStats::new(
+                    28,
+                    Usage {
+                        input: 54_000,
+                        output: 900,
+                        cache_read: 0,
+                        cache_write: 0,
+                        total_tokens: 54_900,
+                    },
+                    Some(0.17),
+                )),
             },
     }
 
@@ -1307,18 +1358,41 @@ mod wire_tag_freeze {
             = StreamDelta::ToolCallDelta { delta: "{}".into() },
     }
 
-    /// Asserts the frozen contract for one sample: declared tag == emitted tag,
-    /// payload keys are camelCase, and the value survives a round-trip.
+    /// Every key in `v`, recursively, as `path -> key` pairs.
     ///
-    /// `seen` collects tags so a sample paired with the wrong pattern is caught
-    /// — that is the one error the macro cannot catch, since both lines
-    /// compile fine and the mismatch only shows as a repeated tag.
-    fn assert_frozen<T>(
-        sample: &T,
-        declared: &str,
-        seen: &mut BTreeSet<&'static str>,
-        declared_static: &'static str,
-    ) where
+    /// Recursive on purpose. Checking only the top level would pass a
+    /// snake_case key one level down — `message.usage.total_tokens` reaches
+    /// clients just as surely as `turnEnd.toolResults` does, and the nested
+    /// payload structs carry their own `rename_all`, which nothing else here
+    /// would notice going missing.
+    fn all_keys(v: &serde_json::Value, path: &str, out: &mut Vec<(String, String)>) {
+        match v {
+            serde_json::Value::Object(map) => {
+                for (k, child) in map {
+                    out.push((path.to_string(), k.clone()));
+                    all_keys(child, &format!("{path}.{k}"), out);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (i, child) in items.iter().enumerate() {
+                    all_keys(child, &format!("{path}[{i}]"), out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Asserts the frozen contract for one sample: the declared tag is the one
+    /// serde emits, no payload key anywhere in the value contains an
+    /// underscore, and the value survives a JSON round-trip.
+    ///
+    /// `seen` collects tags so a mis-paired sample is caught **when it
+    /// duplicates another variant** — which is the case that costs coverage,
+    /// since some variant is then left unsampled. Two samples swapped between
+    /// lines is invisible here, and harmless: the set of samples is unchanged
+    /// and every tag is still checked against serde.
+    fn assert_frozen<T>(sample: &T, declared: &'static str, seen: &mut BTreeSet<&'static str>)
+    where
         T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
     {
         let v = serde_json::to_value(sample).expect("serialize");
@@ -1331,15 +1405,14 @@ mod wire_tag_freeze {
             v["type"]
         );
 
-        for key in v
-            .as_object()
-            .expect("tagged enums serialize as objects")
-            .keys()
-        {
+        let mut keys = Vec::new();
+        all_keys(&v, declared, &mut keys);
+        for (path, key) in &keys {
             assert!(
                 !key.contains('_'),
-                "payload key {key:?} on {declared} is not camelCase — the enum carries \
-                 rename_all_fields = \"camelCase\" and TS clients hardcode these names"
+                "payload key {key:?} at {path} is not camelCase. Every struct on this wire \
+                 carries rename_all = \"camelCase\" and TS clients hardcode these names, so a \
+                 snake_case key here means a rename attribute is missing"
             );
         }
 
@@ -1350,39 +1423,25 @@ mod wire_tag_freeze {
         );
 
         assert!(
-            seen.insert(declared_static),
+            seen.insert(declared),
             "two samples serialize as {declared} — a sample in wire_freeze! does not match \
-             the pattern on its own line"
+             the pattern on its own line, so some variant has no sample at all"
         );
     }
 
     #[test]
     fn every_event_variant_is_frozen_tagged_and_round_trips() {
-        let samples = event_samples();
         let mut seen = BTreeSet::new();
-        for sample in &samples {
-            let declared = expected_event_tag(sample);
-            assert_frozen(sample, declared, &mut seen, declared);
+        for sample in &event_samples() {
+            assert_frozen(sample, expected_event_tag(sample), &mut seen);
         }
-        assert_eq!(
-            seen.len(),
-            samples.len(),
-            "every variant must contribute a distinct tag"
-        );
     }
 
     #[test]
     fn every_delta_variant_is_frozen_tagged_and_round_trips() {
-        let samples = delta_samples();
         let mut seen = BTreeSet::new();
-        for sample in &samples {
-            let declared = expected_delta_tag(sample);
-            assert_frozen(sample, declared, &mut seen, declared);
+        for sample in &delta_samples() {
+            assert_frozen(sample, expected_delta_tag(sample), &mut seen);
         }
-        assert_eq!(
-            seen.len(),
-            samples.len(),
-            "every variant must contribute a distinct tag"
-        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1170,62 +1170,219 @@ impl fmt::Display for StopReason {
     }
 }
 
-/// Wire-tag freeze for [`AgentEvent`] and [`StreamDelta`].
+/// Freezes the serde wire contract for `AgentEvent` and `StreamDelta`.
 ///
-/// These matches deliberately have **no wildcard arm**: adding a variant must
-/// fail to compile here until its serde tag is pinned. That guarantee is the
-/// reason they live in this crate rather than in `tests/` — both enums are
+/// Both enums are documented as a stable wire format for websocket fanout
+/// servers, TypeScript clients and JSONL pipes, so a changed tag, a changed
+/// payload shape, or a variant that quietly serializes however serde happens
+/// to derive it are all breaking changes for consumers who never rebuild
+/// against this crate.
+///
+/// This lives in the defining crate on purpose. Both enums are
 /// `#[non_exhaustive]`, so an integration test *cannot* match them
-/// exhaustively and the compile-time freeze would silently degrade to a
-/// wildcard. Inside the defining crate, exhaustiveness still applies.
-///
-/// A tag change is a breaking change for wire clients — do not edit casually.
-/// `tests/serialization_test.rs` covers the round-trips and payload shapes;
-/// this covers only "no variant escapes without a pinned tag".
+/// exhaustively — its match needs a `_` arm, and a wildcard turns "adding a
+/// variant fails to compile" into "adding a variant is silently untested".
+/// Inside this crate exhaustiveness still applies.
 #[cfg(test)]
 mod wire_tag_freeze {
     use super::*;
+    use std::collections::BTreeSet;
 
-    fn expected_event_tag(event: &AgentEvent) -> &'static str {
-        match event {
-            AgentEvent::AgentStart => "agentStart",
-            AgentEvent::AgentEnd { .. } => "agentEnd",
-            AgentEvent::TurnStart => "turnStart",
-            AgentEvent::TurnEnd { .. } => "turnEnd",
-            AgentEvent::MessageStart { .. } => "messageStart",
-            AgentEvent::MessageUpdate { .. } => "messageUpdate",
-            AgentEvent::MessageEnd { .. } => "messageEnd",
-            AgentEvent::ToolExecutionStart { .. } => "toolExecutionStart",
-            AgentEvent::ToolExecutionUpdate { .. } => "toolExecutionUpdate",
-            AgentEvent::ToolExecutionEnd { .. } => "toolExecutionEnd",
-            AgentEvent::ProgressMessage { .. } => "progressMessage",
-            AgentEvent::InputRejected { .. } => "inputRejected",
-            AgentEvent::LoopDetected { .. } => "loopDetected",
-            AgentEvent::ContextCompacted { .. } => "contextCompacted",
+    /// Declares the frozen tag **and** a sample value for every variant of a
+    /// `#[serde(tag = "type")]` enum, from a single list.
+    ///
+    /// This is the fix for the class of bug that made the old guard useless: a
+    /// hand-written sample list and a hand-written variant count could never
+    /// notice a *new* variant, because a new variant appears in neither. Here
+    /// the generated match has no wildcard, so adding a variant fails to
+    /// compile — and the only way to fix that is to add a line below, which
+    /// supplies the sample in the same breath. The two lists cannot drift
+    /// because they are one list.
+    ///
+    /// Three further mistakes are caught by the compiler rather than by luck:
+    /// a duplicated pattern makes the later arm `unreachable_pattern` (an
+    /// error under CI's `-Dwarnings`), a sample of the wrong type does not
+    /// compile, and a missing arm is a non-exhaustive match.
+    ///
+    /// What the *tests* below add, which no macro can: that the declared tag
+    /// is the one serde actually emits, that each sample survives a
+    /// round-trip, and that a sample on the wrong line is caught (via the
+    /// distinctness check).
+    macro_rules! wire_freeze {
+        ($ty:ty, $tag_of:ident, $samples:ident, $($pat:pat => $tag:literal = $sample:expr),+ $(,)?) => {
+            /// The frozen `"type"` tag per variant. Changing one breaks every
+            /// deployed wire client — do not edit casually.
+            fn $tag_of(v: &$ty) -> &'static str {
+                match v { $($pat => $tag,)+ }
+            }
+
+            /// One sample per variant, positionally paired with the tags above.
+            fn $samples() -> Vec<$ty> { vec![$($sample,)+] }
+        };
+    }
+
+    fn msg() -> AgentMessage {
+        AgentMessage::Llm(Message::Assistant {
+            content: vec![Content::Text { text: "hi".into() }],
+            stop_reason: StopReason::Stop,
+            model: "mock".into(),
+            provider: "mock".into(),
+            usage: Usage::default(),
+            timestamp: 7,
+            error_message: None,
+        })
+    }
+
+    fn tool_result() -> ToolResult {
+        ToolResult {
+            content: vec![Content::Text { text: "ok".into() }],
+            details: serde_json::Value::Null,
         }
     }
 
-    fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
-        match delta {
-            StreamDelta::Text { .. } => "text",
-            StreamDelta::Thinking { .. } => "thinking",
-            StreamDelta::ToolCallDelta { .. } => "toolCallDelta",
+    wire_freeze! {
+        AgentEvent, expected_event_tag, event_samples,
+        AgentEvent::AgentStart => "agentStart" = AgentEvent::AgentStart,
+        AgentEvent::AgentEnd { .. } => "agentEnd"
+            = AgentEvent::agent_end(vec![msg()], SessionStats::default()),
+        AgentEvent::TurnStart => "turnStart" = AgentEvent::TurnStart,
+        AgentEvent::TurnEnd { .. } => "turnEnd" = AgentEvent::TurnEnd {
+            message: msg(),
+            tool_results: vec![],
+        },
+        AgentEvent::MessageStart { .. } => "messageStart"
+            = AgentEvent::MessageStart { message: msg() },
+        AgentEvent::MessageUpdate { .. } => "messageUpdate" = AgentEvent::MessageUpdate {
+            message: msg(),
+            delta: StreamDelta::Text { delta: "hi".into() },
+        },
+        AgentEvent::MessageEnd { .. } => "messageEnd"
+            = AgentEvent::MessageEnd { message: msg() },
+        AgentEvent::ToolExecutionStart { .. } => "toolExecutionStart"
+            = AgentEvent::ToolExecutionStart {
+                tool_call_id: "tc-1".into(),
+                tool_name: "bash".into(),
+                args: serde_json::json!({"command": "ls"}),
+            },
+        AgentEvent::ToolExecutionUpdate { .. } => "toolExecutionUpdate"
+            = AgentEvent::ToolExecutionUpdate {
+                tool_call_id: "tc-1".into(),
+                tool_name: "bash".into(),
+                partial_result: tool_result(),
+            },
+        AgentEvent::ToolExecutionEnd { .. } => "toolExecutionEnd"
+            = AgentEvent::ToolExecutionEnd {
+                tool_call_id: "tc-1".into(),
+                tool_name: "bash".into(),
+                result: tool_result(),
+                is_error: false,
+            },
+        AgentEvent::ProgressMessage { .. } => "progressMessage"
+            = AgentEvent::ProgressMessage {
+                tool_call_id: "tc-1".into(),
+                tool_name: "bash".into(),
+                text: "50% done".into(),
+            },
+        AgentEvent::InputRejected { .. } => "inputRejected"
+            = AgentEvent::InputRejected { reason: "injection detected".into() },
+        AgentEvent::LoopDetected { .. } => "loopDetected"
+            = AgentEvent::loop_detected("bash", 3, false),
+        AgentEvent::ContextCompacted { .. } => "contextCompacted"
+            = AgentEvent::ContextCompacted {
+                method: CompactionMethod::Summarized,
+                messages_before: 40,
+                messages_after: 13,
+                tokens_before: 96_500,
+                tokens_after: 41_200,
+                summary: None,
+            },
+    }
+
+    wire_freeze! {
+        StreamDelta, expected_delta_tag, delta_samples,
+        StreamDelta::Text { .. } => "text" = StreamDelta::Text { delta: "hi".into() },
+        StreamDelta::Thinking { .. } => "thinking"
+            = StreamDelta::Thinking { delta: "hmm".into() },
+        StreamDelta::ToolCallDelta { .. } => "toolCallDelta"
+            = StreamDelta::ToolCallDelta { delta: "{}".into() },
+    }
+
+    /// Asserts the frozen contract for one sample: declared tag == emitted tag,
+    /// payload keys are camelCase, and the value survives a round-trip.
+    ///
+    /// `seen` collects tags so a sample paired with the wrong pattern is caught
+    /// — that is the one error the macro cannot catch, since both lines
+    /// compile fine and the mismatch only shows as a repeated tag.
+    fn assert_frozen<T>(
+        sample: &T,
+        declared: &str,
+        seen: &mut BTreeSet<&'static str>,
+        declared_static: &'static str,
+    ) where
+        T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
+    {
+        let v = serde_json::to_value(sample).expect("serialize");
+
+        assert_eq!(
+            v["type"], declared,
+            "wire tag drifted: {sample:?} serializes as {} but wire_freeze! declares {declared}. \
+             Changing a tag breaks every deployed client — if this is intentional it is a \
+             breaking change, not a test fix",
+            v["type"]
+        );
+
+        for key in v
+            .as_object()
+            .expect("tagged enums serialize as objects")
+            .keys()
+        {
+            assert!(
+                !key.contains('_'),
+                "payload key {key:?} on {declared} is not camelCase — the enum carries \
+                 rename_all_fields = \"camelCase\" and TS clients hardcode these names"
+            );
         }
+
+        let back: T = serde_json::from_value(v).expect("round-trip deserialize");
+        assert_eq!(
+            &back, sample,
+            "{declared} did not survive a JSON round-trip"
+        );
+
+        assert!(
+            seen.insert(declared_static),
+            "two samples serialize as {declared} — a sample in wire_freeze! does not match \
+             the pattern on its own line"
+        );
     }
 
     #[test]
-    fn every_event_variant_has_a_pinned_tag() {
-        // Sampling one variant is enough: the compiler enforces coverage, this
-        // just proves the mapping matches what serde actually emits.
-        let event = AgentEvent::AgentStart;
-        let v = serde_json::to_value(&event).expect("serialize");
-        assert_eq!(v["type"], expected_event_tag(&event));
+    fn every_event_variant_is_frozen_tagged_and_round_trips() {
+        let samples = event_samples();
+        let mut seen = BTreeSet::new();
+        for sample in &samples {
+            let declared = expected_event_tag(sample);
+            assert_frozen(sample, declared, &mut seen, declared);
+        }
+        assert_eq!(
+            seen.len(),
+            samples.len(),
+            "every variant must contribute a distinct tag"
+        );
     }
 
     #[test]
-    fn every_delta_variant_has_a_pinned_tag() {
-        let delta = StreamDelta::Text { delta: "x".into() };
-        let v = serde_json::to_value(&delta).expect("serialize");
-        assert_eq!(v["type"], expected_delta_tag(&delta));
+    fn every_delta_variant_is_frozen_tagged_and_round_trips() {
+        let samples = delta_samples();
+        let mut seen = BTreeSet::new();
+        for sample in &samples {
+            let declared = expected_delta_tag(sample);
+            assert_frozen(sample, declared, &mut seen, declared);
+        }
+        assert_eq!(
+            seen.len(),
+            samples.len(),
+            "every variant must contribute a distinct tag"
+        );
     }
 }

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -298,7 +298,9 @@ fn sample_tool_result() -> ToolResult {
     }
 }
 
-/// One value of every `AgentEvent` variant.
+/// One value per `AgentEvent` variant — **by hand**. Nothing in this file
+/// enforces completeness; `wire_tag_freeze` in `src/types.rs` is what fails to
+/// compile when a variant has no sample.
 fn all_agent_events() -> Vec<AgentEvent> {
     vec![
         AgentEvent::AgentStart,
@@ -432,13 +434,16 @@ fn test_stream_delta_every_variant_roundtrips() {
     }
 }
 
-/// The frozen `"type"` tag for every `AgentEvent` variant. Exhaustive match
+/// The frozen `"type"` tag for the `AgentEvent` variants sampled in
+/// `all_agent_events`. **Not** exhaustive — the `_` arm below is forced by
+/// `#[non_exhaustive]`, so this match cannot be a coverage guarantee.
+///
 /// The compile-time half of this freeze moved into `src/types.rs`
 /// (`wire_tag_freeze`) when `AgentEvent` and `StreamDelta` became
 /// `#[non_exhaustive]` — an integration test can no longer match them
 /// exhaustively, so the "adding a variant fails to compile" guarantee only
 /// holds inside the defining crate. What remains here is the round-trip and
-/// payload-shape coverage **for the variants sampled below** — nothing here
+/// payload-shape coverage **for the variants sampled in `all_agent_events`** — nothing here
 /// notices a variant that has no sample, because `all_agent_events` and the
 /// match arms are both hand-written and a new variant is in neither. That
 /// coverage guarantee lives in `wire_tag_freeze`, where the compiler enforces
@@ -464,7 +469,9 @@ fn expected_event_tag(event: &AgentEvent) -> &'static str {
     }
 }
 
-/// Same exhaustive-match freeze for `StreamDelta` tags.
+/// Same tag freeze for the `StreamDelta` variants sampled above. The `_` arm
+/// is forced by `#[non_exhaustive]`, so this is not a coverage guarantee
+/// either.
 fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
     match delta {
         StreamDelta::Text { .. } => "text",
@@ -474,9 +481,25 @@ fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
     }
 }
 
+/// Guards `all_agent_events` against silent *shrinkage*.
+///
+/// This is the one thing the old `EVENT_VARIANT_COUNT` genuinely did. It never
+/// caught a variant being **added** — the `_ => "unknown"` arm means adding one
+/// forces no edit to this file at all — but deleting a sample here quietly
+/// removes the payload coverage below, and that it does catch. Adding a variant
+/// is `wire_tag_freeze`'s job, where the compiler enforces it.
+const SAMPLED_EVENT_COUNT: usize = 14;
+
 #[test]
 fn test_agent_event_type_tags_are_frozen() {
-    for event in all_agent_events() {
+    let events = all_agent_events();
+    assert_eq!(
+        events.len(),
+        SAMPLED_EVENT_COUNT,
+        "a sample was removed from all_agent_events — the payload-shape assertions in this \
+         file silently stop covering that variant. Deliberate? Lower the constant."
+    );
+    for event in events {
         let v: serde_json::Value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(
             v["type"],

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -387,7 +387,11 @@ fn deterministic_compaction_event() -> AgentEvent {
 
 #[test]
 fn test_context_compacted_wire_shape_is_frozen() {
-    let v = serde_json::to_value(&all_agent_events()[12]).expect("serialize");
+    let compacted = all_agent_events()
+        .into_iter()
+        .find(|e| matches!(e, AgentEvent::ContextCompacted { .. }))
+        .expect("all_agent_events must carry a ContextCompacted sample");
+    let v = serde_json::to_value(&compacted).expect("serialize");
     assert_eq!(v["type"], "contextCompacted");
     assert_eq!(v["method"], "summarized");
     // camelCase, including the acronym casing a TS client hardcodes.
@@ -434,8 +438,11 @@ fn test_stream_delta_every_variant_roundtrips() {
 /// `#[non_exhaustive]` — an integration test can no longer match them
 /// exhaustively, so the "adding a variant fails to compile" guarantee only
 /// holds inside the defining crate. What remains here is the round-trip and
-/// payload-shape coverage, plus [`EVENT_VARIANT_COUNT`], which still fails
-/// until a new variant gets a sample in `all_agent_events`.
+/// payload-shape coverage **for the variants sampled below** — nothing here
+/// notices a variant that has no sample, because `all_agent_events` and the
+/// match arms are both hand-written and a new variant is in neither. That
+/// coverage guarantee lives in `wire_tag_freeze`, where the compiler enforces
+/// it; see #137.
 /// A tag change is a breaking change for wire clients — do not edit casually.
 fn expected_event_tag(event: &AgentEvent) -> &'static str {
     match event {
@@ -467,19 +474,9 @@ fn expected_delta_tag(delta: &StreamDelta) -> &'static str {
     }
 }
 
-/// Number of arms in `expected_event_tag` — bump together with the match.
-const EVENT_VARIANT_COUNT: usize = 14;
-
 #[test]
 fn test_agent_event_type_tags_are_frozen() {
-    let events = all_agent_events();
-    assert_eq!(
-        events.len(),
-        EVENT_VARIANT_COUNT,
-        "a variant was added to expected_event_tag without a sample in all_agent_events — \
-         the new variant's tag and round-trip are untested until one is added"
-    );
-    for event in events {
+    for event in all_agent_events() {
         let v: serde_json::Value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(
             v["type"],


### PR DESCRIPTION
Closes #137.

`EVENT_VARIANT_COUNT`'s message claimed it failed when a variant was added
without a serialization sample. It could not fire for that: the integration
test's match carries a `_ => "unknown"` arm, forced by `#[non_exhaustive]`, so
adding a variant requires no edit to that file at all — the count and the sample
list are both hand-written and a new variant appears in neither.

## One list instead of two

`wire_tag_freeze` (in `src/types.rs`, where `#[non_exhaustive]` still permits
exhaustive matching) declares the frozen tag **and** a sample for every variant
from a single list:

```rust
AgentEvent::LoopDetected { .. } => "loopDetected"
    = AgentEvent::loop_detected("bash", 3, false),
```

Adding a variant is a non-exhaustive-match compile error whose only fix supplies
the sample too. The specifier is `pat_param`, not `pat`, and that is
load-bearing — `pat` would accept an or-pattern, letting someone answer the
compile error by widening an unrelated arm (`TurnStart | NewVariant =>
"turnStart"`) and leave the new variant with no coverage.

Each sample is checked for its frozen tag, a JSON round-trip, and camelCase keys
**recursively** — a snake_case key at `agentEnd.messages[0].usage` reaches
clients as surely as a top-level one. Samples are populated rather than
defaulted: a round-trip cannot notice a field that `#[serde(skip)]` drops if the
value it reconstructs is the default anyway.

## What this does and does not freeze

Stated plainly, because this PR is about a guard that overclaimed.

**Frozen:** every variant has a sample; each sample's serde tag equals its
declared literal; a new variant cannot be added without one; each sample
round-trips; no payload key at any depth contains an underscore.

**Not frozen:** payload shape. A `#[serde(rename)]` on a field still passes.
Field names are pinned only where `tests/serialization_test.rs` asserts them by
literal.

## Verified by mutation

A guard that cannot fire is the bug, so every assertion was checked by breaking
it — confirming each mutation actually applied first, since one silently didn't
and produced two meaningless passes:

| mutation | result |
|---|---|
| add a 15th variant, no sample | **compile error** — `serialization_test` stays 27/27 green on the same mutation |
| or-pattern bypass | **macro parse error** (`no rules expected \|`) |
| tag typo `turnEnd` → `turnEndd` | `wire tag drifted` |
| drop `Usage`'s `totalTokens` rename | `payload key "total_tokens" at agentEnd.messages[0].usage is not camelCase` |
| `#[serde(skip)]` on `AgentEnd.stats` | `agentEnd did not survive a JSON round-trip` |
| delete a sample from `all_agent_events` | `a sample was removed from all_agent_events` |

## Review corrections

Three review agents found this PR's own docs overclaiming. Fixed in a4f64e1:

- **The module claimed to freeze "payload shape."** It doesn't — see the scope
  section above. Same defect one level up.
- **`assert_eq!(seen.len(), samples.len())` could never fire** — `assert_frozen`
  already asserts each `insert` returned true. A decorative assertion inside a
  PR about decorative assertions. Removed.
- **The CHANGELOG stated a false historical event:** that #136's new variant was
  untested. `e840613` added the sample, the arm and the count bump in the same
  commit, and its message says so. The structural criticism is a counterfactual
  and now reads as one. "It could not fire" was also too strong — it *does* fire
  on sample-list shrinkage.
- **That shrinkage guard was a real function I deleted.** Confirmed by A/B:
  deleting a sample failed pre-PR and went green after. Restored under an
  accurate name and message.
- **`assert_frozen`'s duplicated fourth parameter** dropped; both tag functions
  already return `&'static str`.

## Also fixed

- `ToolResult` reaches the wire as `toolExecutionEnd.result` but carried no
  `rename_all = "camelCase"`, unlike `SessionStats` and `SummaryStats` — a no-op
  for today's single-word fields, a silent snake_case leak for the first
  multi-word one.
- `ContextCompacted`'s doc block had been concatenated onto `LoopDetected` since
  #136, leaving `ContextCompacted` undocumented.
- `test_context_compacted_wire_shape_is_frozen` indexed the sample list
  positionally (`all_agent_events()[12]`); it now looks the variant up.
- Three surviving false claims in `serialization_test.rs` docs ("Exhaustive
  match", "every variant") — both matches carry `_` arms.

Test-only apart from two serde attributes. `cargo test --all-features`: 598
passed, 0 failed. Clippy clean under `-Dwarnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)