### PR TITLE
fix: release-gate defects found by a whole-release review of v0.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 .DS_Store
 # mdbook build output (`mdbook build`); the site is published by CI
 /book
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,88 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **The `AgentEvent` wire freeze now catches a new variant**
+- **Release-gate fixes found by a whole-release review** (pre-0.18.0). Eight
+  commits were each reviewed alone; reviewing them together found defects in
+  the interactions no single-PR review could see.
+
+  **Loop detection corrupted the transcript.** The steering nudge and the abort
+  message were pushed the moment the verdict came back — which is *before* the
+  tools run — so the next request carried `assistant(tool_use)` →
+  `user(text)` → `user(tool_result)`. Every provider rejects that shape, and
+  the resulting 400 names tool_result blocks rather than loop detection. The
+  abort was worse: it returned with the calls unanswered, and since
+  `Agent::prompt` keeps those messages, a loop-aborted agent was poisoned —
+  every *later* prompt failed too. The nudge is now deferred until the results
+  are appended, and the abort synthesizes an `is_error` result per outstanding
+  call before stopping. It still does not run the tools.
+
+  This invariant is treated as sacred elsewhere in the crate — `context.rs`
+  calls an unanswered call "an orphan every provider rejects" and
+  `llm_compaction.rs` has a dedicated test for it. Loop detection was the one
+  path that broke it, and no test caught it because `MockProvider` ignores
+  message shape and every loop test asserted only on the event stream. There is
+  now a transcript-invariant assertion, and reverting the fix fails it.
+
+  **Stash retrieval was re-truncated by the cap it exists to escape.** The
+  marker says `shared_state get "tool-out-…"`; the model calls it; the full
+  text came back through the same append-path cap that stashed it. 2000 lines
+  in, 200 out, plus a fresh stash entry against the cap on every attempt. The
+  headline feature of this release did not work through the path the model
+  actually takes — only from Rust, which is what the tests asserted.
+  `shared_state` now joins `read_file` in `default_tool_output_overrides`.
+
+  **`is_configured()` ignored `context_tier`,** so a config priced only above
+  its threshold reported "pricing unknown" and billed every request at $0.
+
+  **GASP recorded a loop abort as `"completed"`.** `LoopDetected` fell into a
+  `_ => {}` wildcard, so the outcome stayed whatever the last stop reason
+  mapped to. The CHANGELOG claimed the opposite. Now `loop_aborted:{tool}`.
+
+  **`Agent::with_shared_state` shipped undocumented** — its doc block ran into
+  `take_tools`'s with no separator, landing the whole thing on a private
+  function. The release's headline API would have rendered blank on docs.rs.
+
+  **An `Abort` later in a batch was downgraded to an earlier `Steer`,** and its
+  signature never reached `steered`, giving it a free pass the next turn too.
+  `LoopVerdict` now derives `Ord` — declaration order is severity order — and
+  the loop keeps the worst verdict rather than the first. It is also
+  `#[must_use]`: an ignored verdict silently disabled detection while still
+  advancing the tracker.
+
+  **The loop-detection text reaching the model carried ~40-space runs**, from
+  literals wrapped across source lines without `\` continuations. `rustfmt`
+  does not reformat literal contents and clippy has no lint for it.
+
+  **The price audit could pass having compared zero fields.** Its guard derived
+  the expected count from the same list it was checking, so an empty
+  `presets()` reported "0 compared, 0 drifted" and passed. It now pins a floor
+  against the number of priced constructors.
+
+  **Breaking: `CostConfig::new` and `ContextTier::new` take two rates, not
+  four.** Cache rates move to `with_cache_read`/`with_cache_write`. Four
+  same-typed `f64`s in a row is a transposition hazard, and no vendor publishes
+  them in one order — Anthropic lists input/cache-write/cache-read/output,
+  OpenAI lists input/cached-input/output. A transposed config still returns
+  `true` from `is_configured`, so every downstream guard passes; that is how
+  `claude_sonnet_5` billed 50% high for 18 releases. This repo had already made
+  the mistake: `examples/llm_compaction_live.rs` silently dropped cache-write
+  pricing in a cost-measurement harness. `ContextTier::cache_write_per_million`
+  was also unreachable — `new` hardcoded it to 0.0 with no setter on a
+  `#[non_exhaustive]` struct.
+
+  **Breaking: `CostConfig::context_tier: Option<ContextTier>` is now
+  `context_tiers: Vec<ContextTier>`,** kept sorted by threshold. Vendors
+  publish multi-step schedules and models.dev already models this as an array —
+  which this release's own audit reads at `/tiers/0/`. Leaving it as one tier
+  would have cost a second breaking release, and would have broken the serde
+  key as well as the field type, invalidating persisted configs.
+
+  **Breaking: `ExecutionLimits` is `#[non_exhaustive]`** with `with_*` builders,
+  closing a break this crate has now taken twice. Also note `ExecutionTracker`
+  lost struct-literal construction in this release (it gained three private
+  fields) — an undeclared fourth breaking change, recorded here.
+
+- **The `AgentEvent` wire freeze now forces a sample for every variant**
   ([#137](https://github.com/yologdev/yoagent/issues/137)). `EVENT_VARIANT_COUNT`'s
   message claimed it failed when a variant was added without a serialization
   sample. It could not fire for that: the integration test's match carries a
@@ -54,7 +135,7 @@ adheres to [Semantic Versioning](https://semver.org/).
   `#[serde(skip)]` on `AgentEnd.stats` now fails the round-trip.
 
   Two related fixes. `ToolResult` reaches the wire as `toolExecutionEnd.result`
-  but carried no `rename_all = "camelCase"`, unlike its siblings — a no-op for
+  but carried no `rename_all = "camelCase"` — a no-op for
   today's single-word fields, and a silent snake_case leak for the first
   multi-word one. And `ContextCompacted`'s doc block had been concatenated onto
   `LoopDetected` since #136, leaving `ContextCompacted` undocumented.

--- a/examples/llm_compaction_live.rs
+++ b/examples/llm_compaction_live.rs
@@ -123,7 +123,7 @@ fn priced(id: &str) -> ModelConfig {
 /// DeepSeek has no write category — populating its cache is free.
 fn deepseek_priced(id: &str, input: f64, output: f64, cache_read: f64) -> ModelConfig {
     let mut config = ModelConfig::deepseek(id, id);
-    config.cost = CostConfig::new(input, output, cache_read, 0.0);
+    config.cost = CostConfig::new(input, output).with_cache_read(cache_read);
     config
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -342,16 +342,6 @@ impl Agent {
         self
     }
 
-    /// Attach a shared key-value store.
-    ///
-    /// Two things follow. The `shared_state` tool is registered, so the model
-    /// can read and write the store — `SharedState` was always described as a
-    /// parent↔sub-agent medium, but until now only `SubAgentTool` wired it, so
-    /// a parent could populate it and never read it back.
-    ///
-    /// And truncated tool output is stashed here: head-tail truncation
-    /// currently discards the middle irrecoverably, and with a store attached
-    /// the marker names a key the model can fetch instead.
     /// Take the tool list for a run, injecting `shared_state` when a store is
     /// configured.
     ///
@@ -370,6 +360,16 @@ impl Agent {
         tools
     }
 
+    /// Attach a shared key-value store.
+    ///
+    /// Two things follow. The `shared_state` tool is registered, so the model
+    /// can read and write the store — `SharedState` was always described as a
+    /// parent↔sub-agent medium, but until now only `SubAgentTool` wired it, so
+    /// a parent could populate it and never read it back.
+    ///
+    /// And truncated tool output is stashed here: head-tail truncation
+    /// currently discards the middle irrecoverably, and with a store attached
+    /// the marker names a key the model can fetch instead.
     pub fn with_shared_state(mut self, state: crate::shared_state::SharedState) -> Self {
         // Only the field. The tool is injected where the tool list is
         // assembled, mirroring `SubAgentTool` — pushing here would double a

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -577,9 +577,14 @@ async fn run_loop(
                 _ => vec![],
             };
 
+            // A loop-detection nudge, held until the assistant's tool calls
+            // have been answered. Injecting it before the `tool_result`s would
+            // orphan them, which every provider rejects.
+            let mut loop_nudge: Option<AgentMessage> = None;
+
             // Repetition check runs *before* execution, so a stuck model does
             // not also pay for the tool run it was never going to learn from.
-            if has_tool_calls_early(&tool_calls) {
+            if !tool_calls.is_empty() {
                 if let Some(ref mut tracker) = tracker {
                     let sigs: Vec<(String, serde_json::Value)> = tool_calls
                         .iter()
@@ -592,7 +597,7 @@ async fn run_loop(
                             repetitions,
                         } => {
                             warn!(
-                                "loop detection: {tool_name} called {repetitions}x with                                  identical arguments; steering"
+                                "loop detection: {tool_name} called {repetitions}x with identical arguments; steering"
                             );
                             tx.send(AgentEvent::LoopDetected {
                                 tool_name: tool_name.clone(),
@@ -607,21 +612,17 @@ async fn run_loop(
                             let nudge = AgentMessage::Llm(Message::User {
                                 content: vec![Content::Text {
                                     text: format!(
-                                        "[You have called {tool_name} {repetitions} times with                                          identical arguments. The result will not change —                                          change approach, or say why the repetition is needed.]"
+                                        "[You have called {tool_name} {repetitions} times with identical arguments. The result will not change — change approach, or say why the repetition is needed.]"
                                     ),
                                 }],
                                 timestamp: now_ms(),
                             });
-                            tx.send(AgentEvent::MessageStart {
-                                message: nudge.clone(),
-                            })
-                            .ok();
-                            tx.send(AgentEvent::MessageEnd {
-                                message: nudge.clone(),
-                            })
-                            .ok();
-                            context.messages.push(nudge.clone());
-                            new_messages.push(nudge);
+                            // Deferred, not pushed here. The assistant's
+                            // `tool_use` blocks are still unanswered at this
+                            // point, and every provider rejects a transcript
+                            // where anything but their `tool_result`s comes
+                            // next. Appended after the results, below.
+                            loop_nudge = Some(nudge);
                         }
                         context::LoopVerdict::Abort {
                             tool_name,
@@ -637,11 +638,34 @@ async fn run_loop(
                             let stop = AgentMessage::Llm(Message::User {
                                 content: vec![Content::Text {
                                     text: format!(
-                                        "[Agent stopped: {tool_name} was called repeatedly with                                          identical arguments after being asked to change                                          approach.]"
+                                        "[Agent stopped: {tool_name} was called repeatedly with identical arguments after being asked to change approach.]"
                                     ),
                                 }],
                                 timestamp: now_ms(),
                             });
+                            // The tools are deliberately not run — a stuck
+                            // model should not also pay for a call it was
+                            // never going to learn from. But the assistant's
+                            // `tool_use` blocks must still be answered, or the
+                            // transcript is one every provider rejects and the
+                            // agent is unusable for any later prompt. Synthesize
+                            // one error result per outstanding call.
+                            for (id, name, _) in &tool_calls {
+                                let denied = Message::ToolResult {
+                                    tool_call_id: id.clone(),
+                                    tool_name: name.clone(),
+                                    content: vec![Content::Text {
+                                        text: "Not executed: the run was stopped for repeating \
+                                               this call with identical arguments."
+                                            .into(),
+                                    }],
+                                    is_error: true,
+                                    timestamp: now_ms(),
+                                };
+                                let am: AgentMessage = denied.into();
+                                context.messages.push(am.clone());
+                                new_messages.push(am);
+                            }
                             tx.send(AgentEvent::MessageStart {
                                 message: stop.clone(),
                             })
@@ -652,6 +676,22 @@ async fn run_loop(
                             .ok();
                             context.messages.push(stop.clone());
                             new_messages.push(stop);
+                            // Match every other abort path in this function:
+                            // callers tracking usage must not miss this turn,
+                            // and a UI pairing TurnStart/TurnEnd must not be
+                            // left with an unmatched TurnStart.
+                            if let Some(after_turn) = config.after_turn.as_ref() {
+                                let usage = match &message {
+                                    Message::Assistant { usage, .. } => usage.clone(),
+                                    _ => Usage::default(),
+                                };
+                                after_turn(&context.messages, &usage);
+                            }
+                            tx.send(AgentEvent::TurnEnd {
+                                message: agent_msg,
+                                tool_results: Vec::new(),
+                            })
+                            .ok();
                             return stats;
                         }
                     }
@@ -833,6 +873,21 @@ async fn run_loop(
                 after_turn(&context.messages, &usage);
             }
 
+            // Now that every `tool_result` is appended, the transcript is
+            // well-formed again and the nudge can land.
+            if let Some(nudge) = loop_nudge.take() {
+                tx.send(AgentEvent::MessageStart {
+                    message: nudge.clone(),
+                })
+                .ok();
+                tx.send(AgentEvent::MessageEnd {
+                    message: nudge.clone(),
+                })
+                .ok();
+                context.messages.push(nudge.clone());
+                new_messages.push(nudge);
+            }
+
             tx.send(AgentEvent::TurnEnd {
                 message: agent_msg,
                 tool_results,
@@ -875,11 +930,6 @@ async fn run_loop(
     }
 
     stats
-}
-
-/// Whether this turn produced any tool call at all.
-fn has_tool_calls_early(calls: &[(String, String, serde_json::Value)]) -> bool {
-    !calls.is_empty()
 }
 
 /// Stream an assistant response from the LLM.

--- a/src/context.rs
+++ b/src/context.rs
@@ -262,7 +262,17 @@ fn default_headroom_turns() -> Option<usize> {
 /// both lossless and directed; cutting the middle out of a source file on top
 /// of that would remove exactly the part the agent asked for.
 fn default_tool_output_overrides() -> HashMap<String, usize> {
-    HashMap::from([("read_file".to_string(), usize::MAX)])
+    HashMap::from([
+        ("read_file".to_string(), usize::MAX),
+        // The retrieval side of the truncation stash. Without this the marker
+        // is a lie: the model follows `shared_state get "tool-out-…"`, and the
+        // full text it asks for is re-truncated by the very cap that stashed
+        // it — head+tail of what it already had, plus a fresh stash entry
+        // against the cap on every attempt. A directed fetch of a known key is
+        // the model asking for exactly this content; capping it defeats the
+        // feature.
+        ("shared_state".to_string(), usize::MAX),
+    ])
 }
 
 impl ContextConfig {
@@ -926,6 +936,7 @@ fn keep_within_budget(messages: &[AgentMessage], budget: usize) -> Vec<AgentMess
 
 /// Execution limits for the agent loop
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ExecutionLimits {
     /// Maximum number of turns (LLM calls)
     pub max_turns: usize,
@@ -955,8 +966,47 @@ impl Default for ExecutionLimits {
     }
 }
 
+impl ExecutionLimits {
+    /// Cap on turns before the run stops.
+    pub fn with_max_turns(mut self, turns: usize) -> Self {
+        self.max_turns = turns;
+        self
+    }
+
+    /// Cap on total tokens across the run.
+    pub fn with_max_total_tokens(mut self, tokens: usize) -> Self {
+        self.max_total_tokens = tokens;
+        self
+    }
+
+    /// Wall-clock cap on the run.
+    pub fn with_max_duration(mut self, duration: std::time::Duration) -> Self {
+        self.max_duration = duration;
+        self
+    }
+
+    /// Consecutive identical tool calls tolerated before steering, then
+    /// stopping. `None` disables loop detection entirely.
+    pub fn with_max_identical_tool_calls(mut self, calls: Option<usize>) -> Self {
+        self.max_identical_tool_calls = calls;
+        self
+    }
+}
+
 /// What the loop should do about a repeated tool call.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Ordered by severity, and that ordering is load-bearing: one batch can
+/// contain several repeated signatures, and the loop must act on the worst.
+/// Declaration order is the severity order, so `Ord` is derived rather than
+/// hand-written — a new escalation slots in by being declared in the right
+/// place.
+///
+/// Deliberately **not** `#[non_exhaustive]`: this is control flow, so a new
+/// variant should be a compile error for matchers, not a silent wildcard
+/// fallthrough. Matches the `ToolDecision` precedent.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[must_use = "a loop verdict that is not acted on silently disables loop detection, \
+              while still advancing the tracker's state"]
 pub enum LoopVerdict {
     /// Nothing repetitive, or below the threshold.
     Continue,
@@ -1032,22 +1082,32 @@ impl ExecutionTracker {
                 }
             }
 
-            if self.consecutive >= threshold && verdict == LoopVerdict::Continue {
+            // No `verdict == Continue` guard: with `Parallel` execution a
+            // model emits multi-call batches routinely, and stopping at the
+            // first escalation both downgraded a later `Abort` to the earlier
+            // `Steer` and skipped recording that later signature in `steered`,
+            // giving it a free pass on the next turn too. Every call is
+            // assessed; the most severe verdict wins via the fold below.
+            if self.consecutive >= threshold {
                 let repetitions = self.consecutive;
-                if self.steered.contains(&sig) {
-                    verdict = LoopVerdict::Abort {
+                let this_call = if self.steered.contains(&sig) {
+                    LoopVerdict::Abort {
                         tool_name: name.clone(),
                         repetitions,
-                    };
+                    }
                 } else {
                     self.steered.push(sig);
                     // Reset so the abort needs another full run of repeats,
                     // rather than firing on the very next call.
                     self.consecutive = 0;
-                    verdict = LoopVerdict::Steer {
+                    LoopVerdict::Steer {
                         tool_name: name.clone(),
                         repetitions,
-                    };
+                    }
+                };
+                // Keep the worst verdict in the batch, not the first.
+                if this_call > verdict {
+                    verdict = this_call;
                 }
             }
         }

--- a/src/gasp.rs
+++ b/src/gasp.rs
@@ -475,6 +475,17 @@ async fn record_event(
             })
             .await?;
         }
+        AgentEvent::LoopDetected {
+            aborted: true,
+            tool_name,
+            ..
+        } if tracking.started => {
+            // Without this the run's outcome stays whatever the last stop
+            // reason mapped to — `ToolUse` -> "completed" — so the durable log
+            // recorded a budget-exhausting loop abort as a clean success, the
+            // exact opposite of what this event exists to make auditable.
+            tracking.outcome = format!("loop_aborted:{tool_name}");
+        }
         AgentEvent::InputRejected { .. } if tracking.started => {
             // A policy rejection is not a crash — label it distinctly in the
             // durable log.

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -84,9 +84,16 @@ pub struct CostConfig {
     #[serde(default)]
     pub cache_write_per_million: f64,
     /// Rates that replace the above once a request's prompt exceeds a
-    /// threshold. `None` means one flat rate at every size.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub context_tier: Option<ContextTier>,
+    /// threshold, ascending by threshold. Empty means one flat rate at every
+    /// size.
+    ///
+    /// A `Vec` rather than a single tier because vendors publish multi-step
+    /// schedules and models.dev already represents this as an array — making
+    /// it one tier would buy a second breaking release the first time a
+    /// three-tier model appears, and it would break the serde key as well as
+    /// the field type, invalidating every persisted config.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub context_tiers: Vec<ContextTier>,
 }
 
 /// Higher rates charged above a context threshold.
@@ -113,47 +120,100 @@ pub struct ContextTier {
 }
 
 impl ContextTier {
-    /// A tier with no separate cache-write rate, which is the common shape.
-    pub fn new(
-        above_prompt_tokens: u64,
-        input_per_million: f64,
-        output_per_million: f64,
-        cache_read_per_million: f64,
-    ) -> Self {
+    /// A tier's threshold and the two rates every tier has.
+    ///
+    /// Cache rates are added with [`with_cache_read`](Self::with_cache_read)
+    /// and [`with_cache_write`](Self::with_cache_write), mirroring
+    /// [`CostConfig::new`] and for the same reason. The previous shape took
+    /// cache-read positionally and silently zeroed cache-write, which would
+    /// have dropped an Anthropic-style tier's $12.50/M cache writes to $0
+    /// above the threshold.
+    ///
+    /// `above_prompt_tokens` is exclusive: a prompt exactly at the threshold
+    /// stays on the band below, matching how vendors publish `>272K`.
+    pub fn new(above_prompt_tokens: u64, input_per_million: f64, output_per_million: f64) -> Self {
+        debug_assert!(
+            above_prompt_tokens > 0,
+            "a tier at 0 applies to every request, making the base rates dead code"
+        );
         Self {
             above_prompt_tokens,
             input_per_million,
             output_per_million,
-            cache_read_per_million,
+            cache_read_per_million: 0.0,
             cache_write_per_million: 0.0,
         }
+    }
+
+    /// Rate for reading a cached prompt prefix above this threshold.
+    pub fn with_cache_read(mut self, per_million: f64) -> Self {
+        self.cache_read_per_million = per_million;
+        self
+    }
+
+    /// Rate for writing a prompt prefix into the cache above this threshold.
+    pub fn with_cache_write(mut self, per_million: f64) -> Self {
+        self.cache_write_per_million = per_million;
+        self
+    }
+
+    /// Whether this tier sets any rate. Mirrors [`CostConfig::is_configured`]:
+    /// all-zero means unknown, not free.
+    pub fn is_configured(&self) -> bool {
+        self.input_per_million != 0.0
+            || self.output_per_million != 0.0
+            || self.cache_read_per_million != 0.0
+            || self.cache_write_per_million != 0.0
     }
 }
 
 impl CostConfig {
-    /// Flat rates, one price per token category at every request size.
+    /// The two rates every priced model has.
+    ///
+    /// Cache rates are set with [`with_cache_read`](Self::with_cache_read) and
+    /// [`with_cache_write`](Self::with_cache_write) rather than as positional
+    /// arguments. Four same-typed `f64`s in a row is a transposition waiting to
+    /// happen, and no vendor publishes them in one order: Anthropic lists
+    /// input / cache write / cache read / output, OpenAI lists input / cached
+    /// input / output. Transcribing top-to-bottom from either page produced a
+    /// wrong-but-compiling config, and `is_configured` returns `true` for a
+    /// transposed one, so every downstream guard passes. That is exactly how
+    /// `claude_sonnet_5` billed 50% high for 18 releases. Two arguments still
+    /// transpose, but output is always dearer than input, so the mistake is
+    /// visible.
     ///
     /// `CostConfig` is `#[non_exhaustive]`, so downstream crates build it here
-    /// rather than with a struct literal. Add a tier with
-    /// [`with_context_tier`](Self::with_context_tier).
-    pub fn new(
-        input_per_million: f64,
-        output_per_million: f64,
-        cache_read_per_million: f64,
-        cache_write_per_million: f64,
-    ) -> Self {
+    /// rather than with a struct literal.
+    pub fn new(input_per_million: f64, output_per_million: f64) -> Self {
         Self {
             input_per_million,
             output_per_million,
-            cache_read_per_million,
-            cache_write_per_million,
-            context_tier: None,
+            cache_read_per_million: 0.0,
+            cache_write_per_million: 0.0,
+            context_tiers: Vec::new(),
         }
     }
 
+    /// Rate for reading a cached prompt prefix.
+    pub fn with_cache_read(mut self, per_million: f64) -> Self {
+        self.cache_read_per_million = per_million;
+        self
+    }
+
+    /// Rate for writing a prompt prefix into the cache.
+    pub fn with_cache_write(mut self, per_million: f64) -> Self {
+        self.cache_write_per_million = per_million;
+        self
+    }
+
     /// Charge higher rates above a prompt-size threshold.
+    ///
+    /// Repeatable. Tiers are kept sorted by threshold so `cost_usd` can take
+    /// the last one the prompt clears, and so declaration order cannot change
+    /// what a config costs.
     pub fn with_context_tier(mut self, tier: ContextTier) -> Self {
-        self.context_tier = Some(tier);
+        self.context_tiers.push(tier);
+        self.context_tiers.sort_by_key(|t| t.above_prompt_tokens);
         self
     }
 
@@ -164,6 +224,10 @@ impl CostConfig {
             || self.output_per_million != 0.0
             || self.cache_read_per_million != 0.0
             || self.cache_write_per_million != 0.0
+            // A config priced only above its threshold is still priced.
+            // Without this, "free below 272K, paid above" reports as unknown
+            // and bills every request at $0.
+            || self.context_tiers.iter().any(|t| t.is_configured())
     }
 
     /// Dollar cost of a usage record at these per-million-token rates.
@@ -174,14 +238,20 @@ impl CostConfig {
         // Prompt size, which is what a context tier is priced against — every
         // caller passes one request's usage, so no extra parameter is needed.
         let prompt = usage.input + usage.cache_read + usage.cache_write;
-        let (input, output, cache_read, cache_write) = match &self.context_tier {
-            Some(t) if prompt > t.above_prompt_tokens => (
+        // The last tier the prompt clears. `with_context_tier` keeps the vec
+        // sorted, so this is the most expensive applicable band.
+        let tier = self
+            .context_tiers
+            .iter()
+            .rfind(|t| prompt > t.above_prompt_tokens);
+        let (input, output, cache_read, cache_write) = match tier {
+            Some(t) => (
                 t.input_per_million,
                 t.output_per_million,
                 t.cache_read_per_million,
                 t.cache_write_per_million,
             ),
-            _ => (
+            None => (
                 self.input_per_million,
                 self.output_per_million,
                 self.cache_read_per_million,
@@ -203,7 +273,7 @@ impl Default for CostConfig {
             output_per_million: 0.0,
             cache_read_per_million: 0.0,
             cache_write_per_million: 0.0,
-            context_tier: None,
+            context_tiers: Vec::new(),
         }
     }
 }
@@ -753,7 +823,7 @@ impl ModelConfig {
                 output_per_million: 30.0,
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 0.0,
-                context_tier: None,
+                context_tiers: Vec::new(),
             },
             ..Self::openai("gpt-5.5", "GPT-5.5")
         }

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -767,12 +767,12 @@ async fn test_execution_limit_counts_cached_tokens() {
         })),
         context_config: None,
         compaction_strategy: None,
-        execution_limits: Some(ExecutionLimits {
-            max_turns: 50,
-            max_total_tokens: 100,
-            max_duration: std::time::Duration::from_secs(60),
-            ..Default::default()
-        }),
+        execution_limits: Some(
+            ExecutionLimits::default()
+                .with_max_turns(50)
+                .with_max_total_tokens(100)
+                .with_max_duration(std::time::Duration::from_secs(60)),
+        ),
         cache_config: CacheConfig::default(),
         tool_output_sink: None,
         output_schema: None,
@@ -2289,12 +2289,12 @@ fn calibration_config(
             ..Default::default()
         }),
         compaction_strategy: Some(strategy),
-        execution_limits: Some(ExecutionLimits {
-            max_turns: 2,
-            max_total_tokens: 1_000_000,
-            max_duration: std::time::Duration::from_secs(60),
-            ..Default::default()
-        }),
+        execution_limits: Some(
+            ExecutionLimits::default()
+                .with_max_turns(2)
+                .with_max_total_tokens(1_000_000)
+                .with_max_duration(std::time::Duration::from_secs(60)),
+        ),
         cache_config: CacheConfig::default(),
         tool_output_sink: None,
         output_schema: None,
@@ -2742,7 +2742,7 @@ async fn cost_accrues_when_rates_are_configured_and_stays_none_otherwise() {
         system_prompt: String::new(),
     };
     let mut priced = yoagent::provider::ModelConfig::anthropic("mock", "Mock");
-    priced.cost = yoagent::provider::CostConfig::new(3.0, 15.0, 0.0, 0.0);
+    priced.cost = yoagent::provider::CostConfig::new(3.0, 15.0);
     let mut config = make_config(MockProvider::new(responses()));
     config.model_config = Some(priced);
     config.get_follow_up_messages = follow_up_once();
@@ -3344,6 +3344,85 @@ fn repeat_call(n: usize, args: serde_json::Value) -> Vec<MockResponse> {
         .collect()
 }
 
+/// Like [`run_with_limits`] but also returns the final transcript.
+///
+/// The events alone were what every loop-detection test asserted on, and that
+/// is exactly how a transcript-corrupting bug shipped: the nudge was injected
+/// between an assistant's `tool_use` blocks and their `tool_result`s, a shape
+/// every provider rejects, while the event stream looked perfect.
+async fn run_with_limits_msgs(
+    responses: Vec<MockResponse>,
+    limits: yoagent::context::ExecutionLimits,
+) -> (Vec<AgentEvent>, Vec<AgentMessage>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut context = AgentContext {
+        messages: vec![],
+        tools: vec![Box::new(SilentTool)],
+        system_prompt: String::new(),
+    };
+    let mut config = make_config(MockProvider::new(responses));
+    config.execution_limits = Some(limits);
+    agent_loop(
+        vec![AgentMessage::Llm(Message::user("go"))],
+        &mut context,
+        &config,
+        tx,
+        CancellationToken::new(),
+    )
+    .await;
+    (collect_events(rx), context.messages)
+}
+
+/// Every `tool_use` an assistant emits must be answered by `tool_result`s
+/// before any other message intervenes.
+///
+/// `src/context.rs` calls an unanswered call "an orphan every provider
+/// rejects", and `llm_compaction.rs` has a dedicated test for it on the
+/// compaction path. This is the same invariant on the loop path.
+fn assert_tool_calls_are_answered(messages: &[AgentMessage], context: &str) {
+    let mut pending: Vec<String> = Vec::new();
+    for (i, m) in messages.iter().enumerate() {
+        let AgentMessage::Llm(msg) = m else { continue };
+        match msg {
+            Message::Assistant { content, .. } => {
+                assert!(
+                    pending.is_empty(),
+                    "{context}: assistant at [{i}] while {pending:?} are still unanswered"
+                );
+                pending = content
+                    .iter()
+                    .filter_map(|c| match c {
+                        Content::ToolCall { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::ToolResult { tool_call_id, .. } => {
+                let at = pending.iter().position(|p| p == tool_call_id);
+                assert!(
+                    at.is_some(),
+                    "{context}: tool_result at [{i}] for {tool_call_id:?} answers no open call"
+                );
+                pending.remove(at.unwrap());
+            }
+            Message::User { .. } => {
+                assert!(
+                    pending.is_empty(),
+                    "{context}: a user message at [{i}] lands between an assistant's tool_use \
+                     and its tool_result — {pending:?} still unanswered. Every provider rejects \
+                     this: Anthropic wants tool_result blocks first in the next message, OpenAI \
+                     wants tool messages for each tool_call_id"
+                );
+            }
+        }
+    }
+    assert!(
+        pending.is_empty(),
+        "{context}: run ended with {pending:?} unanswered — the agent is unusable for any \
+         later prompt, because the orphan stays in its history"
+    );
+}
+
 async fn run_with_limits(
     responses: Vec<MockResponse>,
     limits: yoagent::context::ExecutionLimits,
@@ -3367,6 +3446,107 @@ async fn run_with_limits(
     collect_events(rx)
 }
 
+/// The steer nudge must not orphan the tool calls it interrupts.
+///
+/// Regression: the nudge was pushed into the transcript the moment the verdict
+/// came back, which is *before* the tools run. The next provider request then
+/// carried `assistant(tool_use) -> user(text) -> user(tool_result)` and 400'd,
+/// with an error naming tool_result blocks rather than loop detection.
+#[tokio::test]
+async fn a_steer_nudge_does_not_orphan_the_tool_calls_it_interrupts() {
+    let (_events, messages) = run_with_limits_msgs(
+        repeat_call(6, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+    )
+    .await;
+    assert_tool_calls_are_answered(&messages, "steer");
+}
+
+/// An abort must answer the outstanding calls before it stops.
+///
+/// Worse than a failed turn: `Agent::prompt` keeps these messages, so an
+/// orphaned `tool_use` poisons the agent and *every later* prompt fails too.
+#[tokio::test]
+async fn an_abort_answers_its_outstanding_tool_calls_before_stopping() {
+    let (events, messages) = run_with_limits_msgs(
+        repeat_call(12, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+    )
+    .await;
+    assert!(
+        loop_events(&events).iter().any(|(_, _, a)| *a),
+        "this fixture must reach an abort or the test proves nothing"
+    );
+    assert_tool_calls_are_answered(&messages, "abort");
+}
+
+/// An abort stops the run. Halting *is* the feature — the other limits all
+/// fire eventually, but only after burning the whole budget.
+#[tokio::test]
+async fn an_abort_actually_halts_the_run() {
+    let (events, _messages) = run_with_limits_msgs(
+        repeat_call(40, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+    )
+    .await;
+    let turns = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::TurnStart))
+        .count();
+    assert!(
+        turns < 40,
+        "the run consumed all 40 turns despite aborting — it did not stop, got {turns}"
+    );
+}
+
+/// Loop detection is on by default. Nothing else pins the shipped default, so
+/// flipping it to `None` disabled the whole feature with a green suite.
+#[test]
+fn loop_detection_is_enabled_by_default() {
+    assert_eq!(
+        yoagent::context::ExecutionLimits::default().max_identical_tool_calls,
+        Some(3),
+        "loop detection must ship on; a change here turns it off for everyone who \
+         never sets the field"
+    );
+}
+
+/// The messages the model reads must not carry accidental whitespace.
+///
+/// Regression: the literals were wrapped across source lines without `\`
+/// continuations, baking ~40 spaces mid-sentence into the model's context.
+/// `rustfmt` does not touch literal contents and clippy has no lint for it.
+#[tokio::test]
+async fn loop_detection_messages_are_clean_prose() {
+    let (_events, messages) = run_with_limits_msgs(
+        repeat_call(12, serde_json::json!({"q": "same"})),
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+    )
+    .await;
+    let injected: Vec<String> = messages
+        .iter()
+        .filter_map(|m| match m {
+            AgentMessage::Llm(Message::User { content, .. }) => {
+                content.iter().find_map(|c| match c {
+                    Content::Text { text } if text.starts_with('[') => Some(text.clone()),
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !injected.is_empty(),
+        "expected loop-detection messages in the transcript"
+    );
+    for text in &injected {
+        assert!(
+            !text.contains("  "),
+            "loop-detection text reaches the model with a run of spaces: {text:?}"
+        );
+    }
+}
+
 /// Three identical calls steer; continued repetition aborts. The steer comes
 /// first on purpose — a model repeating a call is often retrying something
 /// transient, and aborting immediately would regress that.
@@ -3374,10 +3554,7 @@ async fn run_with_limits(
 async fn repeated_identical_calls_steer_then_abort() {
     let events = run_with_limits(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits {
-            max_identical_tool_calls: Some(3),
-            ..Default::default()
-        },
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
     )
     .await;
 
@@ -3417,10 +3594,7 @@ async fn distinct_arguments_never_trip() {
 
     let events = run_with_limits(
         responses,
-        yoagent::context::ExecutionLimits {
-            max_identical_tool_calls: Some(3),
-            ..Default::default()
-        },
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
     )
     .await;
     assert!(
@@ -3448,10 +3622,7 @@ async fn an_interleaved_different_call_resets_the_counter() {
 
     let events = run_with_limits(
         responses,
-        yoagent::context::ExecutionLimits {
-            max_identical_tool_calls: Some(3),
-            ..Default::default()
-        },
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
     )
     .await;
     assert!(
@@ -3465,10 +3636,7 @@ async fn an_interleaved_different_call_resets_the_counter() {
 async fn detection_can_be_switched_off() {
     let events = run_with_limits(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits {
-            max_identical_tool_calls: None,
-            ..Default::default()
-        },
+        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(None),
     )
     .await;
     assert!(

--- a/tests/price_audit.rs
+++ b/tests/price_audit.rs
@@ -422,6 +422,20 @@ async fn hardcoded_prices_have_not_drifted() {
     // The load-bearing assertion. Without it, every schema change at or above
     // the `cost` level yields drift.is_empty() == true and a green pass having
     // verified nothing.
+    // `expected` below is derived from `all`, so it cannot notice `all` itself
+    // shrinking — an empty `presets()` produced "0 compared, 0 drifted" and a
+    // green pass. Pin the floor against something independent: the number of
+    // priced constructors in `src/provider/model.rs`. Raise it when you add
+    // one, which is the moment you should also be adding it here.
+    const PRICED_PRESETS: usize = 7;
+    assert!(
+        all.len() >= PRICED_PRESETS,
+        "\n\nThe audit is checking {} presets but the crate ships at least {PRICED_PRESETS}. \
+         A priced preset is unaudited — its rates can drift for as many releases as it takes \
+         someone to notice, which for `claude_sonnet_5` was 18.\n",
+        all.len()
+    );
+
     let expected = all.len() * 4;
     assert_eq!(
         compared + absent,
@@ -460,13 +474,13 @@ fn is_configured_means_any_rate_set() {
         "all-zero rates mean pricing is unknown, not that the model is free"
     );
 
-    let no_cache_write = CostConfig::new(5.0, 30.0, 0.5, 0.0);
+    let no_cache_write = CostConfig::new(5.0, 30.0).with_cache_read(0.5);
     assert!(
         no_cache_write.is_configured(),
         "a provider that charges nothing for cache writes is priced, not unknown"
     );
 
-    let only_one_field = CostConfig::new(0.0, 0.0, 0.1, 0.0);
+    let only_one_field = CostConfig::new(0.0, 0.0).with_cache_read(0.1);
     assert!(
         only_one_field.is_configured(),
         "any single rate is enough to count as priced"
@@ -492,8 +506,9 @@ fn cost_usd_applies_the_context_tier_by_prompt_size() {
     use yoagent::provider::{ContextTier, CostConfig};
     use yoagent::types::Usage;
 
-    let cfg = CostConfig::new(5.0, 30.0, 0.5, 0.0)
-        .with_context_tier(ContextTier::new(272_000, 10.0, 45.0, 1.0));
+    let cfg = CostConfig::new(5.0, 30.0)
+        .with_cache_read(0.5)
+        .with_context_tier(ContextTier::new(272_000, 10.0, 45.0).with_cache_read(1.0));
 
     let usage = |input: u64, output: u64| Usage {
         input,

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -165,12 +165,10 @@ fn test_full_conversation_roundtrip() {
 #[test]
 fn test_execution_limits_roundtrip() {
     use yoagent::context::ExecutionLimits;
-    let limits = ExecutionLimits {
-        max_turns: 25,
-        max_total_tokens: 500_000,
-        max_duration: std::time::Duration::from_secs(300),
-        ..Default::default()
-    };
+    let limits = ExecutionLimits::default()
+        .with_max_turns(25)
+        .with_max_total_tokens(500_000)
+        .with_max_duration(std::time::Duration::from_secs(300));
     let json = serde_json::to_string(&limits).expect("serialize");
     let back: ExecutionLimits = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(limits.max_turns, back.max_turns);


### PR DESCRIPTION
Blocks the 0.18.0 release. Five review agents audited `v0.17.0..main` as a whole; each of the eight commits had already been reviewed alone. **Every critical finding is an interaction between commits that no single-PR review could have seen.**

## Critical

**1. Loop detection corrupted the transcript.** The nudge and the abort message were pushed the moment the verdict came back — *before* the tools run — so the next request carried `assistant(tool_use)` → `user(text)` → `user(tool_result)`. Every provider rejects that; Anthropic's 400 names tool_result blocks, so the error points nowhere near loop detection.

The abort was worse: it returned with the calls unanswered, and `Agent::prompt` keeps those messages — so a loop-aborted agent was **poisoned, and every later prompt failed too**. On by default (`Some(3)`), and reachable from a single parallel batch, not three turns.

The crate treats this invariant as sacred everywhere else — `context.rs` calls an unanswered call *"an orphan every provider rejects"*, and `llm_compaction.rs` has a dedicated test. Loop detection was the one path that broke it, and nothing caught it because `MockProvider` ignores message shape and every loop test asserted only on events.

**2. Stash retrieval was re-truncated by the cap it exists to escape.** The marker says `shared_state get "tool-out-…"`; the returned text came back through the same append-path cap that stashed it. 2000 lines in, 200 out, plus a fresh stash entry on every attempt. The release's headline feature did not work through the path the model takes — only from Rust, which is exactly what the test asserted (`scoped.get(key)`), one hop short.

**3. `is_configured()` ignored `context_tier`** → a config priced only above its threshold reported "pricing unknown" and billed everything at $0.

**4. GASP recorded a loop abort as `"completed"`** — `LoopDetected` fell into `_ => {}`, the same silent-coverage hole #143 closed in `types.rs`. The CHANGELOG claimed the opposite.

**5. `Agent::with_shared_state` shipped undocumented** — doc block ran into `take_tools`'s, landing on a private fn. The headline API would have rendered blank on docs.rs. Same defect class the CHANGELOG boasts about fixing this release.

## Breaking changes (free now, a release later)

- **`context_tier: Option<ContextTier>` → `context_tiers: Vec<ContextTier>`**, kept sorted. models.dev models tiers as an array and *this release's own audit* reads `/tiers/0/`. Leaving it would have broken the field type **and** the serde key, invalidating persisted configs.
- **`CostConfig::new` / `ContextTier::new` take two rates**; cache rates move to `with_cache_read`/`with_cache_write`. Four same-typed `f64`s is a transposition hazard, no vendor publishes them in one order, and a transposed config still passes `is_configured` — which is how `claude_sonnet_5` billed 50% high for 18 releases. This repo had already made the mistake, in a *cost-measurement harness*. Also made `ContextTier::cache_write_per_million` reachable; it was dead.
- **`ExecutionLimits` is `#[non_exhaustive]`** with builders. Records `ExecutionTracker` losing struct-literal construction — an undeclared **fourth** breaking change in this release.

## Tests

Five new, each mutation-verified:

| mutation | result |
|---|---|
| revert the steer fix | `a user message at [6] lands between an assistant's tool_use and its tool_result` |
| delete the abort's `return` | **compile error** — `agent_msg` moved into `TurnEnd` |
| default → `None` | `loop detection must ship on` |
| re-mangle the nudge text | `reaches the model with a run of spaces` |
| empty `presets()` | `checking 0 presets but the crate ships at least 7` |

That last one closes a vacuous pass in the file gating every shipped price: its guard derived the expected count from the same list it was checking.

## CHANGELOG corrections

The #143 title I wrote — *"the wire freeze now catches a new variant"* — was itself an overclaim, in the entry about a guard that overclaimed. `git show e840613^` confirms zero wildcard arms, so it **already** caught new variants; what was missing was a forced *sample*. Retitled. Also softened "deliberately populated" (several samples use `false`, the `bool` default) and an "unlike its siblings" that isn't true of `Message`/`Usage`.

## Deferred

#144 (MemoryBackend never evicts), #145 (loop-detection test gaps, alternating-call blind spot), #146 (shared-state error paths).

## Verification

`cargo test --all-features`: **603 passed, 0 failed**. Clippy clean under `-Dwarnings`. Live price audit: 26 compared, **0 drifted**. `cargo package` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)