### PR TITLE
fix: the three deferred release-gate issues (#144, #145, #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,71 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Stash eviction protects caller-owned keys; the default backend no longer
+  wedges** ([#144](https://github.com/yologdev/yoagent/issues/144)).
+
+  `MemoryBackend` — what `SharedState::new()` returns, and the documented path
+  for `Agent::with_shared_state` — rejected rather than evicted, and nothing
+  ever removed `tool-out-*`. At ~300KB per stashed build or grep output a 10MB
+  cap holds ~33 results, after which **every** write failed for the rest of the
+  run, including the model's own `shared_state set`, with the bytes never
+  reclaimed. It now evicts stashed output, oldest first.
+
+  `FileBackend` had the opposite bug: it evicted whatever was oldest, including
+  keys a caller had set through the backend's own API. A parent that stored a
+  `plan` got `None` back later with no error path anywhere.
+
+  Both now draw the same line. **Stash entries are evictable; caller keys are
+  not.** Losing a stash entry degrades a marker to an ordinary "key not found"
+  the agent can act on, and the head+tail is still in the transcript — nothing
+  regenerates a caller's artifact. When only caller keys remain, the write
+  reports capacity instead of destroying data. Every eviction now logs; a
+  successful one was previously silent, which mattered because the
+  verify-after-store loop only checks the keys written for the current result
+  and cannot see that this write evicted an earlier one.
+
+  The line is drawn scope-aware: a sub-agent's stash lands as
+  `scope\u{1f}tool-out-…`, so a whole-key prefix test would read it as
+  caller-owned and never evict it — re-creating the wedge for every delegating
+  run and starving the parent's keys instead.
+
+- **A looping sub-agent no longer reports success to its parent**
+  ([#146](https://github.com/yologdev/yoagent/issues/146)). `extract_error`
+  matched only `StopReason::Error`, but a loop abort leaves `ToolUse` on the
+  last assistant message, and `extract_final_text` scans assistant messages
+  only — so it never saw the trailing `[Agent stopped: …]` and fell through to
+  `"(sub-agent produced no text output)"`. The parent received
+  `is_error: false`. A sub-agent that burned its entire budget looping was
+  indistinguishable from one that had nothing to say.
+
+  The marker prefix is now a public constant, `agent_loop::AGENT_STOPPED_PREFIX`,
+  so recognising a self-stopped run does not mean matching a magic string.
+
+  Also: `FileBackend::set` returned `Err` for a value already written to disk —
+  `evict_to_fit` propagates `read_dir`/`next_entry` errors, both of which run
+  *after* the write, and the loop's error arm never records the key so rollback
+  could not reach it. It now unlinks before propagating. And a failed rollback
+  is logged rather than discarded.
+
+- **Loop detection: accurate name, bounded state, and the coverage it lacked**
+  ([#145](https://github.com/yologdev/yoagent/issues/145)).
+  `max_identical_tool_calls` is now `max_consecutive_identical_tool_calls`. The
+  implementation caps consecutive-run length only, so an alternating
+  `[a, b, a, b, …]` loop is never detected; the doc was honest about that, the
+  name was not, and a public field is far cheaper to rename before release.
+
+  Deliberately **not** widened to a windowed count — that would regress
+  `an_interleaved_different_call_resets_the_counter`, which pins a considered
+  trade-off: an agent working through a list calls one tool repeatedly and
+  legitimately, and a detector firing on interleaved repeats would be worse than
+  none. The limitation is documented on the field and pinned by a test, so it is
+  a decision rather than a surprise.
+
+  `steered` held a full clone of every steered signature's arguments — for a
+  file-write tool, the entire file body — unbounded, inside the one type whose
+  job is bounding runaway resource use. Now a capped list of FNV hashes, sharing
+  the one `fnv1a` that `tool_output_key` had inlined.
+
 - **Release-gate fixes found by a whole-release review** (pre-0.18.0). Eight
   commits were each reviewed alone; reviewing them together found defects in
   the interactions no single-PR review could see.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,7 +287,7 @@ adheres to [Semantic Versioning](https://semver.org/).
   eventually, but only after burning the full turn, token and wall-clock budget,
   so the run costs its maximum to discover it achieved nothing.
 
-  `max_identical_tool_calls: Option<usize>`, default `Some(3)`, `None` to
+  `max_consecutive_identical_tool_calls: Option<usize>`, default `Some(3)`, `None` to
   disable. Two escalations, mirroring the house pattern of steering before
   aborting:
 
@@ -310,7 +310,7 @@ adheres to [Semantic Versioning](https://semver.org/).
   The check runs **before** tool execution, so a stuck model does not also pay
   for the tool run it was never going to learn from.
 
-- **Breaking: `ExecutionLimits` gained `max_identical_tool_calls`.** The struct
+- **Breaking: `ExecutionLimits` gained `max_consecutive_identical_tool_calls`.** The struct
   is not `#[non_exhaustive]`, so downstream struct-literal construction needs
   the new field or `..Default::default()`. Behaviour changes only for
   pathological sessions, but it *is* on by default.

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -123,6 +123,24 @@ fn default_convert_to_llm(messages: &[AgentMessage]) -> Vec<Message> {
 }
 
 /// Start an agent loop with new prompt messages.
+/// Prefix of the message the loop appends when it stops a run itself.
+///
+/// A run stopped by a limit or by loop detection ends with a `Message::User`
+/// carrying this prefix. The last *assistant* message still reports whatever
+/// stop reason it had — `ToolUse` for a loop abort — so a consumer inspecting
+/// only assistant messages cannot tell a stopped run from a finished one.
+/// `SubAgentTool` uses this to avoid reporting an aborted delegation as a
+/// bland success.
+pub const AGENT_STOPPED_PREFIX: &str = "[Agent stopped:";
+
+/// The stop marker for a run halted by loop detection specifically.
+///
+/// Distinct from the limit stops because the two mean opposite things to a
+/// caller. Hitting `max_turns` is a bound: the work was cut short but what it
+/// produced is real, and `SubAgentTool` returns it. A loop abort is a failure:
+/// the model was emitting the same call forever and there is nothing to keep.
+pub const LOOP_ABORT_PREFIX: &str = "[Agent stopped: repeated tool call —";
+
 pub async fn agent_loop(
     prompts: Vec<AgentMessage>,
     context: &mut AgentContext,
@@ -351,7 +369,7 @@ async fn run_loop(
                     warn!("Execution limit reached: {}", reason);
                     let limit_msg = AgentMessage::Llm(Message::User {
                         content: vec![Content::Text {
-                            text: format!("[Agent stopped: {}]", reason),
+                            text: format!("{AGENT_STOPPED_PREFIX} {}]", reason),
                         }],
                         timestamp: now_ms(),
                     });
@@ -638,7 +656,8 @@ async fn run_loop(
                             let stop = AgentMessage::Llm(Message::User {
                                 content: vec![Content::Text {
                                     text: format!(
-                                        "[Agent stopped: {tool_name} was called repeatedly with identical arguments after being asked to change approach.]"
+                                        "{LOOP_ABORT_PREFIX} {tool_name} was called repeatedly with identical \
+                                         arguments after being asked to change approach.]"
                                     ),
                                 }],
                                 timestamp: now_ms(),
@@ -831,7 +850,14 @@ async fn run_loop(
                                 // artifacts to make room for debris.
                                 if !all_stored {
                                     for key in &written {
-                                        sink.remove(key).await;
+                                        if !sink.remove(key).await {
+                                            // `remove` already swallowed any backend error into
+                                            // `false` + a warn. Surfacing it here too matters
+                                            // because a failed rollback leaves a stashed value
+                                            // no marker names, consuming cap quota for the rest
+                                            // of the run.
+                                            warn!("shared state: rollback could not remove {key}");
+                                        }
                                     }
                                 }
                                 if all_stored {

--- a/src/context.rs
+++ b/src/context.rs
@@ -500,15 +500,22 @@ pub const TOOL_OUTPUT_KEY_PREFIX: &str = "tool-out-";
 /// Hashing the content keeps the key deterministic on replay while making a
 /// collision mean the contents were identical anyway.
 pub fn tool_output_key(tool_call_id: &str, full_output: &str) -> String {
-    // FNV-1a, for the same reason the GASP recorder uses it: `DefaultHasher`
-    // is documented as unstable across releases, and a key that moves between
-    // compiler versions silently stops resolving.
+    format!(
+        "{TOOL_OUTPUT_KEY_PREFIX}{tool_call_id}-{:016x}",
+        fnv1a(full_output.as_bytes())
+    )
+}
+
+/// FNV-1a, for the same reason the GASP recorder uses it: `DefaultHasher` is
+/// documented as unstable across Rust releases, and a key that moves between
+/// compiler versions silently stops resolving.
+fn fnv1a(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in full_output.as_bytes() {
+    for byte in bytes {
         hash ^= u64::from(*byte);
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    format!("{TOOL_OUTPUT_KEY_PREFIX}{tool_call_id}-{hash:016x}")
+    hash
 }
 
 /// The stash key for one content block of a tool result.
@@ -951,8 +958,19 @@ pub struct ExecutionLimits {
     /// but only after burning the full turn, token and wall-clock budget — so
     /// the run costs its maximum to discover it achieved nothing.
     ///
-    /// `None` disables the check. Default `Some(3)`.
-    pub max_identical_tool_calls: Option<usize>,
+    /// **Consecutive**, and that word is load-bearing. A different signature
+    /// resets the streak, so a model alternating `[a, b, a, b, …]` forever is
+    /// *not* detected. That is a deliberate trade, not an oversight: an agent
+    /// working through a list calls one tool repeatedly and legitimately, and
+    /// a detector that fired on interleaved repeats would be worse than none.
+    /// See `an_interleaved_different_call_resets_the_counter`. Widening this
+    /// to a windowed count is tracked separately.
+    ///
+    /// `None` disables the check. `Some(0)` also disables it — there is no
+    /// streak length below which a call has not been made. `Some(1)` steers on
+    /// the very first tool call of a run, which is almost never wanted.
+    /// Default `Some(3)`.
+    pub max_consecutive_identical_tool_calls: Option<usize>,
 }
 
 impl Default for ExecutionLimits {
@@ -961,7 +979,7 @@ impl Default for ExecutionLimits {
             max_turns: 50,
             max_total_tokens: 1_000_000,
             max_duration: std::time::Duration::from_secs(600),
-            max_identical_tool_calls: Some(3),
+            max_consecutive_identical_tool_calls: Some(3),
         }
     }
 }
@@ -987,10 +1005,25 @@ impl ExecutionLimits {
 
     /// Consecutive identical tool calls tolerated before steering, then
     /// stopping. `None` disables loop detection entirely.
-    pub fn with_max_identical_tool_calls(mut self, calls: Option<usize>) -> Self {
-        self.max_identical_tool_calls = calls;
+    pub fn with_max_consecutive_identical_tool_calls(mut self, calls: Option<usize>) -> Self {
+        self.max_consecutive_identical_tool_calls = calls;
         self
     }
+}
+
+/// How many steered signatures to remember before dropping the oldest.
+const MAX_STEERED_SIGNATURES: usize = 32;
+
+/// Stable hash of a tool call's identity, for the steered-signature set.
+///
+/// Hashes the serialized `Value`, but only after `serde_json` has normalised
+/// it — `to_string` on a `Value` emits object keys in the map's own order, so
+/// two calls differing only in key order hash the same, matching how
+/// `last_signature` compares `Value`s rather than text.
+fn signature_hash(name: &str, args: &serde_json::Value) -> u64 {
+    let mut h = fnv1a(name.as_bytes());
+    h ^= fnv1a(args.to_string().as_bytes());
+    h
 }
 
 /// What the loop should do about a repeated tool call.
@@ -1037,10 +1070,23 @@ pub struct ExecutionTracker {
     /// same call, and string comparison would miss the loop.
     last_signature: Option<(String, serde_json::Value)>,
     consecutive: usize,
-    /// Signatures already steered about. A second trip on one of these aborts
+    /// Hashes of signatures already steered about, capped. A second trip on one
+    /// of these aborts.
+    ///
+    /// Hashes rather than the signatures themselves, and bounded rather than
+    /// unbounded: this held a full clone of every steered call's arguments —
+    /// for a file-write tool, the entire file body — inside the one type whose
+    /// job is bounding runaway resource use. FNV for the same reason
+    /// [`fnv1a`] is used elsewhere here: `DefaultHasher` is documented as
+    /// unstable across Rust releases.
+    ///
+    /// A collision would abort a run one escalation early. At 64 bits, across
+    /// the handful of distinct signatures a single run steers about, that is
+    /// far less likely than the memory blowup it replaces.
+    ///
     /// rather than steering again, so a model that ignores the nudge does not
     /// loop forever between nudges.
-    steered: Vec<(String, serde_json::Value)>,
+    steered: Vec<u64>,
 }
 
 impl ExecutionTracker {
@@ -1062,7 +1108,7 @@ impl ExecutionTracker {
     /// defaults to `Parallel`, so a model can emit the same call three times in
     /// one message and never take a second turn.
     pub fn record_tool_calls(&mut self, calls: &[(String, serde_json::Value)]) -> LoopVerdict {
-        let Some(threshold) = self.limits.max_identical_tool_calls else {
+        let Some(threshold) = self.limits.max_consecutive_identical_tool_calls else {
             return LoopVerdict::Continue;
         };
         if threshold == 0 {
@@ -1090,13 +1136,20 @@ impl ExecutionTracker {
             // assessed; the most severe verdict wins via the fold below.
             if self.consecutive >= threshold {
                 let repetitions = self.consecutive;
-                let this_call = if self.steered.contains(&sig) {
+                let sig_hash = signature_hash(name, args);
+                let this_call = if self.steered.contains(&sig_hash) {
                     LoopVerdict::Abort {
                         tool_name: name.clone(),
                         repetitions,
                     }
                 } else {
-                    self.steered.push(sig);
+                    // Bounded: a run that steers about many distinct
+                    // signatures is already pathological, and the oldest
+                    // entries are the least likely to recur.
+                    if self.steered.len() >= MAX_STEERED_SIGNATURES {
+                        self.steered.remove(0);
+                    }
+                    self.steered.push(sig_hash);
                     // Reset so the abort needs another full run of repeats,
                     // rather than firing on the very next call.
                     self.consecutive = 0;

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -111,7 +111,10 @@ pub trait SharedStateBackend: Send + Sync {
 
 /// In-memory backend backed by `HashMap` with a byte capacity limit.
 pub struct MemoryBackend {
-    inner: RwLock<HashMap<String, String>>,
+    /// Value plus the sequence number it was written at, so eviction has a
+    /// definition of "oldest" — a `HashMap` has no insertion order.
+    inner: RwLock<HashMap<String, (u64, String)>>,
+    next_seq: std::sync::atomic::AtomicU64,
     max_bytes: usize,
 }
 
@@ -125,6 +128,7 @@ impl MemoryBackend {
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(HashMap::new()),
+            next_seq: std::sync::atomic::AtomicU64::new(0),
             max_bytes: DEFAULT_MAX_BYTES,
         }
     }
@@ -132,6 +136,7 @@ impl MemoryBackend {
     pub fn with_max_bytes(max_bytes: usize) -> Self {
         Self {
             inner: RwLock::new(HashMap::new()),
+            next_seq: std::sync::atomic::AtomicU64::new(0),
             max_bytes,
         }
     }
@@ -140,21 +145,49 @@ impl MemoryBackend {
 #[async_trait::async_trait]
 impl SharedStateBackend for MemoryBackend {
     async fn get(&self, key: &str) -> Result<Option<String>, SharedStateError> {
-        Ok(self.inner.read().await.get(key).cloned())
+        Ok(self.inner.read().await.get(key).map(|(_, v)| v.clone()))
     }
 
     async fn set(&self, key: &str, value: String) -> Result<(), SharedStateError> {
         let mut map = self.inner.write().await;
 
         // Calculate current total excluding the old value for this key.
-        let current: usize = map
+        let mut current: usize = map
             .iter()
             .filter(|(k, _)| k.as_str() != key)
-            .map(|(k, v)| k.len() + v.len())
+            .map(|(k, (_, v))| k.len() + v.len())
             .sum();
         let new_entry = key.len() + value.len();
 
+        // Evict stashed tool output, oldest first, to make room. Without this
+        // the default backend wedged permanently: at ~300KB per stashed build
+        // or grep output a 10MB cap holds ~33 results, after which *every*
+        // write failed for the rest of the run — including the model's own
+        // `shared_state set` — with no way to recover and the bytes never
+        // reclaimed.
         if current + new_entry > self.max_bytes {
+            let mut evictable: Vec<(u64, String, usize)> = map
+                .iter()
+                .filter(|(k, _)| k.as_str() != key && is_stash_key(k))
+                .map(|(k, (seq, v))| (*seq, k.clone(), k.len() + v.len()))
+                .collect();
+            evictable.sort_by_key(|(seq, _, _)| *seq);
+
+            for (_, victim, size) in evictable {
+                if current + new_entry <= self.max_bytes {
+                    break;
+                }
+                map.remove(&victim);
+                current = current.saturating_sub(size);
+                // Never silent: a marker in the transcript may still name this
+                // key, and the agent will get "not found" when it follows it.
+                warn!("shared state: evicted {victim} to make room for {key}");
+            }
+        }
+
+        if current + new_entry > self.max_bytes {
+            // Only caller-owned keys remain. Refuse rather than destroy data
+            // nothing can regenerate.
             return Err(CapacityError {
                 key: key.to_string(),
                 value_bytes: value.len(),
@@ -164,7 +197,10 @@ impl SharedStateBackend for MemoryBackend {
             .into());
         }
 
-        map.insert(key.to_string(), value);
+        let seq = self
+            .next_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        map.insert(key.to_string(), (seq, value));
         Ok(())
     }
 
@@ -182,7 +218,7 @@ impl SharedStateBackend for MemoryBackend {
     async fn summary(&self) -> Result<String, SharedStateError> {
         let map = self.inner.read().await;
         Ok(format_summary(
-            map.iter().map(|(k, v)| (k.as_str(), v.len())),
+            map.iter().map(|(k, (_, v))| (k.as_str(), v.len())),
         ))
     }
 }
@@ -272,7 +308,13 @@ impl FileBackend {
         }
 
         entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-        for (_, name, path, len) in entries {
+        // Only stashed tool output is evictable. This directory previously
+        // evicted whatever was oldest, including keys a caller had set through
+        // this very backend — a parent that stored a `plan` got `None` back
+        // later with no error path anywhere. The total still counts every file,
+        // so caller keys constrain the budget without being destroyed by it;
+        // when only they remain the write reports capacity instead.
+        for (_, name, path, len) in entries.into_iter().filter(|(_, n, _, _)| is_stash_key(n)) {
             if total as usize <= self.max_bytes {
                 break;
             }
@@ -281,7 +323,17 @@ impl FileBackend {
                 continue;
             }
             match tokio::fs::remove_file(&path).await {
-                Ok(()) => total = total.saturating_sub(len),
+                Ok(()) => {
+                    total = total.saturating_sub(len);
+                    // Never silent: a marker frozen in the transcript may still
+                    // name this key, and the verify-after-store loop only
+                    // checks keys written for the current result — it cannot
+                    // see that this write just evicted an earlier one.
+                    warn!(
+                        "shared state: evicted {} to stay under the cap",
+                        path.display()
+                    );
+                }
                 // A failed unlink must not fail the write that triggered
                 // eviction — the cap is a bound, not a guarantee — but it must
                 // not be silent either, or the directory grows without bound
@@ -369,7 +421,18 @@ impl SharedStateBackend for FileBackend {
         tokio::fs::write(&path, &value).await?;
         // Eviction runs after the write and skips this key, so the value that
         // triggered it is never the one removed.
-        self.evict_to_fit(Some(key)).await?;
+        //
+        // Unlink on failure. `evict_to_fit` propagates errors from `read_dir`
+        // and `next_entry`, both of which run *after* the write — so a failure
+        // returned `Err` for a value already on disk. The loop's error arm
+        // never records the key, so rollback could not reach it: orphan bytes,
+        // referenced by no marker, consuming cap quota forever and going on to
+        // evict other keys. The exact inverse of the case handled above.
+        if let Err(e) = self.evict_to_fit(Some(key)).await {
+            let _ = tokio::fs::remove_file(&path).await;
+            warn!("shared state: eviction failed after writing {key}; write rolled back: {e}");
+            return Err(e);
+        }
         Ok(())
     }
 
@@ -430,6 +493,24 @@ impl SharedStateBackend for FileBackend {
 /// Separator between a scope name and a key. Non-printable, so it cannot
 /// collide with a key a caller would plausibly choose.
 const SCOPE_SEP: char = '\u{1f}';
+
+/// Whether a key holds machine-generated stashed tool output.
+///
+/// The eviction line. Stash entries are *recyclable*: losing one degrades the
+/// marker to an ordinary "key not found" tool result the agent can act on, and
+/// the content is still in the transcript's head+tail. A caller-owned key is
+/// not recyclable — nothing regenerates a parent's `plan` — so it is never
+/// evicted, and a store that is full of caller keys reports capacity rather
+/// than silently destroying them.
+///
+/// Scope-aware: a scoped write lands as `scope\u{1f}tool-out-…`, so a
+/// whole-key prefix test would miss it and treat it as caller-owned.
+fn is_stash_key(key: &str) -> bool {
+    key.rsplit(SCOPE_SEP)
+        .next()
+        .unwrap_or(key)
+        .starts_with(crate::context::TOOL_OUTPUT_KEY_PREFIX)
+}
 
 /// A shared string key-value store for sub-agent communication.
 ///

--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -543,6 +543,24 @@ impl AgentTool for SubAgentTool {
 
 /// Check if the last assistant message was an error, return the error message.
 fn extract_error(messages: &[AgentMessage]) -> Option<String> {
+    // A loop abort ends with a marker user message while the last *assistant*
+    // message still carries `ToolUse`, so the scan below returned `None` and
+    // the delegation reported as a clean success with "(sub-agent produced no
+    // text output)". A sub-agent that burned its entire budget looping looked
+    // like one that simply had nothing to say.
+    //
+    // Only loop aborts. Hitting `max_turns` is a bound, not a failure — the
+    // work was cut short but what it produced is real, so it is returned, with
+    // the stop notice appended by `extract_final_text` so the parent's model
+    // knows the answer is partial.
+    if let Some(AgentMessage::Llm(Message::User { content, .. })) = messages.last() {
+        if let Some(Content::Text { text }) = content.first() {
+            if text.starts_with(crate::agent_loop::LOOP_ABORT_PREFIX) {
+                return Some(text.clone());
+            }
+        }
+    }
+
     for msg in messages.iter().rev() {
         if let AgentMessage::Llm(Message::Assistant {
             stop_reason,
@@ -564,7 +582,20 @@ fn extract_error(messages: &[AgentMessage]) -> Option<String> {
 
 /// Extract the final assistant text from agent messages.
 /// Collects text from the last assistant message, or returns a fallback.
+/// The loop's own stop marker, if the run ended on one.
+fn stopped_notice(messages: &[AgentMessage]) -> Option<String> {
+    if let Some(AgentMessage::Llm(Message::User { content, .. })) = messages.last() {
+        if let Some(Content::Text { text }) = content.first() {
+            if text.starts_with(crate::agent_loop::AGENT_STOPPED_PREFIX) {
+                return Some(text.clone());
+            }
+        }
+    }
+    None
+}
+
 fn extract_final_text(messages: &[AgentMessage]) -> String {
+    let mut out = None;
     for msg in messages.iter().rev() {
         if let AgentMessage::Llm(Message::Assistant { content, .. }) = msg {
             let texts: Vec<&str> = content
@@ -575,9 +606,20 @@ fn extract_final_text(messages: &[AgentMessage]) -> String {
                 })
                 .collect();
             if !texts.is_empty() {
-                return texts.join("\n");
+                out = Some(texts.join("\n"));
+                break;
             }
         }
     }
-    "(sub-agent produced no text output)".to_string()
+
+    // Tell the parent the answer is partial, whether or not there was text to
+    // return. A turn-limited run whose last assistant message held only tool
+    // calls has no text at all, and reporting that as "produced no text output"
+    // reads as an empty success rather than a run cut short.
+    match (out, stopped_notice(messages)) {
+        (Some(text), Some(stop)) => format!("{text}\n\n{stop}"),
+        (Some(text), None) => text,
+        (None, Some(stop)) => stop,
+        (None, None) => "(sub-agent produced no text output)".to_string(),
+    }
 }

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -3456,7 +3456,8 @@ async fn run_with_limits(
 async fn a_steer_nudge_does_not_orphan_the_tool_calls_it_interrupts() {
     let (_events, messages) = run_with_limits_msgs(
         repeat_call(6, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     assert_tool_calls_are_answered(&messages, "steer");
@@ -3470,7 +3471,8 @@ async fn a_steer_nudge_does_not_orphan_the_tool_calls_it_interrupts() {
 async fn an_abort_answers_its_outstanding_tool_calls_before_stopping() {
     let (events, messages) = run_with_limits_msgs(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     assert!(
@@ -3486,7 +3488,8 @@ async fn an_abort_answers_its_outstanding_tool_calls_before_stopping() {
 async fn an_abort_actually_halts_the_run() {
     let (events, _messages) = run_with_limits_msgs(
         repeat_call(40, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     let turns = events
@@ -3504,7 +3507,7 @@ async fn an_abort_actually_halts_the_run() {
 #[test]
 fn loop_detection_is_enabled_by_default() {
     assert_eq!(
-        yoagent::context::ExecutionLimits::default().max_identical_tool_calls,
+        yoagent::context::ExecutionLimits::default().max_consecutive_identical_tool_calls,
         Some(3),
         "loop detection must ship on; a change here turns it off for everyone who \
          never sets the field"
@@ -3520,7 +3523,8 @@ fn loop_detection_is_enabled_by_default() {
 async fn loop_detection_messages_are_clean_prose() {
     let (_events, messages) = run_with_limits_msgs(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     let injected: Vec<String> = messages
@@ -3547,6 +3551,137 @@ async fn loop_detection_messages_are_clean_prose() {
     }
 }
 
+/// The threshold is exact: `Some(n)` trips on the nth consecutive call, not
+/// the (n+1)th.
+///
+/// The existing tests feed 12 repeats and assert only that *some* steer
+/// occurred, so `>=` could become `>` unnoticed and every user would get one
+/// extra wasted call before intervention.
+#[test]
+fn the_threshold_trips_on_the_nth_consecutive_call() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(3)),
+    );
+    let call = |n: &str| vec![(n.to_string(), serde_json::json!({"q": 1}))];
+
+    assert_eq!(tracker.record_tool_calls(&call("a")), LoopVerdict::Continue);
+    assert_eq!(tracker.record_tool_calls(&call("a")), LoopVerdict::Continue);
+    assert!(
+        matches!(
+            tracker.record_tool_calls(&call("a")),
+            LoopVerdict::Steer { repetitions: 3, .. }
+        ),
+        "the 3rd consecutive call must steer, and report 3 repetitions"
+    );
+}
+
+/// Duplicates inside a single batch count.
+///
+/// This is the motivating case in `record_tool_calls`'s own doc — with
+/// `Parallel` execution a model can emit the same call three times in one
+/// message and never take a second turn — but every fixture emitted one call
+/// per response, so only the across-turns path was ever walked.
+#[test]
+fn identical_calls_within_one_batch_trip_the_detector() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(3)),
+    );
+    let batch = vec![
+        ("bash".to_string(), serde_json::json!({"cmd": "ls"})),
+        ("bash".to_string(), serde_json::json!({"cmd": "ls"})),
+        ("bash".to_string(), serde_json::json!({"cmd": "ls"})),
+    ];
+    assert!(
+        matches!(
+            tracker.record_tool_calls(&batch),
+            LoopVerdict::Steer { repetitions: 3, .. }
+        ),
+        "three identical calls in one message must trip without a second turn"
+    );
+}
+
+/// The worst verdict in a batch wins.
+///
+/// Regression: the loop stopped at the first escalation, so an `Abort` later in
+/// the batch was downgraded to an earlier `Steer` — and that later signature
+/// never reached `steered`, giving it a free pass on the next turn too.
+#[test]
+fn a_batch_reports_its_most_severe_verdict() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(3)),
+    );
+    let b = |n: &str| (n.to_string(), serde_json::json!({"q": 1}));
+
+    // Get "b" steered first, so a later trip on it is an abort.
+    assert!(matches!(
+        tracker.record_tool_calls(&[b("b"), b("b"), b("b")]),
+        LoopVerdict::Steer { .. }
+    ));
+
+    // "a" trips for the first time (steer) and "b" trips again (abort) in one
+    // batch. Abort must win regardless of order.
+    let verdict = tracker.record_tool_calls(&[b("a"), b("a"), b("a"), b("b"), b("b"), b("b")]);
+    assert!(
+        matches!(&verdict, LoopVerdict::Abort { tool_name, .. } if tool_name == "b"),
+        "an abort later in the batch must not be downgraded to the earlier steer, got {verdict:?}"
+    );
+}
+
+/// Signature comparison is structural, not textual: two calls differing only
+/// in key order are the same call.
+#[test]
+fn key_order_does_not_disguise_a_repeat() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(2)),
+    );
+    let a = vec![("t".to_string(), serde_json::json!({"x": 1, "y": 2}))];
+    let b = vec![("t".to_string(), serde_json::json!({"y": 2, "x": 1}))];
+    assert_eq!(tracker.record_tool_calls(&a), LoopVerdict::Continue);
+    assert!(
+        matches!(tracker.record_tool_calls(&b), LoopVerdict::Steer { .. }),
+        "reordered keys are the same call — string comparison would miss the loop"
+    );
+}
+
+/// `Some(0)` disables the check rather than tripping on every call.
+#[test]
+fn a_zero_threshold_disables_the_check() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(0)),
+    );
+    let call = vec![("t".to_string(), serde_json::json!({}))];
+    for _ in 0..10 {
+        assert_eq!(tracker.record_tool_calls(&call), LoopVerdict::Continue);
+    }
+}
+
+/// Alternating calls are deliberately *not* detected, and this pins that so the
+/// trade-off is a decision rather than a surprise.
+///
+/// Widening to a windowed count would regress
+/// `an_interleaved_different_call_resets_the_counter` — an agent working
+/// through a list calls one tool repeatedly and legitimately.
+#[test]
+fn alternating_calls_are_not_detected_by_design() {
+    use yoagent::context::{ExecutionLimits, ExecutionTracker, LoopVerdict};
+    let mut tracker = ExecutionTracker::new(
+        ExecutionLimits::default().with_max_consecutive_identical_tool_calls(Some(3)),
+    );
+    for i in 0..50 {
+        let name = if i % 2 == 0 { "a" } else { "b" };
+        assert_eq!(
+            tracker.record_tool_calls(&[(name.to_string(), serde_json::json!({}))]),
+            LoopVerdict::Continue,
+            "the consecutive detector must not fire on alternating calls"
+        );
+    }
+}
+
 /// Three identical calls steer; continued repetition aborts. The steer comes
 /// first on purpose — a model repeating a call is often retrying something
 /// transient, and aborting immediately would regress that.
@@ -3554,7 +3689,8 @@ async fn loop_detection_messages_are_clean_prose() {
 async fn repeated_identical_calls_steer_then_abort() {
     let events = run_with_limits(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
 
@@ -3594,7 +3730,8 @@ async fn distinct_arguments_never_trip() {
 
     let events = run_with_limits(
         responses,
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     assert!(
@@ -3622,7 +3759,8 @@ async fn an_interleaved_different_call_resets_the_counter() {
 
     let events = run_with_limits(
         responses,
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(Some(3)),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(Some(3)),
     )
     .await;
     assert!(
@@ -3636,7 +3774,8 @@ async fn an_interleaved_different_call_resets_the_counter() {
 async fn detection_can_be_switched_off() {
     let events = run_with_limits(
         repeat_call(12, serde_json::json!({"q": "same"})),
-        yoagent::context::ExecutionLimits::default().with_max_identical_tool_calls(None),
+        yoagent::context::ExecutionLimits::default()
+            .with_max_consecutive_identical_tool_calls(None),
     )
     .await;
     assert!(

--- a/tests/shared_state_test.rs
+++ b/tests/shared_state_test.rs
@@ -468,7 +468,7 @@ fn a_marker_inside_the_tools_own_output_is_left_alone() {
 }
 
 #[tokio::test]
-async fn file_backend_evicts_oldest_to_stay_under_its_cap() {
+async fn file_backend_evicts_the_oldest_stash_entry_to_stay_under_its_cap() {
     let dir = tempfile::tempdir().unwrap();
     let state = SharedState::with_backend(yoagent::shared_state::FileBackend::with_max_bytes(
         dir.path(),
@@ -480,7 +480,10 @@ async fn file_backend_evicts_oldest_to_stay_under_its_cap() {
     // tiebreak agrees with mtime, so the test would pass whether or not the
     // age ordering worked at all.
     for name in ["z", "y", "x", "w", "v", "a"] {
-        state.set(name, "q".repeat(100)).await.unwrap();
+        state
+            .set(&format!("tool-out-{name}"), "q".repeat(100))
+            .await
+            .unwrap();
     }
 
     let keys = state.keys().await;
@@ -490,12 +493,115 @@ async fn file_backend_evicts_oldest_to_stay_under_its_cap() {
         "cap must bound the directory without emptying it, got {keys:?}"
     );
     assert!(
-        keys.contains(&"a".to_string()),
+        keys.contains(&"tool-out-a".to_string()),
         "the newest write is 'a', which sorts first — it must survive anyway: {keys:?}"
     );
     assert!(
-        !keys.contains(&"z".to_string()),
+        !keys.contains(&"tool-out-z".to_string()),
         "the oldest write is 'z', which sorts last — it must go first anyway: {keys:?}"
+    );
+}
+
+/// Caller-owned keys are never evicted; only stashed tool output is.
+///
+/// The old policy evicted whatever was oldest, so a parent that stored a plan
+/// through this very backend got `None` back later with no error path anywhere.
+/// Stash entries are recyclable — losing one degrades a marker to an ordinary
+/// "not found" the agent can act on — and a caller's key is not.
+#[tokio::test]
+async fn eviction_never_takes_a_caller_owned_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = SharedState::with_backend(yoagent::shared_state::FileBackend::with_max_bytes(
+        dir.path(),
+        300,
+    ));
+
+    state.set("plan", "q".repeat(100)).await.unwrap();
+    for i in 0..5 {
+        state
+            .set(&format!("tool-out-tc{i}-aaaa-b0"), "q".repeat(100))
+            .await
+            .unwrap();
+    }
+
+    let keys = state.keys().await;
+    assert!(
+        keys.contains(&"plan".to_string()),
+        "the caller's own key must survive five stash writes that blew the cap: {keys:?}"
+    );
+    assert_eq!(
+        state.get("plan").await.as_deref(),
+        Some("q".repeat(100).as_str()),
+        "and it must still hold its value, not merely exist"
+    );
+}
+
+/// A sub-agent's scoped stash is evictable too.
+///
+/// Scoped writes land as `scope\u{1f}tool-out-…`, so a whole-key prefix test
+/// reads them as caller-owned and never evicts them — re-creating the wedge for
+/// every delegating run, and starving the parent's own keys instead. The
+/// scope-stripping in `is_stash_key` is what prevents that, and nothing else
+/// here exercises it.
+#[tokio::test]
+async fn a_scoped_stash_entry_is_evictable() {
+    let state =
+        SharedState::with_backend(yoagent::shared_state::MemoryBackend::with_max_bytes(500));
+    let sub = state.scoped("worker-1");
+
+    state.set("plan", "q".repeat(80)).await.unwrap();
+    for i in 0..20 {
+        sub.set(&format!("tool-out-tc{i}-aaaa-b0"), "q".repeat(100))
+            .await
+            .unwrap_or_else(|e| panic!("scoped stash write {i} failed — sub-agent wedged: {e}"));
+    }
+    assert!(
+        state.get("plan").await.is_some(),
+        "the parent's key must not be starved by a sub-agent's stash"
+    );
+}
+
+/// A store full of caller keys reports capacity rather than destroying them.
+#[tokio::test]
+async fn a_store_of_caller_keys_refuses_rather_than_evicting() {
+    let state =
+        SharedState::with_backend(yoagent::shared_state::MemoryBackend::with_max_bytes(300));
+    for i in 0..2 {
+        state
+            .set(&format!("artifact{i}"), "q".repeat(100))
+            .await
+            .unwrap();
+    }
+    let err = state.set("artifact9", "q".repeat(200)).await;
+    assert!(
+        err.is_err(),
+        "with nothing evictable the write must fail loudly, not silently drop a caller's data"
+    );
+    assert!(
+        state.get("artifact0").await.is_some(),
+        "and the existing caller keys must be untouched"
+    );
+}
+
+/// The default in-memory backend recycles stash entries instead of wedging.
+///
+/// Regression: `MemoryBackend` rejected rather than evicted and nothing ever
+/// removed `tool-out-*`, so after ~33 large results every write failed for the
+/// rest of the run — including the model's own `shared_state set` — with the
+/// bytes never reclaimed.
+#[tokio::test]
+async fn the_default_backend_does_not_wedge_once_full() {
+    let state =
+        SharedState::with_backend(yoagent::shared_state::MemoryBackend::with_max_bytes(500));
+    for i in 0..40 {
+        state
+            .set(&format!("tool-out-tc{i}-aaaa-b0"), "q".repeat(100))
+            .await
+            .unwrap_or_else(|e| panic!("write {i} failed — the store wedged: {e}"));
+    }
+    assert!(
+        state.get("tool-out-tc39-aaaa-b0").await.is_some(),
+        "the most recent stash must be retrievable after 40 writes over a 500-byte cap"
     );
 }
 

--- a/tests/sub_agent_test.rs
+++ b/tests/sub_agent_test.rs
@@ -1103,3 +1103,107 @@ async fn stashed_output_does_not_leak_into_the_sub_agent_system_prompt() {
     assert!(store.prompt_summary().await.contains("findings"));
     assert!(store.summary().await.contains("tool-out-"));
 }
+
+/// A sub-agent stopped by loop detection must not report success.
+///
+/// Regression: `extract_error` matched only `StopReason::Error`, but a loop
+/// abort leaves `ToolUse` on the last assistant message, and
+/// `extract_final_text` scans assistant messages only — so it never saw the
+/// trailing `[Agent stopped: …]` and fell through to "(sub-agent produced no
+/// text output)". The parent got `is_error: false`. A sub-agent that burned its
+/// whole budget looping was indistinguishable from one that had nothing to say.
+///
+/// Loop detection is inherited, not configured here: `SubAgentTool` takes
+/// `ExecutionLimits::default()`, so every delegation runs with `Some(3)`.
+#[tokio::test]
+async fn a_looping_sub_agent_reports_failure_not_empty_success() {
+    let responses: Vec<MockResponse> = (0..12)
+        .map(|_| {
+            MockResponse::ToolCalls(vec![MockToolCall {
+                provider_metadata: None,
+                name: "echo".into(),
+                arguments: serde_json::json!({"text": "same"}),
+            }])
+        })
+        .collect();
+
+    let echo_tool: Arc<dyn AgentTool> = Arc::new(EchoTool);
+    let sub_agent = SubAgentTool::from_provider(
+        "looper",
+        Arc::new(MockProvider::new(responses)),
+        ModelConfig::mock(),
+    )
+    .with_system_prompt("Use the echo tool.")
+    .with_tools(vec![echo_tool]);
+
+    let result = sub_agent
+        .execute(
+            serde_json::json!({"task": "go"}),
+            ToolContext::new("tc-1", "looper"),
+        )
+        .await;
+
+    match result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("echo") || msg.contains("repeatedly"),
+                "the failure must say why the sub-agent stopped, got: {msg}"
+            );
+        }
+        Ok(r) => {
+            let text = match &r.content[0] {
+                Content::Text { text } => text.clone(),
+                _ => String::new(),
+            };
+            panic!("a loop-aborted sub-agent reported success to its parent: {text:?}");
+        }
+    }
+}
+
+/// A turn-limited sub-agent returns its work, and says the work is partial.
+///
+/// The two self-stop kinds mean opposite things to a parent: `max_turns` is a
+/// bound (keep the output), a loop abort is a failure (there is nothing to
+/// keep). Without the notice, half-finished work is indistinguishable from a
+/// complete answer and the parent's model treats it as final.
+///
+/// The limit fires at the top of a turn, so the fixture must call a tool —
+/// a text-only reply ends the run normally and never reaches the check.
+#[tokio::test]
+async fn a_turn_limited_sub_agent_returns_partial_work_and_says_so() {
+    let sub_provider = Arc::new(MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
+            name: "echo".into(),
+            arguments: serde_json::json!({"text": "more"}),
+        }]),
+        MockResponse::Text("Should not reach".into()),
+    ]));
+
+    let echo_tool: Arc<dyn AgentTool> = Arc::new(EchoTool);
+    let sub_agent = SubAgentTool::from_provider("limited2", sub_provider, ModelConfig::mock())
+        .with_tools(vec![echo_tool])
+        .with_max_turns(1);
+
+    let result = sub_agent
+        .execute(
+            serde_json::json!({"task": "keep going"}),
+            ToolContext::new("tc-1", "limited2"),
+        )
+        .await
+        .expect("a turn limit is a bound, not a failure");
+
+    let text = match &result.content[0] {
+        Content::Text { text } => text.clone(),
+        _ => panic!("expected text"),
+    };
+    assert!(
+        text.contains(yoagent::agent_loop::AGENT_STOPPED_PREFIX),
+        "and the parent must be told the answer is partial: {text:?}"
+    );
+    assert!(
+        !text.contains("Should not reach"),
+        "the turn limit must actually have stopped it: {text:?}"
+    );
+}


### PR DESCRIPTION
Closes #144, #145, #146. The last three blockers before 0.18.0.

## #144 — eviction policy

Both backends were wrong, in opposite directions.

**`MemoryBackend`** — what `SharedState::new()` returns, and the documented path for `Agent::with_shared_state` — rejected rather than evicted, and nothing ever removed `tool-out-*`. At ~300KB per stashed build or grep output a 10MB cap holds ~33 results, after which **every** write failed for the rest of the run, including the model's own `shared_state set`, with the bytes never reclaimed.

**`FileBackend`** evicted whatever was oldest, including keys a caller had set through its own API. A parent that stored a `plan` got `None` back later with no error path anywhere.

Both now draw one line: **stash entries are evictable, caller keys are not.** A stash entry is recyclable — losing one degrades a marker to an ordinary "key not found" the agent can act on, and the head+tail is still in the transcript. Nothing regenerates a caller's artifact. When only caller keys remain, the write reports capacity rather than destroying data.

Every eviction now logs. A *successful* one was previously silent, which matters because the verify-after-store loop only checks the keys written for the current result — it cannot see that this write just evicted an earlier one whose marker is frozen in the transcript.

The line is **scope-aware**: a sub-agent's stash lands as `scope␟tool-out-…`, so a whole-key prefix test reads it as caller-owned and never evicts it, re-creating the wedge for every delegating run. This is the one case my first cut got wrong — the mutation passed green until I added `a_scoped_stash_entry_is_evictable`.

## #145 — loop detection

`max_identical_tool_calls` → `max_consecutive_identical_tool_calls`. It caps consecutive-run length only, so `[a, b, a, b, …]` is never detected. The doc was honest; the name was not, and a public field is far cheaper to rename before release.

**Deliberately not widened** to a windowed count. That would regress `an_interleaved_different_call_resets_the_counter`, which pins a considered trade-off: an agent working through a list calls one tool repeatedly and legitimately. The limitation is now documented on the field and pinned by `alternating_calls_are_not_detected_by_design`, so it is a decision rather than a surprise.

`steered` held a full clone of every steered signature's arguments — for a file-write tool, the entire file body — unbounded, inside the one type whose job is bounding runaway resource use. Now a capped list of FNV hashes, sharing the `fnv1a` that `tool_output_key` had inlined.

## #146 — sub-agent failure reporting

`extract_error` matched only `StopReason::Error`, but a loop abort leaves `ToolUse` on the last assistant message, and `extract_final_text` scans assistant messages only — so it never saw the trailing marker and fell through to `"(sub-agent produced no text output)"` with `is_error: false`. A sub-agent that burned its whole budget looping was indistinguishable from one that had nothing to say.

**Only loop aborts are errors.** `max_turns` is a bound, not a failure — the work was cut short but what it produced is real, so it is returned with the stop notice appended so the parent's model knows the answer is partial. That distinction came out of a test: my first cut errored on both and broke `test_sub_agent_max_turns`, which deliberately asserts a turn-limited sub-agent succeeds.

Also: `FileBackend::set` returned `Err` for a value already on disk (`evict_to_fit` propagates `read_dir`/`next_entry` errors, both of which run *after* the write, and rollback could never reach the key) — it now unlinks before propagating. A failed rollback is logged rather than discarded.

## Verification

| mutation | result |
|---|---|
| every key evictable again | `the caller's own key must survive five stash writes` |
| MemoryBackend eviction removed | `write 4 failed — the store wedged` |
| `is_stash_key` ignores scope | `scoped stash write 3 failed — sub-agent wedged` |
| `extract_error` reverted | `reported success to its parent: "(sub-agent produced no text output)"` |
| threshold `>=` → `>` | caught |
| only first call in a batch counted | caught |
| severity fold → first-wins | caught, reproducing the bug exactly: `Steer{a}` where `Abort{b}` is right |
| signature compared as text | caught |

`cargo test --all-features`: **615 passed, 0 failed**. Clippy clean under `-Dwarnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)