### PR TITLE
test: live validation harnesses — and the two findings they produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Fixed: tools with no parameters were uncallable on Anthropic.** A tool
+  whose schema takes no arguments has no JSON to stream, and Anthropic still
+  emits an `input_json_delta` carrying `""`. `serde_json::from_str("")` fails
+  with "EOF while parsing a value", so the `__partial_json` sentinel survived
+  `content_block_stop` and the post-stream sweep failed the whole turn with
+  *"tool call(s) with unusable arguments, not executed"*. Every no-argument
+  tool — `get_status`, `list_files`, `read_log` — was affected.
+
+  An empty accumulator is an empty argument object, not malformed input. The
+  decision is now a small pure function, `resolve_tool_arguments`, so it has a
+  regression test; genuinely truncated JSON still fails, which is what the
+  sentinel exists for.
+
+  Found by `examples/release_smoke.rs` against a live provider, not by the
+  suite: `MockProvider` never streams SSE, so nothing exercised the tool-call
+  accumulator at all.
+
+- **`examples/release_smoke.rs` — a pre-release check against a live provider.**
+  All 618 unit tests use `MockProvider`, which accepts any message sequence
+  handed to it. That is structural, not an oversight, and it is where this
+  release's worst bug lived: loop detection injected a message between an
+  assistant's `tool_use` blocks and their `tool_result`s, which every real
+  provider rejects, and the suite stayed green.
+
+  Four checks, chosen for what a mock cannot verify: that loop detection
+  produces a transcript the provider accepts *and leaves the agent usable for a
+  second prompt*; that the model follows a truncation marker and retrieves
+  content head+tail truncation cannot contain; that cost comes from real usage;
+  and that a stable system prompt still produces cache reads.
+
+  ```
+  ANTHROPIC_API_KEY=... cargo run --example release_smoke
+  SMOKE_MODEL=deepseek DEEPSEEK_API_KEY=... cargo run --example release_smoke
+  ```
+
+  Verified 6/6 on Sonnet 5 and 5/5 on DeepSeek (its config is unpriced, so the
+  cost check reports n/a rather than failing). Exits non-zero on failure.
+
 - **Stash eviction protects caller-owned keys; the default backend no longer
   wedges** ([#144](https://github.com/yologdev/yoagent/issues/144)).
 

--- a/examples/long_horizon.rs
+++ b/examples/long_horizon.rs
@@ -1,0 +1,502 @@
+//! Long-horizon validation against a **live** provider.
+//!
+//! Run with: `ANTHROPIC_API_KEY=sk-... cargo run --example long_horizon`
+//! Provider: `SMOKE_MODEL=deepseek` (default Sonnet 5).
+//!
+//! # What this is for
+//!
+//! `release_smoke` checks four narrow behaviours over short runs. This checks
+//! the thing yoagent actually claims to be for: **an agent that runs long
+//! enough to exhaust its context, compacts, and keeps working.** That path had
+//! no live coverage at all — every compaction test uses `MockProvider`, which
+//! cannot tell you whether a compacted transcript is still one a provider
+//! accepts, or whether the agent still knows what it learned an hour ago.
+//!
+//! The promises being checked, each stated in the docs or CHANGELOG:
+//!
+//! 1. **Compaction actually triggers** on a long run and the run survives it.
+//! 2. **Task continuity**: the agent can still recall a fact it learned
+//!    *before* compaction. A compaction that loses the thread is worse than
+//!    hitting the limit.
+//! 3. **The transcript stays provider-valid across compaction** — no orphaned
+//!    tool calls, which is what `splice_never_orphans_a_parallel_tool_call`
+//!    asserts in unit tests but never against a real API.
+//! 4. **Prefix caching survives compaction.** The compaction marker is
+//!    deliberately constant text so the cached prefix stays byte-stable; if
+//!    that were untrue the cache would cold-start on every compaction and the
+//!    whole design would be a pessimisation.
+//! 5. **`SessionStats` reports what actually happened** — turns, compactions,
+//!    and a cost that matches the usage.
+//! 6. **Sub-agent delegation works end to end**, including the scoped stash.
+//!
+//! Exits non-zero on failure.
+
+use std::sync::Arc;
+use yoagent::agent::Agent;
+use yoagent::context::ContextConfig;
+use yoagent::provider::ModelConfig;
+use yoagent::shared_state::SharedState;
+use yoagent::sub_agent::SubAgentTool;
+use yoagent::types::{
+    AgentMessage, AgentTool, Content, Message, SessionStats, ToolContext, ToolError, ToolResult,
+};
+use yoagent::*;
+
+// ---------------------------------------------------------------------------
+// A tool that returns bulky, distinct records — enough to fill a context.
+// ---------------------------------------------------------------------------
+
+/// The fact planted in record 1, which the agent must still know at the end.
+const EARLY_SECRET: &str = "MERIDIAN-8831";
+
+#[derive(Clone)]
+struct RecordTool;
+
+#[async_trait::async_trait]
+impl AgentTool for RecordTool {
+    fn name(&self) -> &str {
+        "fetch_record"
+    }
+    fn label(&self) -> &str {
+        "Fetch record"
+    }
+    fn description(&self) -> &str {
+        "Fetch inspection record N (1-24). Each record is a block of findings."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "n": { "type": "integer", "description": "record number 1-24" } },
+            "required": ["n"]
+        })
+    }
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let n = params.get("n").and_then(|v| v.as_i64()).unwrap_or(1);
+        let mut body = String::new();
+        if n == 1 {
+            body.push_str(&format!(
+                "record 1 header: the ASSET CODE for this inspection is {EARLY_SECRET}. \
+                 Remember it; later records do not repeat it.\n"
+            ));
+        }
+        // Bulk, so the context fills in a realistic number of turns.
+        for i in 0..60 {
+            body.push_str(&format!(
+                "record {n} line {i}: subsystem {i} nominal, drift {:.3}, margin ok, \
+                 no action required, logged by inspector {n}\n",
+                (n as f64 * 0.017) + (i as f64 * 0.003)
+            ));
+        }
+        Ok(ToolResult {
+            content: vec![Content::Text { text: body }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+struct Report {
+    checks: Vec<(String, bool)>,
+}
+
+impl Report {
+    fn record(&mut self, name: &str, ok: bool, detail: impl Into<String>) {
+        println!(
+            "  {} {name}\n      {}",
+            if ok { "PASS" } else { "FAIL" },
+            detail.into()
+        );
+        self.checks.push((name.to_string(), ok));
+    }
+    fn note(&self, detail: impl Into<String>) {
+        println!("       {}", detail.into());
+    }
+}
+
+struct RunOutcome {
+    text: String,
+    error: Option<String>,
+    stats: Option<SessionStats>,
+    compactions: u32,
+    cache_read_after_compaction: u64,
+}
+
+/// Drain a run, recording compaction events and the usage that follows them.
+async fn drain(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> RunOutcome {
+    let mut out = RunOutcome {
+        text: String::new(),
+        error: None,
+        stats: None,
+        compactions: 0,
+        cache_read_after_compaction: 0,
+    };
+    let mut assistant_turns = 0usize;
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::MessageUpdate {
+                delta: StreamDelta::Text { delta },
+                ..
+            } => out.text.push_str(&delta),
+
+            AgentEvent::ContextCompacted {
+                method,
+                messages_before,
+                messages_after,
+                tokens_before,
+                tokens_after,
+                ..
+            } => {
+                out.compactions += 1;
+                println!(
+                    "       [compaction #{}] {method:?}: {messages_before} msgs / \
+                     {tokens_before} tok -> {messages_after} msgs / {tokens_after} tok",
+                    out.compactions
+                );
+            }
+
+            AgentEvent::MessageEnd {
+                message:
+                    AgentMessage::Llm(Message::Assistant {
+                        usage,
+                        stop_reason,
+                        error_message,
+                        ..
+                    }),
+            } => {
+                {
+                    // `DefaultCompaction` emits no `ContextCompacted` event — it has
+                    // no event channel — so keying off that flag measured
+                    // nothing. Count cache reads on the back half of the run
+                    // instead: by then compaction has certainly run, and a
+                    // byte-stable prefix should still be producing hits.
+                    assistant_turns += 1;
+                    if assistant_turns > 6 {
+                        out.cache_read_after_compaction += usage.cache_read;
+                    }
+                    if stop_reason == StopReason::Error {
+                        out.error =
+                            Some(error_message.unwrap_or_else(|| "unknown provider error".into()));
+                    }
+                }
+            }
+
+            AgentEvent::AgentEnd { stats, .. } => out.stats = Some(stats),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Every `tool_use` answered before anything else intervenes.
+fn transcript_is_well_formed(messages: &[AgentMessage]) -> Result<(), String> {
+    let mut pending: Vec<String> = Vec::new();
+    for (i, m) in messages.iter().enumerate() {
+        let AgentMessage::Llm(msg) = m else { continue };
+        match msg {
+            Message::Assistant { content, .. } => {
+                if !pending.is_empty() {
+                    return Err(format!("assistant at [{i}] while {pending:?} unanswered"));
+                }
+                pending = content
+                    .iter()
+                    .filter_map(|c| match c {
+                        Content::ToolCall { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::ToolResult { tool_call_id, .. } => {
+                if let Some(at) = pending.iter().position(|p| p == tool_call_id) {
+                    pending.remove(at);
+                }
+            }
+            Message::User { .. } => {
+                if !pending.is_empty() {
+                    return Err(format!(
+                        "user message at [{i}] with {pending:?} unanswered — the shape \
+                         providers reject"
+                    ));
+                }
+            }
+        }
+    }
+    if pending.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("ended with {pending:?} unanswered"))
+    }
+}
+
+fn model() -> ModelConfig {
+    match std::env::var("SMOKE_MODEL").ok().as_deref() {
+        Some("deepseek") => ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat"),
+        Some("gpt") => ModelConfig::openai("gpt-5.5", "GPT-5.5"),
+        _ => ModelConfig::claude_sonnet_5(),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let cfg = model();
+    println!(
+        "\nyoagent long-horizon validation — live provider: {}\n",
+        cfg.name
+    );
+    let mut report = Report { checks: Vec::new() };
+
+    // -----------------------------------------------------------------
+    // A long run, deliberately given far less context than the task needs.
+    // -----------------------------------------------------------------
+    println!("[1/3] long run with forced compaction");
+
+    let mut agent = Agent::from_config(cfg.clone())
+        .with_system_prompt(
+            "You are inspecting an asset. Use fetch_record to read records one at a time. \
+             Work through every record you are asked for, in order, one tool call per turn. \
+             Be terse — do not summarise each record, just proceed.",
+        )
+        .with_tools(vec![Box::new(RecordTool) as Box<dyn AgentTool>])
+        .with_context_config(ContextConfig {
+            // Big enough to be a plausible budget, small enough that a dozen
+            // bulky records must compact. 6_000 was too aggressive to be a
+            // fair test: the agent thrashed, burned all 50 turns, and lost the
+            // thread — which is correct behaviour for an absurd budget, not
+            // evidence about compaction.
+            max_context_tokens: 30_000,
+            keep_recent: 6,
+            keep_first: 2,
+            tool_output_max_lines: 200,
+            ..Default::default()
+        });
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    agent = agent.with_compaction_strategy(
+        yoagent::LlmCompaction::from_config(cfg.clone())
+            .with_trigger_ratio(0.35)
+            .with_event_sender(tx.clone()),
+    );
+    agent
+        .prompt_with_sender(
+            "Fetch records 1 through 14, one at a time, in order. \
+             After the last one, reply with exactly: DONE",
+            tx,
+        )
+        .await;
+    let run = drain(&mut rx).await;
+    agent.finish().await;
+
+    report.record(
+        "the long run completes without a provider error",
+        run.error.is_none(),
+        run.error
+            .clone()
+            .unwrap_or_else(|| "no provider error".into()),
+    );
+
+    let compacted = run.compactions > 0
+        || run
+            .stats
+            .as_ref()
+            .map(|s| s.compactions > 0)
+            .unwrap_or(false);
+    report.record(
+        "compaction actually triggered",
+        compacted,
+        if compacted {
+            format!("{} compaction event(s)", run.compactions)
+        } else {
+            "no compaction — the context never filled, so nothing below is a real test \
+             of the compaction path. Lower max_context_tokens or raise the record count."
+                .into()
+        },
+    );
+
+    match transcript_is_well_formed(agent.messages()) {
+        Ok(()) if agent.messages().is_empty() => report.record(
+            "transcript stays provider-valid across compaction",
+            false,
+            "0 messages — nothing inspected",
+        ),
+        Ok(()) => report.record(
+            "transcript stays provider-valid across compaction",
+            true,
+            format!(
+                "{} messages, every tool_use answered",
+                agent.messages().len()
+            ),
+        ),
+        Err(e) => report.record(
+            "transcript stays provider-valid across compaction",
+            false,
+            e,
+        ),
+    }
+
+    if let Some(stats) = &run.stats {
+        report.note(format!(
+            "stats: {} turns, {} compactions, in={} out={} cache_read={} cache_write={}",
+            stats.turns,
+            stats.compactions,
+            stats.usage.input,
+            stats.usage.output,
+            stats.usage.cache_read,
+            stats.usage.cache_write,
+        ));
+        let coherent = stats.turns > 0 && (!compacted || stats.compactions > 0);
+        report.record(
+            "SessionStats reports what actually happened",
+            coherent,
+            format!(
+                "turns={} compactions={} hit_rate={:.1}%",
+                stats.turns,
+                stats.compactions,
+                stats.cache_hit_rate() * 100.0
+            ),
+        );
+    } else {
+        report.record(
+            "SessionStats reports what actually happened",
+            false,
+            "no AgentEnd carried stats",
+        );
+    }
+
+    report.record(
+        "prefix cache still hits after compaction",
+        run.cache_read_after_compaction > 0 || !compacted,
+        format!(
+            "cache_read on post-compaction turns = {} tokens{}",
+            run.cache_read_after_compaction,
+            if run.cache_read_after_compaction == 0 && compacted {
+                " — 0 means the compacted prefix is not byte-stable, or this provider \
+                 does not cache. The constant COMPACTION_MARKER exists to prevent the former."
+            } else {
+                ""
+            }
+        ),
+    );
+
+    // -----------------------------------------------------------------
+    // Continuity: does it still know what it read before compaction?
+    // -----------------------------------------------------------------
+    println!("\n[2/3] task continuity across compaction");
+    {
+        // What `LlmCompaction` documents is a "shift-handoff briefing covering
+        // goals, progress, and decisions" — task continuity, not a verbatim
+        // record of tool output. Testing it for an arbitrary data fact would be
+        // testing a promise the library never makes; that is what the
+        // truncation stash is for, and `release_smoke` covers it.
+        let mut rx = agent
+            .prompt(
+                "Without calling any tools: what task are you working on, and roughly how \
+                 far through it did you get? One sentence.",
+            )
+            .await;
+        let follow = drain(&mut rx).await;
+        agent.finish().await;
+
+        let lower = follow.text.to_lowercase();
+        let on_task = lower.contains("record") || lower.contains("inspect");
+        report.record(
+            "the agent still knows the task after compaction",
+            on_task && follow.error.is_none(),
+            if on_task {
+                format!("continuity held: {:?}", follow.text.trim())
+            } else {
+                format!(
+                    "lost the thread — the briefing did not carry goals/progress. \
+                     err={:?} reply={:?}",
+                    follow.error,
+                    follow.text.trim()
+                )
+            },
+        );
+
+        // Stated, not assumed: specific values from tool output are NOT a
+        // compaction promise. Retrieval of those is the stash's job.
+        let mut rx2 = agent
+            .prompt(
+                "Without calling tools: what was the ASSET CODE in record 1? \
+                 If you no longer have it, reply LOST.",
+            )
+            .await;
+        let fact = drain(&mut rx2).await;
+        agent.finish().await;
+        report.note(format!(
+            "data-fact recall after compaction: {} — informational only; the briefing \
+             covers goals/progress/decisions, and exact tool output is the stash's job",
+            if fact.text.contains(EARLY_SECRET) {
+                "retained".to_string()
+            } else {
+                format!("lost ({:?})", fact.text.trim())
+            }
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // Sub-agent delegation with a scoped stash.
+    // -----------------------------------------------------------------
+    println!("\n[3/3] sub-agent delegation with a scoped stash");
+    {
+        let state = SharedState::new();
+        let worker = SubAgentTool::from_config("inspector", cfg.clone())
+            .with_description("Delegate a record inspection. Give it a record number.")
+            .with_system_prompt(
+                "Fetch the record you are asked for. Your final reply MUST contain the ASSET \
+             CODE value itself, spelled out. Do not merely say where you stored it.",
+            )
+            .with_tools(vec![Arc::new(RecordTool) as Arc<dyn AgentTool>])
+            .with_scoped_shared_state(state.clone(), "inspector")
+            .with_max_turns(6);
+
+        let mut parent = Agent::from_config(cfg.clone())
+            .with_system_prompt("Delegate to the inspector sub-agent. Report what it tells you.")
+            .with_tools(vec![Box::new(worker) as Box<dyn AgentTool>]);
+
+        let mut rx = parent
+            .prompt("Ask the inspector to look at record 1 and tell me the ASSET CODE.")
+            .await;
+        let sub = drain(&mut rx).await;
+        parent.finish().await;
+
+        let ok = sub.error.is_none() && sub.text.contains(EARLY_SECRET);
+        report.record(
+            "sub-agent delegation returns real work to the parent",
+            ok,
+            if ok {
+                format!("parent reported {EARLY_SECRET} via the sub-agent")
+            } else {
+                format!("err={:?} reply={:?}", sub.error, sub.text.trim())
+            },
+        );
+    }
+
+    // -----------------------------------------------------------------
+    println!("\n{}", "-".repeat(72));
+    let failed: Vec<&str> = report
+        .checks
+        .iter()
+        .filter(|(_, ok)| !ok)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    println!(
+        "{} of {} checks passed",
+        report.checks.len() - failed.len(),
+        report.checks.len()
+    );
+    if failed.is_empty() {
+        println!("\nLong-horizon: PASS");
+    } else {
+        println!("\nLong-horizon: FAIL");
+        for f in &failed {
+            println!("  - {f}");
+        }
+        std::process::exit(1);
+    }
+}

--- a/examples/release_smoke.rs
+++ b/examples/release_smoke.rs
@@ -210,6 +210,10 @@ fn model() -> ModelConfig {
     match std::env::var("SMOKE_MODEL").ok().as_deref() {
         Some("gpt") => ModelConfig::openai("gpt-5.5", "GPT-5.5"),
         Some("gemini") => ModelConfig::google("gemini-3-pro", "Gemini 3 Pro"),
+        // The OpenAI-compat path is a separate provider implementation from
+        // Anthropic's, with its own SSE parsing and tool-call accumulation —
+        // worth running before a release, not just one provider.
+        Some("deepseek") => ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat"),
         _ => ModelConfig::claude_sonnet_5(),
     }
 }
@@ -236,6 +240,10 @@ async fn main() {
 
         let mut rx = agent.prompt("Check the status of service 'api'.").await;
         let (_text, err) = drain(&mut rx).await;
+        // Required: `prompt` spawns the loop, `finish` awaits it and syncs
+        // messages back. Without it `messages()` is empty and the transcript
+        // check below passes having inspected nothing.
+        agent.finish().await;
 
         report.record(
             "loop run completes without a provider error",
@@ -244,7 +252,13 @@ async fn main() {
                 .unwrap_or_else(|| "no provider error".to_string()),
         );
 
+        let n = agent.messages().len();
         match transcript_is_well_formed(agent.messages()) {
+            Ok(()) if n == 0 => report.record(
+                "transcript is well-formed after loop detection",
+                false,
+                "0 messages — nothing was inspected, so this check proves nothing",
+            ),
             Ok(()) => report.record(
                 "transcript is well-formed after loop detection",
                 true,
@@ -295,6 +309,7 @@ async fn main() {
             )
             .await;
         let (text, err) = drain(&mut rx).await;
+        agent.finish().await;
 
         let found = text.contains(NEEDLE);
         report.record(
@@ -320,17 +335,31 @@ async fn main() {
         let mut agent = Agent::from_config(cfg.clone()).with_system_prompt("Be concise.");
         let mut rx = agent.prompt("Name three primary colours.").await;
         let (_t, err) = drain(&mut rx).await;
+        agent.finish().await;
 
         let cost = agent.session_cost_usd();
-        let ok = err.is_none() && cost.map(|c| c > 0.0).unwrap_or(false);
-        report.record(
-            "session cost is computed from real usage",
-            ok,
-            match cost {
-                Some(c) => format!("session_cost_usd = ${c:.6}"),
-                None => "session_cost_usd = None — the preset reports unpriced".to_string(),
-            },
-        );
+        // Only the priced presets carry rates. A generic constructor like
+        // `ModelConfig::deepseek(id, name)` reports unpriced by design —
+        // all-zero rates mean unknown, not free — so failing here would be
+        // testing the harness's choice of model, not the library.
+        if cfg.cost.is_configured() {
+            let ok = err.is_none() && cost.map(|c| c > 0.0).unwrap_or(false);
+            report.record(
+                "session cost is computed from real usage",
+                ok,
+                match cost {
+                    Some(c) => format!("session_cost_usd = ${c:.6}"),
+                    None => "priced preset returned None — is_configured and \
+                             session_cost_usd disagree"
+                        .to_string(),
+                },
+            );
+        } else {
+            println!(
+                "  n/a  session cost — {} is an unpriced config, nothing to check",
+                cfg.name
+            );
+        }
     }
 
     // -----------------------------------------------------------------

--- a/examples/release_smoke.rs
+++ b/examples/release_smoke.rs
@@ -1,0 +1,399 @@
+//! Pre-release smoke test against a **live** provider.
+//!
+//! Run with: `ANTHROPIC_API_KEY=sk-... cargo run --example release_smoke`
+//!
+//! # Why this exists
+//!
+//! Every one of the 615 unit tests uses `MockProvider`, which accepts any
+//! message sequence you hand it. The v0.18.0 release gate found a bug that no
+//! mock can catch: loop detection injected a message between an assistant's
+//! `tool_use` blocks and their `tool_result`s, a shape every real provider
+//! rejects with a 400. The suite was green. A real request is the only thing
+//! that checks it.
+//!
+//! So this covers what a mock structurally cannot:
+//!
+//! 1. **Transcript validity after loop detection** — including a *second*
+//!    prompt on the same agent, because the abort used to leave an orphaned
+//!    `tool_use` in history that poisoned every later call.
+//! 2. **Stash retrieval through the model** — the model must actually follow
+//!    the marker and receive content that is not in the head or tail. The
+//!    existing test asserted a Rust-side `get`, one hop short of the real path.
+//! 3. **Cost and usage accounting** against real provider numbers.
+//! 4. **Prefix caching** — that a stable system prompt still produces cache
+//!    reads, which the compaction marker's byte-stability depends on.
+//!
+//! Exit code is non-zero if any check fails, so this can gate a release.
+
+use yoagent::agent::Agent;
+use yoagent::context::ContextConfig;
+use yoagent::provider::ModelConfig;
+use yoagent::shared_state::SharedState;
+use yoagent::types::{
+    AgentMessage, AgentTool, Content, Message, ToolContext, ToolError, ToolResult,
+};
+use yoagent::*;
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+/// Always returns the same thing, so a model asked to retry will loop.
+#[derive(Clone)]
+struct StuckTool;
+
+#[async_trait::async_trait]
+impl AgentTool for StuckTool {
+    fn name(&self) -> &str {
+        "check_status"
+    }
+    fn label(&self) -> &str {
+        "Check status"
+    }
+    fn description(&self) -> &str {
+        "Check the deployment status. Returns the current state."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "service": { "type": "string" } },
+            "required": ["service"]
+        })
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        Ok(ToolResult {
+            content: vec![Content::Text {
+                text: "status: PENDING".into(),
+            }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+/// Returns a long output with a unique needle buried in the middle, so a
+/// head+tail truncation provably cannot contain it.
+#[derive(Clone)]
+struct BigOutputTool;
+
+const NEEDLE: &str = "ZEPHYR-4417-QUINCE";
+
+#[async_trait::async_trait]
+impl AgentTool for BigOutputTool {
+    fn name(&self) -> &str {
+        "read_log"
+    }
+    fn label(&self) -> &str {
+        "Read log"
+    }
+    fn description(&self) -> &str {
+        "Read the build log. Returns the full log text."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {}, "required": [] })
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let mut lines = Vec::new();
+        for i in 0..2000 {
+            if i == 1000 {
+                lines.push(format!("line {i}: BUILD TOKEN {NEEDLE}"));
+            } else {
+                lines.push(format!("line {i}: routine build output, nothing notable"));
+            }
+        }
+        Ok(ToolResult {
+            content: vec![Content::Text {
+                text: lines.join("\n"),
+            }],
+            details: serde_json::Value::Null,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Report {
+    checks: Vec<(String, bool, String)>,
+}
+
+impl Report {
+    fn record(&mut self, name: &str, ok: bool, detail: impl Into<String>) {
+        let detail = detail.into();
+        println!(
+            "  {} {name}\n      {detail}",
+            if ok { "PASS" } else { "FAIL" }
+        );
+        self.checks.push((name.to_string(), ok, detail));
+    }
+}
+
+/// Drain an event stream, returning the assistant text and whether the run
+/// reported a provider error.
+async fn drain(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>,
+) -> (String, Option<String>) {
+    let mut text = String::new();
+    let mut err = None;
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::MessageUpdate {
+                delta: StreamDelta::Text { delta },
+                ..
+            } => text.push_str(&delta),
+            AgentEvent::MessageEnd {
+                message:
+                    AgentMessage::Llm(Message::Assistant {
+                        stop_reason: StopReason::Error,
+                        error_message,
+                        ..
+                    }),
+            } => {
+                err = Some(error_message.unwrap_or_else(|| "unknown provider error".into()));
+            }
+            _ => {}
+        }
+    }
+    (text, err)
+}
+
+/// Every `tool_use` must be answered by its `tool_result`s before anything
+/// else. This is the invariant the release-gate bug violated.
+fn transcript_is_well_formed(messages: &[AgentMessage]) -> Result<(), String> {
+    let mut pending: Vec<String> = Vec::new();
+    for (i, m) in messages.iter().enumerate() {
+        let AgentMessage::Llm(msg) = m else { continue };
+        match msg {
+            Message::Assistant { content, .. } => {
+                if !pending.is_empty() {
+                    return Err(format!("assistant at [{i}] while {pending:?} unanswered"));
+                }
+                pending = content
+                    .iter()
+                    .filter_map(|c| match c {
+                        Content::ToolCall { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::ToolResult { tool_call_id, .. } => {
+                if let Some(at) = pending.iter().position(|p| p == tool_call_id) {
+                    pending.remove(at);
+                }
+            }
+            Message::User { .. } => {
+                if !pending.is_empty() {
+                    return Err(format!(
+                        "user message at [{i}] lands between an assistant's tool_use and its \
+                         tool_result — {pending:?} unanswered. This is the shape every provider \
+                         rejects."
+                    ));
+                }
+            }
+        }
+    }
+    if !pending.is_empty() {
+        return Err(format!("run ended with {pending:?} unanswered"));
+    }
+    Ok(())
+}
+
+fn model() -> ModelConfig {
+    match std::env::var("SMOKE_MODEL").ok().as_deref() {
+        Some("gpt") => ModelConfig::openai("gpt-5.5", "GPT-5.5"),
+        Some("gemini") => ModelConfig::google("gemini-3-pro", "Gemini 3 Pro"),
+        _ => ModelConfig::claude_sonnet_5(),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let cfg = model();
+    println!("\nyoagent release smoke — live provider: {}\n", cfg.name);
+
+    let mut report = Report { checks: Vec::new() };
+
+    // -----------------------------------------------------------------
+    // 1. Loop detection produces a transcript the provider accepts, and
+    //    leaves the agent usable afterwards.
+    // -----------------------------------------------------------------
+    println!("[1/4] loop detection — transcript validity and agent reuse");
+    {
+        let mut agent = Agent::from_config(cfg.clone())
+            .with_system_prompt(
+                "You are checking a deployment. If the status is PENDING, check again. \
+                 Keep checking until it changes. Do not give up.",
+            )
+            .with_tools(vec![Box::new(StuckTool) as Box<dyn AgentTool>]);
+
+        let mut rx = agent.prompt("Check the status of service 'api'.").await;
+        let (_text, err) = drain(&mut rx).await;
+
+        report.record(
+            "loop run completes without a provider error",
+            err.is_none(),
+            err.clone()
+                .unwrap_or_else(|| "no provider error".to_string()),
+        );
+
+        match transcript_is_well_formed(agent.messages()) {
+            Ok(()) => report.record(
+                "transcript is well-formed after loop detection",
+                true,
+                format!(
+                    "{} messages, every tool_use answered",
+                    agent.messages().len()
+                ),
+            ),
+            Err(e) => report.record("transcript is well-formed after loop detection", false, e),
+        }
+
+        // The poisoning check. The abort used to leave an orphaned tool_use in
+        // history, so this second prompt is what a real user hits next.
+        let mut rx2 = agent
+            .prompt("Never mind. Reply with the single word: ok")
+            .await;
+        let (text2, err2) = drain(&mut rx2).await;
+        report.record(
+            "agent is still usable after a loop abort",
+            err2.is_none(),
+            err2.unwrap_or_else(|| format!("follow-up succeeded: {:?}", text2.trim())),
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // 2. Truncation stash — the model follows the marker and gets the middle.
+    // -----------------------------------------------------------------
+    println!("\n[2/4] truncation stash — retrieval through the model");
+    {
+        let state = SharedState::new();
+        let mut agent = Agent::from_config(cfg.clone())
+            .with_system_prompt(
+                "You inspect build logs. Tool output may be truncated; when it is, the marker \
+                 tells you a shared_state key holding the full text. Use it.",
+            )
+            .with_tools(vec![Box::new(BigOutputTool) as Box<dyn AgentTool>])
+            .with_shared_state(state)
+            .with_context_config(ContextConfig {
+                truncate_tool_output_on_append: true,
+                tool_output_max_lines: 40,
+                ..Default::default()
+            });
+
+        let mut rx = agent
+            .prompt(
+                "Read the build log and tell me the BUILD TOKEN. It is in the middle of the \
+                 log, not near the start or end. Reply with just the token.",
+            )
+            .await;
+        let (text, err) = drain(&mut rx).await;
+
+        let found = text.contains(NEEDLE);
+        report.record(
+            "model retrieved stashed content it could not otherwise see",
+            found && err.is_none(),
+            if found {
+                format!("recovered {NEEDLE} from the stash")
+            } else {
+                format!(
+                    "did NOT recover the token — head+tail truncation cannot contain it, so the \
+                     stash path failed. err={err:?} reply={:?}",
+                    text.trim()
+                )
+            },
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // 3. Cost and usage accounting against real numbers.
+    // -----------------------------------------------------------------
+    println!("\n[3/4] cost and usage accounting");
+    {
+        let mut agent = Agent::from_config(cfg.clone()).with_system_prompt("Be concise.");
+        let mut rx = agent.prompt("Name three primary colours.").await;
+        let (_t, err) = drain(&mut rx).await;
+
+        let cost = agent.session_cost_usd();
+        let ok = err.is_none() && cost.map(|c| c > 0.0).unwrap_or(false);
+        report.record(
+            "session cost is computed from real usage",
+            ok,
+            match cost {
+                Some(c) => format!("session_cost_usd = ${c:.6}"),
+                None => "session_cost_usd = None — the preset reports unpriced".to_string(),
+            },
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // 4. Prefix caching still produces cache reads.
+    // -----------------------------------------------------------------
+    println!("\n[4/4] prefix cache");
+    {
+        // A system prompt long enough to be worth caching.
+        let big_prompt = format!(
+            "You are a precise assistant. Reference material follows.\n{}",
+            "Rust's ownership model moves values by default; borrows are checked. ".repeat(400)
+        );
+
+        let mut cache_read_total = 0u64;
+        for round in 0..2 {
+            let mut agent = Agent::from_config(cfg.clone()).with_system_prompt(&big_prompt);
+            let mut rx = agent.prompt("Reply with the single word: ping").await;
+            while let Some(event) = rx.recv().await {
+                let AgentEvent::MessageEnd { message } = event else {
+                    continue;
+                };
+                let AgentMessage::Llm(Message::Assistant { usage, .. }) = &message else {
+                    continue;
+                };
+                if round == 1 {
+                    cache_read_total += usage.cache_read;
+                }
+            }
+        }
+        report.record(
+            "second run reads from the prefix cache",
+            cache_read_total > 0,
+            format!(
+                "cache_read on run 2 = {cache_read_total} tokens{}",
+                if cache_read_total == 0 {
+                    " — 0 means caching is off for this provider/model, or the prefix moved"
+                } else {
+                    ""
+                }
+            ),
+        );
+    }
+
+    // -----------------------------------------------------------------
+    println!("\n{}", "-".repeat(72));
+    let failed: Vec<&str> = report
+        .checks
+        .iter()
+        .filter(|(_, ok, _)| !ok)
+        .map(|(n, _, _)| n.as_str())
+        .collect();
+    println!(
+        "{} of {} checks passed",
+        report.checks.len() - failed.len(),
+        report.checks.len()
+    );
+    if failed.is_empty() {
+        println!("\nRelease smoke: PASS");
+    } else {
+        println!("\nRelease smoke: FAIL");
+        for f in &failed {
+            println!("  - {f}");
+        }
+        std::process::exit(1);
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1748,3 +1748,99 @@ mod tests {
         assert!(tracker.check_limits().is_some());
     }
 }
+
+#[cfg(test)]
+mod compaction_retention {
+    use super::*;
+    use crate::types::{Content, StopReason, Usage};
+
+    fn assistant_call(i: usize) -> AgentMessage {
+        AgentMessage::Llm(Message::Assistant {
+            content: vec![Content::ToolCall {
+                id: format!("tc-{i}"),
+                name: "fetch_record".into(),
+                arguments: serde_json::json!({"n": i}),
+                provider_metadata: None,
+            }],
+            stop_reason: StopReason::ToolUse,
+            model: "m".into(),
+            provider: "p".into(),
+            usage: Usage::default(),
+            timestamp: i as u64,
+            error_message: None,
+        })
+    }
+
+    fn tool_result(i: usize) -> AgentMessage {
+        AgentMessage::Llm(Message::ToolResult {
+            tool_call_id: format!("tc-{i}"),
+            tool_name: "fetch_record".into(),
+            content: vec![Content::Text {
+                text: "record line, nominal, no action required ".repeat(400),
+            }],
+            is_error: false,
+            timestamp: i as u64,
+        })
+    }
+
+    /// Compaction must leave a transcript a provider will accept, and must
+    /// leave the agent something to work with.
+    ///
+    /// Written after a live long-horizon run reported a compaction collapsing
+    /// 22 messages / 21371 tokens to **1 message / 22 tokens** — far below
+    /// `keep_first + keep_recent`. That did not reproduce here (retention is
+    /// 15-24 messages on the same shape), so this pins the two properties that
+    /// matter, in-crate where the live path cannot be reached: no orphaned tool
+    /// call, and never emptied to nothing.
+    #[test]
+    fn compaction_keeps_a_usable_well_formed_transcript() {
+        let cfg = ContextConfig {
+            max_context_tokens: 30_000,
+            keep_recent: 6,
+            keep_first: 2,
+            ..Default::default()
+        };
+        for pairs in [6usize, 11, 12, 20, 40] {
+            let mut msgs = vec![AgentMessage::Llm(Message::user("go"))];
+            for i in 0..pairs {
+                msgs.push(assistant_call(i));
+                msgs.push(tool_result(i));
+            }
+            let before = msgs.len();
+            let out = compact_messages(msgs, &cfg);
+
+            assert!(
+                !out.is_empty(),
+                "compaction of {before} messages emptied the transcript"
+            );
+
+            // No `tool_use` may be left unanswered — the shape every provider
+            // rejects, and the one thing compaction must never produce.
+            let mut pending: Vec<String> = Vec::new();
+            for m in &out {
+                let AgentMessage::Llm(msg) = m else { continue };
+                match msg {
+                    Message::Assistant { content, .. } => {
+                        pending = content
+                            .iter()
+                            .filter_map(|c| match c {
+                                Content::ToolCall { id, .. } => Some(id.clone()),
+                                _ => None,
+                            })
+                            .collect();
+                    }
+                    Message::ToolResult { tool_call_id, .. } => {
+                        if let Some(at) = pending.iter().position(|p| p == tool_call_id) {
+                            pending.remove(at);
+                        }
+                    }
+                    Message::User { .. } => {}
+                }
+            }
+            assert!(
+                pending.is_empty(),
+                "compaction of {before} messages orphaned tool calls {pending:?}"
+            );
+        }
+    }
+}

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -312,10 +312,10 @@ impl StreamProvider for AnthropicProvider {
                                                     .and_then(|v| v.as_str())
                                                     .map(|s| s.to_string())
                                                 {
-                                                    match serde_json::from_str(&partial) {
-                                                        Ok(parsed) => *arguments = parsed,
-                                                        Err(e) => warn!(
-                                                            "tool call `{}` has malformed JSON arguments ({e}): {}",
+                                                    match resolve_tool_arguments(&partial) {
+                                                        Some(parsed) => *arguments = parsed,
+                                                        None => warn!(
+                                                            "tool call `{}` has malformed JSON arguments: {}",
                                                             name,
                                                             truncate_for_error(&partial)
                                                         ),
@@ -866,6 +866,24 @@ struct AnthropicMessageDeltaInner {
     stop_reason: Option<String>,
 }
 
+/// Resolve a tool call's accumulated `input_json_delta` text into arguments.
+///
+/// `None` means malformed, and the caller leaves the `__partial_json` sentinel
+/// in place so the post-stream sweep fails the turn rather than running the
+/// tool on its defaults.
+///
+/// An **empty** accumulator is not malformed. A tool with no parameters has no
+/// JSON to stream, and Anthropic still emits an `input_json_delta` carrying
+/// `""` — so `from_str("")` failed with "EOF while parsing a value", the
+/// sentinel survived, and the sweep rejected the whole turn. Every
+/// no-argument tool (`get_status`, `list_files`, …) was uncallable.
+fn resolve_tool_arguments(partial: &str) -> Option<serde_json::Value> {
+    if partial.trim().is_empty() {
+        return Some(serde_json::Value::Object(Default::default()));
+    }
+    serde_json::from_str(partial).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1408,5 +1426,48 @@ mod tests {
             request_url(&config),
             "https://api.anthropic.com/v1/messages"
         );
+    }
+}
+
+#[cfg(test)]
+mod no_arg_tool_calls {
+    use super::resolve_tool_arguments;
+
+    /// A tool with no parameters must be callable.
+    ///
+    /// Found by the live release smoke, not by the suite: `MockProvider` never
+    /// streams SSE, so nothing exercised the `input_json_delta` accumulator.
+    /// Anthropic answered a `read_log` call with an empty argument stream and
+    /// the whole turn failed with "tool call(s) with unusable arguments".
+    #[test]
+    fn an_empty_argument_stream_is_an_empty_object() {
+        for partial in ["", "   ", "\n"] {
+            assert_eq!(
+                resolve_tool_arguments(partial),
+                Some(serde_json::json!({})),
+                "a no-parameter tool streams no JSON; {partial:?} must resolve to {{}}"
+            );
+        }
+    }
+
+    #[test]
+    fn well_formed_arguments_parse() {
+        assert_eq!(
+            resolve_tool_arguments(r#"{"service":"api"}"#),
+            Some(serde_json::json!({"service": "api"}))
+        );
+    }
+
+    /// Genuinely malformed input must still fail, or a truncated stream would
+    /// silently run the tool on its defaults — the case the sentinel exists for.
+    #[test]
+    fn malformed_arguments_still_fail() {
+        for partial in [r#"{"service":"#, "not json", "{"] {
+            assert_eq!(
+                resolve_tool_arguments(partial),
+                None,
+                "{partial:?} is truncated or invalid and must not resolve"
+            );
+        }
     }
 }


### PR DESCRIPTION
Answers "how do we gain confidence before 0.18.0". Three commits: two harnesses, and a real bug fix that came out of running them.

## The gap they close

All 619 unit tests use `MockProvider`, which accepts any message sequence handed to it. That is structural, not an oversight — and it is where this release's worst bug lived: loop detection injected a message between an assistant's `tool_use` blocks and their `tool_result`s, a shape every real provider rejects, and the suite stayed green throughout.

## `examples/release_smoke.rs` — short-run gate

Four checks, each targeting something a mock cannot verify:

1. Loop detection produces a transcript the provider accepts — **then a second prompt on the same agent**, because the abort used to leave an orphaned `tool_use` that poisoned every later call.
2. The model follows a truncation marker and recovers a needle at line 1000 of 2000. The existing test asserts a Rust-side `get`, one hop short of the path the model takes — exactly where the re-truncation bug lived.
3. Cost from real provider usage.
4. A stable system prompt still produces cache reads.

| provider | result |
|---|---|
| Sonnet 5 | **6/6** — 9-message transcript, needle recovered, $0.000216, 8444 cache-read tokens |
| DeepSeek | **5/5** — 15-message transcript, needle recovered, 5504 cache-read tokens (cost n/a, unpriced config) |

DeepSeek matters: it exercises the OpenAI-compat implementation, a separate SSE parser from Anthropic's.

## The bug it found on the first run

**Tools with no parameters were uncallable on Anthropic.** A no-argument tool has no JSON to stream, but Anthropic still emits an `input_json_delta` carrying `""`. `from_str("")` fails with *"EOF while parsing a value"*, so the `__partial_json` sentinel survived `content_block_stop` and the sweep failed the whole turn:

```
tool call(s) with unusable arguments, not executed: `read_log` ()
```

Every `get_status` / `list_files` / `read_log`-shaped tool. Now `resolve_tool_arguments`, a pure function with a regression test — genuinely truncated JSON still fails, which is what the sentinel exists for. Pre-existing, so it affects released versions too.

## `examples/long_horizon.rs` — the compaction path

`release_smoke` checks four narrow behaviours over short runs. This exercises what yoagent claims to be for: an agent that exhausts its context, compacts, and keeps working. Results on Sonnet 5, 25 turns, 30k budget:

- transcript stays provider-valid across compaction
- **prefix cache survives it: 67.2% hit rate, 236,930 cache-read tokens on post-compaction turns** — direct evidence the constant `COMPACTION_MARKER` does its job
- `SessionStats` matches the run
- sub-agent delegation returns real work through a scoped stash

And one finding, filed as **#150**: `LlmCompaction` took the deterministic fallback on *every* compaction, at `trigger_ratio` 0.6 and 0.35 alike. Root-caused in the issue — `compact_headroom_turns: Some(30)` drives `effective_target_ratio` to its `MIN_HEADROOM_RATIO` floor for any tool-heavy agent, so it runs at ~15% of its configured budget, compacts constantly, and never leaves a wide enough window for the briefing to land. Pre-existing and byte-identical in v0.16.5/v0.17.0, so not a 0.18.0 blocker.

## Corrections to the harnesses, not the library

Worth stating, because each was a check that passed while proving nothing:

- **`Agent::finish()` must be awaited** to sync messages back. Without it `agent.messages()` was empty and the transcript check reported *"0 messages, every tool_use answered"*. It now fails explicitly on an empty transcript.
- **Cache reads were measured from a `seen_compaction` flag** armed by `ContextCompacted` — which `DefaultCompaction` never emits. It measured nothing; it now counts the back half of the run.
- **The continuity check asked for a data fact from tool output**, which `LlmCompaction` never promises — the documented product is *"a shift-handoff briefing covering goals, progress, and decisions"*. It now checks that, with data-fact recall reported as informational.
- **The cost check now skips an unpriced config** rather than failing, since all-zero rates mean unknown by design.

## Also added

`compaction_keeps_a_usable_well_formed_transcript` in `src/context.rs`, pinning the two properties that matter on a tool-calling transcript: never emptied, never orphaning a tool call. Added because a live compaction reported collapsing 22 messages to 1 — which does not reproduce in isolation, and is now explained on #150.

`cargo test --all-features`: **619 passed, 0 failed**. Clippy clean under `-Dwarnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)