### PR TITLE
release: 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.18.0
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 # MSRV-aware dependency resolution (cargo 1.84+): prefer dependency versions
 # whose own rust-version fits ours. Without it CI re-resolves to whatever is


### PR DESCRIPTION
Twelve commits since `v0.17.0`. **Six breaking changes**, so a minor bump.

## Breaking

- `CostConfig::new` and `ContextTier::new` take two rates; cache rates move to `with_cache_read` / `with_cache_write`
- `CostConfig::context_tier: Option<ContextTier>` → `context_tiers: Vec<ContextTier>`, kept sorted
- `CostConfig` and `ExecutionLimits` are now `#[non_exhaustive]` — build with `new()` / `Default::default()` plus `with_*`
- `ExecutionLimits` gained `max_consecutive_identical_tool_calls` (on by default, `Some(3)`)
- `AgentLoopConfig` gained `tool_output_sink`

`ExecutionTracker` also lost struct-literal construction; it is recorded in the CHANGELOG.

## Headline

- **Retrievable tool output** — truncation stashes the full text and the marker names a key the model can fetch
- **Loop detection** — steers on the third consecutive identical call, stops on the next
- **Price drift audit** against models.dev, gating every shipped rate
- **Context tiers** in `CostConfig` (no preset uses one; see `gpt_5_5`'s docs for why)
- **Fixed: tools with no parameters were uncallable on Anthropic** — pre-existing, affects released versions

## Verification

| | |
|---|---|
| Tests | 619 passed, 0 failed |
| Clippy | clean under `-Dwarnings` |
| Feature combos | default / openapi / gasp all green |
| Live price audit | 26 compared, **0 drifted** |
| Live smoke | 6/6 Sonnet 5, 5/5 DeepSeek |
| Long-horizon | transcript valid across compaction, 67.2% cache hit rate |
| Packaging | `cargo package` builds |
| Docs | reference updated to the new API, `mdbook build` clean |

## Known, not blocking

**#150** — `LlmCompaction` takes the deterministic fallback on tool-heavy workloads, root-caused to `compact_headroom_turns` driving the target ratio to its floor. Byte-identical in `v0.16.5` and `v0.17.0`, so holding this release protects nobody; the fix is a defaults change that wants measurement.

Release commit is exactly two files — `Cargo.lock` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)