### PR TITLE
release: 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `yoagent` are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/), and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.18.1
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 # MSRV-aware dependency resolution (cargo 1.84+): prefer dependency versions
 # whose own rust-version fits ours. Without it CI re-resolves to whatever is


### PR DESCRIPTION
Two commits since `v0.18.0`. **Patch — no API change.**

## Fixed

**Summarization retries panicked in debug builds.** `RetryConfig::delay_for_attempt` documents a 1-indexed attempt and computes `attempt - 1`; `llm_compaction.rs` passed the raw `0..=max_retries` loop variable, so the first retry underflowed `usize`. `agent_loop.rs` increments before calling and was correct — this was confined to compaction.

It landed on a **detached task**, so nothing surfaced: the summarization vanished, no briefing arrived, and compaction fell back deterministically. That is one of the behaviours [#150](https://github.com/yologdev/yoagent/issues/150) was filed about, so some of those fallbacks were this rather than summarizer speed.

**A briefing rejected on fingerprint mismatch now reports what it cost.** The event carried `summary: None`, so cost accounting off `SummaryStats` under-counted the most wasteful failure — contradicting the contract `types.rs` states explicitly.

## Added

**`LlmCompaction` says so when briefings keep losing the race.** After five consecutive deterministic fallbacks it warns once, naming the likely cause; a splice that lands resets the streak and clears the latch. Gated on a request having actually been issued, so it cannot claim a cost in the inert configuration.

The module docs now lead with the summarizer choice, which is the actual cause: reusing the loop's `ModelConfig` is the obvious call and, for a slow loop model, the worst one.

## Verification

| | |
|---|---|
| Tests | 627 passed, 0 failed |
| Clippy | clean under `-Dwarnings` |
| Feature combos | default / openapi / gasp green |
| Live price audit | 26 compared, **0 drifted** |

Release commit is exactly two files — `Cargo.lock` is gitignored.

**Still open: #150** — `compact_headroom_turns` defaults to `Some(30)`, pinning the target ratio to its 0.15 floor for tool-heavy work. That is a defaults change for every user and wants measurement across growth rates first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)