### PR TITLE
test: MockProvider rejects transcripts a real provider would

### DIFF
--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -32,13 +32,93 @@ pub struct MockToolCall {
 /// Mock LLM provider for tests. Supply a sequence of responses.
 pub struct MockProvider {
     responses: std::sync::Mutex<Vec<MockResponse>>,
+    /// Whether to reject a request whose transcript a real provider would.
+    ///
+    /// On by default, and that default is the point. This type used to discard
+    /// `StreamConfig` entirely, so 600+ tests drove the agent loop without one
+    /// of them noticing when it built a message sequence every provider
+    /// rejects. Loop detection shipped exactly that bug to a release branch:
+    /// a steering message injected between an assistant's `tool_use` blocks and
+    /// their `tool_result`s, which poisons the agent for every later prompt.
+    ///
+    /// Turning this off is legitimate for a test that deliberately constructs a
+    /// malformed history — say the compaction orphan-handling paths — but it
+    /// should be deliberate and commented.
+    validate_transcript: bool,
+}
+
+/// Reject a message sequence a real provider would reject.
+///
+/// The invariant every provider enforces: an assistant's `tool_use` blocks must
+/// be answered by their `tool_result`s before anything else intervenes.
+/// Anthropic returns "tool_use ids were found without tool_result blocks
+/// immediately after"; OpenAI returns the equivalent about tool messages. The
+/// crate treats this as sacred elsewhere — `context.rs` calls an unanswered
+/// call "an orphan every provider rejects", and `llm_compaction.rs` has a
+/// dedicated test for it — but nothing enforced it on the loop's own output.
+///
+/// Returns the reason a provider would give, or `None` if the transcript is
+/// well-formed.
+fn transcript_violation(messages: &[Message]) -> Option<String> {
+    let mut pending: Vec<String> = Vec::new();
+    for (i, msg) in messages.iter().enumerate() {
+        match msg {
+            Message::Assistant { content, .. } => {
+                if !pending.is_empty() {
+                    return Some(format!(
+                        "assistant message at [{i}] while tool calls {pending:?} are still \
+                         unanswered"
+                    ));
+                }
+                pending = content
+                    .iter()
+                    .filter_map(|c| match c {
+                        Content::ToolCall { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::ToolResult { tool_call_id, .. } => {
+                match pending.iter().position(|p| p == tool_call_id) {
+                    Some(at) => {
+                        pending.remove(at);
+                    }
+                    None => {
+                        return Some(format!(
+                            "tool_result at [{i}] for {tool_call_id:?} answers no open tool call"
+                        ))
+                    }
+                }
+            }
+            Message::User { .. } => {
+                if !pending.is_empty() {
+                    return Some(format!(
+                        "a user message at [{i}] lands between an assistant's tool_use and its \
+                         tool_result — {pending:?} still unanswered"
+                    ));
+                }
+            }
+        }
+    }
+    None
 }
 
 impl MockProvider {
     pub fn new(responses: Vec<MockResponse>) -> Self {
         Self {
             responses: std::sync::Mutex::new(responses),
+            validate_transcript: true,
         }
+    }
+
+    /// Accept message sequences a real provider would reject.
+    ///
+    /// For tests that construct a malformed history *on purpose* — orphan
+    /// handling, compaction edge cases, recovery paths. Say why at the call
+    /// site; the default exists because the alternative let a real bug through.
+    pub fn without_transcript_validation(mut self) -> Self {
+        self.validate_transcript = false;
+        self
     }
 
     /// Convenience: provider that always returns the same text
@@ -61,10 +141,27 @@ impl MockProvider {
 impl StreamProvider for MockProvider {
     async fn stream(
         &self,
-        _config: StreamConfig,
+        config: StreamConfig,
         tx: mpsc::UnboundedSender<StreamEvent>,
         cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Message, ProviderError> {
+        // A mock that accepts anything tests the loop against a provider that
+        // does not exist. Panic rather than return an error: a malformed
+        // transcript is a defect in the code under test, and the loop is
+        // designed to survive provider *errors*, so returning one would be
+        // swallowed by the very retry path that should never see this.
+        if self.validate_transcript {
+            if let Some(why) = transcript_violation(&config.messages) {
+                panic!(
+                    "MockProvider received a transcript a real provider would reject: {why}.\n\n\
+                     This is the shape that poisons an agent — the history is kept, so every \
+                     later prompt fails too. If the malformed sequence is deliberate, use \
+                     `MockProvider::without_transcript_validation()` and say why.\n\n\
+                     Messages: {:#?}",
+                    config.messages
+                );
+            }
+        }
         let response = {
             let mut responses = self.responses.lock().unwrap();
             if responses.is_empty() {

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -230,6 +230,22 @@ async fn test_continue_from_tool_result() {
         system_prompt: "test".into(),
         messages: vec![
             AgentMessage::Llm(Message::user("do something")),
+            // The assistant turn that *made* the call. Without it the
+            // tool_result answers nothing, which is a history no provider
+            // accepts — and which therefore cannot arise in production, so
+            // asserting resume behaviour on it proved nothing about the real
+            // path. MockProvider now rejects it.
+            AgentMessage::Llm(Message::assistant(
+                vec![Content::tool_call(
+                    "tc-1",
+                    "test_tool",
+                    serde_json::json!({}),
+                )],
+                StopReason::ToolUse,
+                "mock",
+                "mock",
+                Usage::default(),
+            )),
             AgentMessage::Llm(Message::ToolResult {
                 tool_call_id: "tc-1".into(),
                 tool_name: "test_tool".into(),


### PR DESCRIPTION
The highest-leverage change available: it retroactively upgrades every existing test.

## The structural hole

`MockProvider::stream` took `_config: StreamConfig` and discarded it. So 600+ tests drove the agent loop without a single one noticing when it built a message sequence every provider rejects.

That is not a coverage gap more tests would close. It is why loop detection reached a release branch injecting a steering message **between an assistant's `tool_use` blocks and their `tool_result`s** — a history that shape poisons the agent, because it is kept, so every later prompt fails too. The suite was green throughout.

## The change

The mock now checks the one invariant every provider enforces — a `tool_use` is answered by its `tool_result`s before anything else intervenes — and **panics** with the reason a provider would give.

Panics rather than returning `Err` deliberately: a malformed transcript is a defect in the code under test, and a provider error would be swallowed by the very retry path that should never see it.

`MockProvider::without_transcript_validation()` exists for tests that build a malformed history on purpose. **Nothing needed it.**

## Effect, measured

Reverting the 0.18 steer fix:

| | before this PR | after |
|---|---|---|
| tests failing | **0** — whole suite green | **5**, with the exact diagnostic |

```
MockProvider received a transcript a real provider would reject:
a user message at [6] lands between an assistant's tool_use and its
tool_result — ["mock-tool-0"] still unanswered.
```

600+ existing tests became transcript guards without writing one.

## One real fixture bug found

`test_continue_from_tool_result` resumed from `[user, tool_result]` — a tool result answering nothing. No provider accepts that, so it cannot arise in production, so the test proved nothing about the resume path it named. It now includes the assistant turn that made the call.

That it was the **only** failure across 629 tests is itself the useful signal: the loop's own transcript-building is clean, which is evidence the 0.18.1 fixes were right.

`cargo test --all-features`: **629 passed, 0 failed**. Clippy clean under `-Dwarnings`.

Test-infrastructure only — no library behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)